### PR TITLE
install: add one-command plugin and CLI setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
           cp target/release/board "$stage/target/release/board"
           cp herdr-plugin.toml "$stage/herdr-plugin.toml"
           cp -r skill "$stage/skill"
-          cp scripts/build.sh scripts/open-board.sh scripts/install.sh "$stage/scripts/"
+          cp scripts/build.sh scripts/install-cli.sh scripts/open-board.sh scripts/install.sh "$stage/scripts/"
           [ -f README.md ] && cp README.md "$stage/README.md"
           for lic in LICENSE LICENSE.md LICENSE-MIT LICENSE.txt; do
             [ -f "$lic" ] && cp "$lic" "$stage/$lic"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- GitHub plugin installation now builds herdr-board and copies the `board` CLI to `~/.local/bin/board` as part of the trusted plugin build, with an install-directory override for custom setups. A per-directory marker records the installed binary's SHA-256 checksum; managed updates validate matching regular-file contents and refuse to overwrite an unrelated or subsequently replaced `board` command.
+
 ## [0.1.1] - 2026-07-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,44 +56,127 @@ The single `board` binary is TUI, daemon, and CLI (subcommands). Crates: `board-
 
 ## Install
 
-herdr-board is a herdr plugin distributed from source (topic: `herdr-plugin`).
+herdr-board is a Linux herdr plugin distributed from source (topic: `herdr-plugin`). It requires
+herdr 0.7+, Git, and a Rust toolchain with `cargo`. Ensure `~/.local/bin` is on your `PATH` (for
+example, add `export PATH="$HOME/.local/bin:$PATH"` to your shell profile).
 
 ```bash
-# 1. Clone.
-git clone https://github.com/nelsonPires5/herdr-board
-cd herdr-board
+herdr plugin install nelsonPires5/herdr-board
+```
 
-# 2. Build + link the plugin + copy the agent skill + add the keybinding. install.sh
-#    is SAFE by default: it builds and PRINTS the mutating steps. --yes applies them.
-./scripts/install.sh            # dry run: prints plugin-link / skill-copy / symlink / keybinding
-./scripts/install.sh --yes      # build + `herdr plugin link` + copy skill + symlink ~/.local/bin/board
-                                #   + add the [[keys.command]] keybinding to ~/.config/herdr/config.toml
-                                #   (idempotent: skipped if a binding already invokes open-board;
-                                #    backs the config up to config.toml.bak.<epoch> before appending)
-./scripts/install.sh --yes --key prefix+shift+b   # same, custom key combo (default: prefix+shift+k)
+herdr first shows an interactive trust preview of the plugin's build commands. After approval it
+checks out the source, builds the release binary, registers the plugin, and copies the CLI to
+`~/.local/bin/board` as a regular executable (not a symlink into Herdr's managed checkout). For a
+noninteractive install after reviewing the manifest and scripts:
 
-# 3. Recommended — precise agent status (idle/working/blocked) + session refs:
+```bash
+herdr plugin install nelsonPires5/herdr-board --yes
+```
+
+Set `HERDR_BOARD_CLI_INSTALL_DIR` to an absolute user bin directory before installing to override
+`~/.local/bin`; the installed command is `<that-directory>/board`. The installer records the
+installed binary's SHA-256 checksum in `<that-directory>/.herdr-board-cli-managed`. Updates require
+that `board` remain a regular, non-symlink file with matching contents, and refuse to overwrite a
+pre-existing or subsequently replaced command.
+
+Open the board overlay with:
+
+```bash
+herdr plugin action invoke open-board --plugin herdr-board
+```
+
+If `overlay` placement is unavailable in your herdr, open it as a tab instead:
+
+```bash
+herdr plugin pane open --plugin herdr-board --entrypoint board --placement tab --focus
+```
+
+The `board` command is also now available directly for CLI operations.
+
+Plugin installation deliberately does **not** edit `~/.config/herdr/config.toml` or copy the Claude
+skill. To add a keybinding, put a command such as this in that config (do not reuse a herdr default;
+`prefix+k` is `focus_pane_up`, so check `herdr --default-config`):
+
+```toml
+[[keys.command]]
+key = "prefix+shift+k"
+type = "shell"
+command = "herdr plugin action invoke open-board --plugin herdr-board"
+```
+
+The repository's optional **agent skill** (`skill/SKILL.md`) teaches Claude Code sessions how to
+comment and call `board done`, but is only copied automatically by the local-development installer
+below.
+
+For more precise Claude agent status (idle/working/blocked) and session refs, optionally install
+herdr's integration; the board otherwise still works:
+
+```bash
 herdr integration install claude
 ```
 
-If `overlay` placement is unavailable in your herdr, open the board on demand with:
-`herdr plugin pane open --plugin herdr-board --entrypoint board --placement overlay --focus`.
-
 **Named sessions**: herdr keeps a plugin registry *per session* (keybindings/config are global,
-plugins are not). In each named session run once, from inside it:
-`herdr plugin link /path/to/herdr-board`. A single boardd runs one board across **every** herdr
-session: a card carries a `session` (the default session when unset), and the daemon resolves it
-to that session's socket at dispatch (via `herdr session list`) to create/resolve the workspace and
-spawn the pane there. Use a second stack with `BOARD_SOCKET`/`BOARD_DB` overrides only for a fully
-separate *board*. Don't bind keys herdr already uses by default (`prefix+k` is `focus_pane_up`;
-check `herdr --default-config`).
+plugins are not). Run the GitHub install command once from each named session where you want the
+plugin registered. A single boardd runs one board across **every** herdr session: a card carries a
+`session` (the default session when unset), and the daemon resolves it to that session's socket at
+dispatch (via `herdr session list`) to create/resolve the workspace and spawn the pane there. Use a
+second stack with `BOARD_SOCKET`/`BOARD_DB` overrides only for a fully separate *board*.
 
-The **agent skill** (`skill/SKILL.md`, copied to `~/.claude/skills/herdr-board/` by `install.sh`)
-teaches Claude Code sessions how to drive the board from inside a run.
+### Uninstall
+
+Herdr's plugin uninstall cannot remove the CLI copied outside its managed checkout. Remove the CLI
+only if it is still the managed binary, then unregister the plugin:
+
+```bash
+(
+  if [ "${HERDR_BOARD_CLI_INSTALL_DIR+x}" = x ]; then
+    install_dir="$HERDR_BOARD_CLI_INSTALL_DIR"
+  else
+    install_dir="${HOME:?HOME must be set}/.local/bin"
+  fi
+  case "$install_dir" in /*) ;; *) echo "Install directory must be absolute" >&2; exit 1;; esac
+
+  board="$install_dir/board"
+  marker="$install_dir/.herdr-board-cli-managed"
+  prefix="herdr-board install-cli.sh managed board sha256:"
+  if [ -f "$board" ] && [ ! -L "$board" ] && [ -f "$marker" ] && [ ! -L "$marker" ]; then
+    checksum=""
+    checksum_output="$(sha256sum <"$board")" && checksum="${checksum_output%% *}"
+    if [[ "$checksum" =~ ^[0-9a-f]{64}$ ]] && printf '%s\n' "$prefix$checksum" | cmp -s - "$marker"; then
+      rm -- "$board" "$marker"
+    else
+      echo "board CLI was changed or is unrecognized; retaining $board and $marker" >&2
+    fi
+  else
+    echo "board CLI was changed or is unrecognized; retaining $board and $marker" >&2
+  fi
+)
+herdr plugin uninstall herdr-board
+```
+
+If you used `HERDR_BOARD_CLI_INSTALL_DIR`, use the **same directory** for every plugin update and
+for cleanup. Changing or omitting it later can leave a second installed copy behind. Uninstall the
+plugin from each named session where it was registered.
+
+### Local development / source install
+
+For a checkout you plan to edit, clone the repository and use `scripts/install.sh` instead. It
+builds and prints its proposed plugin link, skill copy, PATH symlink, and keybinding changes by
+default; `--yes` applies those broader development-only changes. It is intentionally not called by
+the GitHub plugin install flow.
+
+```bash
+git clone https://github.com/nelsonPires5/herdr-board
+cd herdr-board
+./scripts/install.sh                         # dry run
+./scripts/install.sh --yes                   # apply, default key: prefix+shift+k
+./scripts/install.sh --yes --key prefix+shift+b
+```
 
 ## Quickstart
 
-1. Press your keybinding (e.g. `prefix+shift+k`) to open the board overlay.
+1. Run `herdr plugin action invoke open-board --plugin herdr-board` to open the overlay (or press
+   the optional keybinding if you configured one).
 2. On the empty board press `T` to apply the example pipeline (or `N` to add your own columns), then
    `n` to create a card — the guided form picks harness/model/effort/permission, session, and space.
 3. Move the card into an `auto` column (`m` for the column picker, or drag it) — the move dispatches
@@ -176,8 +259,11 @@ argv = ["mytool", "--model", "{model}"]   # {model}/{effort}/{permission_mode} p
 
 ## Scripts
 
-- `scripts/build.sh` — release build of the `board` binary (plugin `[[build]]` step; idempotent).
-- `scripts/install.sh` — build + link plugin + copy skill (mutating steps guarded behind `--yes`).
+- `scripts/build.sh` — release build of the `board` binary (first plugin `[[build]]` step; idempotent).
+- `scripts/install-cli.sh` — copy the built CLI to `~/.local/bin/board` (second plugin `[[build]]`
+  step; override the directory with `HERDR_BOARD_CLI_INSTALL_DIR`).
+- `scripts/install.sh` — local-development build + link + skill/keybinding setup (mutations guarded
+  behind `--yes`; not called by GitHub plugin installation).
 - `scripts/open-board.sh` — the `open-board` action launcher (open-or-focus, toggle off on repeat).
 - `e2e/` — live end-to-end scenario suite against a REAL herdr; run `e2e/run-all.sh`
   (`scripts/e2e.sh` is a compat wrapper). See [`e2e/README.md`](e2e/README.md) and

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -19,6 +19,12 @@ platforms = ["linux"]
 [[build]]
 command = ["./scripts/build.sh"]
 
+# Copy the built CLI to a stable user PATH location. This must remain separate
+# from install.sh, whose plugin-link, skill, and keybinding changes are intended
+# only for explicit local-development installs.
+[[build]]
+command = ["./scripts/install-cli.sh"]
+
 # The kanban TUI, spawned by herdr in an overlay pane. `overlay` is an accepted
 # placement (herdr 0.7.3: overlay|split|tab|zoomed). The same binary auto-starts
 # the boardd daemon if it is not already running.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Copy the plugin-built CLI out of Herdr's managed checkout and into a user bin directory.
+set -euo pipefail
+
+if [ "$#" -ne 0 ]; then
+  echo "install-cli.sh: no arguments expected; set HERDR_BOARD_CLI_INSTALL_DIR to override the destination directory" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+source_bin="$repo_root/target/release/board"
+
+if [ "${HERDR_BOARD_CLI_INSTALL_DIR+x}" = x ]; then
+  if [ -z "$HERDR_BOARD_CLI_INSTALL_DIR" ]; then
+    echo "install-cli.sh: HERDR_BOARD_CLI_INSTALL_DIR must not be empty" >&2
+    exit 2
+  fi
+  install_dir="$HERDR_BOARD_CLI_INSTALL_DIR"
+else
+  if [ -z "${HOME:-}" ]; then
+    echo "install-cli.sh: HOME must be set when HERDR_BOARD_CLI_INSTALL_DIR is not provided" >&2
+    exit 2
+  fi
+  install_dir="$HOME/.local/bin"
+fi
+
+case "$install_dir" in
+  /*) ;;
+  *)
+    echo "install-cli.sh: install directory must be an absolute path: $install_dir" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$source_bin" ] || [ ! -x "$source_bin" ]; then
+  echo "install-cli.sh: expected executable source binary at $source_bin; run scripts/build.sh first" >&2
+  exit 1
+fi
+if ! command -v sha256sum >/dev/null 2>&1; then
+  echo "install-cli.sh: GNU sha256sum is required to validate managed CLI contents" >&2
+  exit 1
+fi
+
+sha256_file() {
+  local path="$1"
+  local output checksum
+  if ! output="$(sha256sum <"$path")"; then
+    echo "install-cli.sh: failed to calculate SHA-256 checksum for $path" >&2
+    return 1
+  fi
+  checksum="${output%% *}"
+  if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "install-cli.sh: sha256sum returned an invalid checksum for $path" >&2
+    return 1
+  fi
+  printf '%s\n' "$checksum"
+}
+
+if [ -e "$install_dir" ] && [ ! -d "$install_dir" ]; then
+  echo "install-cli.sh: install directory exists but is not a directory: $install_dir" >&2
+  exit 1
+fi
+
+mkdir -p -- "$install_dir"
+destination="$install_dir/board"
+marker="$install_dir/.herdr-board-cli-managed"
+marker_prefix="herdr-board install-cli.sh managed board sha256:"
+
+# -e is false for a broken symlink, so test -L as well. Never read a marker
+# through a symlink or from a special file.
+if { [ -e "$marker" ] || [ -L "$marker" ]; } && { [ ! -f "$marker" ] || [ -L "$marker" ]; }; then
+  echo "install-cli.sh: ownership marker path is not a regular non-symlink file: $marker" >&2
+  exit 1
+fi
+
+managed=false
+managed_checksum=""
+if [ -f "$marker" ]; then
+  marker_value="$(<"$marker")"
+  if [[ "$marker_value" =~ ^${marker_prefix}([0-9a-f]{64})$ ]]; then
+    managed=true
+    managed_checksum="${BASH_REMATCH[1]}"
+  fi
+fi
+
+# A valid checksum marker is the only permission this script gives itself to
+# replace an existing command. Before every managed update, ensure the command
+# is still the exact regular file installed previously.
+if { [ -e "$destination" ] || [ -L "$destination" ]; } && [ "$managed" != true ]; then
+  echo "install-cli.sh: refusing to overwrite unmanaged destination: $destination" >&2
+  echo "install-cli.sh: move it aside or set HERDR_BOARD_CLI_INSTALL_DIR to a different absolute directory" >&2
+  exit 1
+fi
+if [ "$managed" = true ]; then
+  if [ ! -f "$destination" ] || [ -L "$destination" ]; then
+    echo "install-cli.sh: managed destination is not a regular non-symlink file; refusing to overwrite it: $destination" >&2
+    exit 1
+  fi
+  if ! destination_checksum="$(sha256_file "$destination")"; then
+    exit 1
+  fi
+  if [ "$destination_checksum" != "$managed_checksum" ]; then
+    echo "install-cli.sh: managed destination checksum does not match its ownership marker; refusing to overwrite it: $destination" >&2
+    exit 1
+  fi
+fi
+
+temporary="$(mktemp "$install_dir/.board.XXXXXX")"
+marker_temporary="$(mktemp "$install_dir/.herdr-board-cli-managed.XXXXXX")"
+cleanup() {
+  rm -f -- "$temporary" "$marker_temporary"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+# Build both files beside their destinations so readers never observe partial
+# contents. On a first install, hard-linking is an atomic no-clobber operation;
+# managed updates use an atomic rename over the owned destination.
+cp -p -- "$source_bin" "$temporary"
+if ! installed_checksum="$(sha256_file "$temporary")"; then
+  exit 1
+fi
+marker_value="${marker_prefix}${installed_checksum}"
+printf '%s\n' "$marker_value" >"$marker_temporary"
+chmod 0644 "$marker_temporary"
+if [ "$managed" = true ]; then
+  mv -fT -- "$temporary" "$destination"
+  mv -fT -- "$marker_temporary" "$marker"
+else
+  if ! ln -T -- "$temporary" "$destination"; then
+    echo "install-cli.sh: refusing to overwrite destination created during install: $destination" >&2
+    exit 1
+  fi
+  rm -f -- "$temporary"
+  if ! mv -fT -- "$marker_temporary" "$marker"; then
+    rm -f -- "$destination"
+    echo "install-cli.sh: could not create ownership marker: $marker" >&2
+    exit 1
+  fi
+fi
+trap - EXIT HUP INT TERM
+
+echo "install-cli.sh: installed managed CLI at $destination"

--- a/scripts/tests/test_install_cli.py
+++ b/scripts/tests/test_install_cli.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "install-cli.sh"
+MARKER_NAME = ".herdr-board-cli-managed"
+MARKER_PREFIX = "herdr-board install-cli.sh managed board sha256:"
+
+
+def marker_bytes(content: bytes) -> bytes:
+    checksum = hashlib.sha256(content).hexdigest()
+    return f"{MARKER_PREFIX}{checksum}\n".encode()
+
+
+class InstallCliTests(unittest.TestCase):
+    def make_fixture(self, root: Path, content: str = "#!/bin/sh\necho first\n") -> tuple[Path, Path]:
+        script = root / "scripts" / "install-cli.sh"
+        script.parent.mkdir(parents=True)
+        shutil.copy2(SCRIPT, script)
+
+        source = root / "target" / "release" / "board"
+        source.parent.mkdir(parents=True)
+        source.write_text(content, encoding="utf-8")
+        source.chmod(0o751)
+        return script, source
+
+    def run_script(
+        self,
+        script: Path,
+        *,
+        home: Path,
+        install_dir: Path | None = None,
+        path_prefix: Path | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        # The plugin is Linux-only and intentionally uses GNU no-target-directory
+        # semantics. Let this test suite run on macOS when Homebrew coreutils is
+        # available under its conventional g-prefixed command names.
+        if os.uname().sysname == "Darwin":
+            gnu_commands = {
+                command: shutil.which(f"g{command}")
+                for command in ("ln", "mv", "sha256sum")
+            }
+            if all(gnu_commands.values()):
+                gnu_bin = home / ".test-gnu-bin"
+                gnu_bin.mkdir(parents=True, exist_ok=True)
+                for command, executable in gnu_commands.items():
+                    command_path = gnu_bin / command
+                    if not command_path.exists():
+                        command_path.symlink_to(executable)
+                env["PATH"] = f"{gnu_bin}{os.pathsep}{env['PATH']}"
+        if path_prefix is not None:
+            env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
+        if install_dir is None:
+            env.pop("HERDR_BOARD_CLI_INSTALL_DIR", None)
+        else:
+            env["HERDR_BOARD_CLI_INSTALL_DIR"] = str(install_dir)
+        return subprocess.run(
+            ["bash", str(script)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_refuses_unrelated_existing_board_without_changing_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, _source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            install_dir.mkdir(parents=True)
+            destination.write_bytes(b"unrelated executable\n")
+            destination.chmod(0o700)
+
+            result = self.run_script(script, home=home)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("refusing to overwrite", result.stderr)
+            self.assertEqual(destination.read_bytes(), b"unrelated executable\n")
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o700)
+            self.assertFalse((install_dir / MARKER_NAME).exists())
+
+    def test_refuses_other_unmanaged_destination_types(self) -> None:
+        for destination_type in ("broken symlink", "directory"):
+            with self.subTest(destination_type=destination_type), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp) / "repo"
+                home = Path(tmp) / "home"
+                script, _source = self.make_fixture(root)
+                install_dir = home / ".local" / "bin"
+                destination = install_dir / "board"
+                install_dir.mkdir(parents=True)
+                if destination_type == "broken symlink":
+                    destination.symlink_to(install_dir / "missing-target")
+                else:
+                    destination.mkdir()
+                    (destination / "keep").write_text("untouched", encoding="utf-8")
+
+                result = self.run_script(script, home=home)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("refusing to overwrite", result.stderr)
+                if destination_type == "broken symlink":
+                    self.assertTrue(destination.is_symlink())
+                    self.assertEqual(os.readlink(destination), str(install_dir / "missing-target"))
+                else:
+                    self.assertEqual((destination / "keep").read_text(encoding="utf-8"), "untouched")
+
+    def test_first_install_creates_ownership_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+
+            result = self.run_script(script, home=home)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertFalse(destination.is_symlink())
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o751)
+            marker = install_dir / MARKER_NAME
+            self.assertTrue(marker.is_file())
+            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
+
+    def test_managed_install_updates_idempotently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            marker = install_dir / MARKER_NAME
+
+            first = self.run_script(script, home=home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            original_marker = marker.read_bytes()
+
+            source.write_text("#!/bin/sh\necho second\n", encoding="utf-8")
+            source.chmod(0o755)
+            second = self.run_script(script, home=home)
+
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o755)
+            self.assertNotEqual(marker.read_bytes(), original_marker)
+            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
+
+    def test_managed_update_refuses_replaced_board_and_preserves_both_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            marker = install_dir / MARKER_NAME
+
+            first = self.run_script(script, home=home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            original_marker = marker.read_bytes()
+
+            replacement = b"#!/bin/sh\necho installed by another tool\n"
+            destination.write_bytes(replacement)
+            destination.chmod(0o700)
+            source.write_text("#!/bin/sh\necho second\n", encoding="utf-8")
+            source.chmod(0o755)
+
+            update = self.run_script(script, home=home)
+
+            self.assertNotEqual(update.returncode, 0)
+            self.assertIn("checksum does not match", update.stderr)
+            self.assertEqual(destination.read_bytes(), replacement)
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o700)
+            self.assertEqual(marker.read_bytes(), original_marker)
+
+    def test_managed_update_refuses_destination_changed_to_symlinked_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            marker = install_dir / MARKER_NAME
+
+            first = self.run_script(script, home=home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            original_marker = marker.read_bytes()
+
+            destination.unlink()
+            symlink_target = Path(tmp) / "other-tool-directory"
+            symlink_target.mkdir()
+            keep = symlink_target / "keep"
+            keep.write_text("untouched", encoding="utf-8")
+            destination.symlink_to(symlink_target, target_is_directory=True)
+            source.write_text("#!/bin/sh\necho second\n", encoding="utf-8")
+            source.chmod(0o755)
+
+            update = self.run_script(script, home=home)
+
+            self.assertNotEqual(update.returncode, 0)
+            self.assertIn("not a regular non-symlink file", update.stderr)
+            self.assertTrue(destination.is_symlink())
+            self.assertEqual(os.readlink(destination), str(symlink_target))
+            self.assertEqual(list(symlink_target.iterdir()), [keep])
+            self.assertEqual(keep.read_text(encoding="utf-8"), "untouched")
+            self.assertEqual(marker.read_bytes(), original_marker)
+
+    def test_install_directory_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            custom_bin = Path(tmp) / "custom" / "bin"
+            script, source = self.make_fixture(root)
+
+            result = self.run_script(script, home=home, install_dir=custom_bin)
+            destination = custom_bin / "board"
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertTrue((custom_bin / MARKER_NAME).is_file())
+            self.assertFalse((home / ".local" / "bin" / "board").exists())
+
+    def test_missing_built_binary_has_useful_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            source.unlink()
+
+            result = self.run_script(script, home=home)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("expected executable source binary", result.stderr)
+            self.assertIn("scripts/build.sh", result.stderr)
+
+    def test_invalid_checksum_tool_output_has_useful_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, _source = self.make_fixture(root)
+            fake_bin = Path(tmp) / "fake-bin"
+            fake_bin.mkdir()
+            fake_sha256sum = fake_bin / "sha256sum"
+            fake_sha256sum.write_text("#!/bin/sh\nprintf 'not-a-checksum  -\\n'\n", encoding="utf-8")
+            fake_sha256sum.chmod(0o755)
+
+            result = self.run_script(script, home=home, path_prefix=fake_bin)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("sha256sum returned an invalid checksum", result.stderr)
+            install_dir = home / ".local" / "bin"
+            self.assertFalse((install_dir / "board").exists())
+            self.assertFalse((install_dir / MARKER_NAME).exists())
+
+
+class PluginManifestTests(unittest.TestCase):
+    def test_build_runs_before_managed_cli_install(self) -> None:
+        with (REPO_ROOT / "herdr-plugin.toml").open("rb") as manifest_file:
+            manifest = tomllib.load(manifest_file)
+
+        self.assertEqual(
+            [step["command"] for step in manifest["build"]],
+            [["./scripts/build.sh"], ["./scripts/install-cli.sh"]],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install the `board` CLI during `herdr plugin install`
- protect existing binaries with checksum-managed ownership
- document simple install, update, and safe uninstall flows
- add installer and manifest tests

## Tests
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 20 passed
- shell syntax checks
- `git diff --check`
- Rust gates deferred to GitHub CI because Cargo is unavailable locally