### PR TITLE
fix(daemon): stabilize chained pane placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- Flaky Stage1→Stage2 pane placement race: when a chained auto-column Stage1
+  finishes and its agent pane closes, the Stage2 placement could pick up the
+  now-closing pane, focus it, and fail `agent.start` with `pane_not_found`.
+  The placement now retries once on `pane_not_found`, rediscovering the
+  `kanban` tab; and existing-but-empty tabs land unsplit instead of querying
+  `pane.layout(null)` which may return a different tab's layout.
+
 ## [0.2.0] - 2026-07-16
 
 ### Changed

--- a/crates/board-daemon/src/spawner.rs
+++ b/crates/board-daemon/src/spawner.rs
@@ -181,13 +181,16 @@ const ERR_AGENT_NAME_TAKEN: &str = "agent_name_taken";
 /// herdr protocol error code: `agent.start` targeted a tab that no longer
 /// exists (raced away between find-or-create and start). We redo find-or-create.
 const ERR_PLACEMENT_NOT_FOUND: &str = "agent_placement_not_found";
+/// herdr protocol error code: a targeted pane no longer exists (e.g. closed
+/// between listing and the operation). We redo find-or-create of the tab.
+const ERR_PANE_NOT_FOUND: &str = "pane_not_found";
 
 /// Place a run's agent pane in the `label` tab of `ws_id`: find-or-create the
 /// tab, then either fill a freshly-created tab (no split, closing its leftover
 /// shell pane) or split the largest existing pane per [`grid_slot`].
 ///
-/// Retries find-or-create once if the tab vanishes between listing and
-/// `agent.start` ([`ERR_PLACEMENT_NOT_FOUND`]).
+/// Retries find-or-create once if the tab or a targeted pane vanishes between
+/// listing and `agent.start` ([`ERR_PLACEMENT_NOT_FOUND`], [`ERR_PANE_NOT_FOUND`]).
 fn place_in_tab(
     client: &mut HerdrClient,
     req: &SpawnReq,
@@ -200,9 +203,10 @@ fn place_in_tab(
         match try_place_once(client, req, env, ws_id, label) {
             Ok(started) => return Ok(started),
             Err(HerdrError::Protocol { code, message })
-                if code == ERR_PLACEMENT_NOT_FOUND && attempt == 0 =>
+                if (code == ERR_PLACEMENT_NOT_FOUND || code == ERR_PANE_NOT_FOUND)
+                    && attempt == 0 =>
             {
-                // Tab raced away; loop redoes find-or-create.
+                // Tab or pane raced away; loop redoes find-or-create.
                 last_err = Some(HerdrError::Protocol { code, message });
             }
             Err(e) => return Err(anyhow!(e)),
@@ -245,12 +249,20 @@ fn try_place_once(
     }
 
     // Existing tab: split its largest pane to keep the mesh roughly square.
-    // Use any pane in the tab as the layout anchor.
     let tab_panes: Vec<_> = client
         .pane_list(Some(ws_id))?
         .into_iter()
         .filter(|p| p.tab_id == tab_id)
         .collect();
+
+    if tab_panes.is_empty() {
+        // Tab exists but has no panes (all previous agents exited): land
+        // unsplit, same as a freshly created tab. Avoids calling
+        // `pane_layout(None)` which may return a different tab's layout.
+        return agent_start_retry_name(client, &params, req.name_fallback.as_deref());
+    }
+
+    // Use any pane in the tab as the layout anchor.
     let anchor = tab_panes.first().map(|p| p.pane_id.clone());
     let layout = client.pane_layout(anchor.as_deref())?;
 
@@ -336,8 +348,15 @@ pub fn grid_slot(panes: &[LayoutPane]) -> (String, SplitDirection) {
 
 #[cfg(test)]
 mod tests {
-    use super::grid_slot;
-    use board_herdr::{LayoutPane, Rect, SplitDirection};
+    use std::collections::BTreeMap;
+    use std::io::{BufRead, BufReader, Write};
+    use std::os::unix::net::UnixListener;
+    use std::thread;
+
+    use super::{grid_slot, place_in_tab, ERR_PANE_NOT_FOUND};
+    use board_core::spawn::SpawnReq;
+    use board_herdr::{AgentStarted, HerdrClient, LayoutPane, Rect, SplitDirection};
+    use serde_json::Value;
 
     fn pane(id: &str, width: u64, height: u64) -> LayoutPane {
         LayoutPane {
@@ -386,5 +405,156 @@ mod tests {
         let (target, dir) = grid_slot(&panes);
         assert_eq!(target, "biggest");
         assert_eq!(dir, SplitDirection::Right);
+    }
+
+    // -----------------------------------------------------------------------
+    // pane_not_found retry tests
+    // -----------------------------------------------------------------------
+
+    /// Start a fake herdr server on a temp unix socket. The `handler` maps
+    /// each JSON-RPC request to a reply string. One request per connection.
+    fn serve_fake_herdr<F>(handler: F) -> std::path::PathBuf
+    where
+        F: Fn(&Value) -> String + Send + Sync + 'static,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("herdr.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        thread::spawn(move || {
+            for conn in listener.incoming() {
+                let Ok(stream) = conn else { break };
+                let mut w = stream.try_clone().unwrap();
+                let mut r = BufReader::new(stream);
+                let mut line = String::new();
+                match r.read_line(&mut line) {
+                    Ok(0) | Err(_) => continue,
+                    Ok(_) => {}
+                }
+                let Ok(req) = serde_json::from_str::<Value>(line.trim()) else {
+                    continue;
+                };
+                let reply = handler(&req);
+                let _ = w.write_all(reply.as_bytes());
+                let _ = w.write_all(b"\n");
+                let _ = w.flush();
+            }
+        });
+        // Leak the tempdir so the socket stays alive for the test duration.
+        std::mem::forget(dir);
+        path
+    }
+
+    fn json_reply(id: &str, result: &str) -> String {
+        format!(r#"{{"id":"{id}","result":{result}}}"#)
+    }
+
+    fn json_error(id: &str, code: &str, message: &str) -> String {
+        format!(r#"{{"id":"{id}","error":{{"code":"{code}","message":"{message}"}}}}"#)
+    }
+
+    fn fake_agent_started() -> &'static str {
+        r#"{"type":"agent_started","agent":{"pane_id":"w1:p2","terminal_id":"t2","workspace_id":"w1","tab_id":"w1:t1","agent":"card-1-stage2","agent_status":"working"},"argv":["bash","fake-agent.sh"]}"#
+    }
+
+    /// Simulates the Stage1→Stage2 pane-not-found race: the first
+    /// `agent.start` returns `pane_not_found` (Stage1's pane already closed),
+    /// and the retry succeeds by rediscovering the tab and landing unsplit.
+    #[test]
+    fn place_in_tab_retries_on_pane_not_found() {
+        use std::sync::atomic::AtomicU32;
+        use std::sync::Arc;
+
+        // Stateful handler: track rediscovery and both agent.start calls.
+        let tab_calls = Arc::new(AtomicU32::new(0));
+        let tab_calls2 = Arc::clone(&tab_calls);
+        let agent_calls = Arc::new(AtomicU32::new(0));
+        let agent_calls2 = Arc::clone(&agent_calls);
+        let retry_was_unsplit = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let retry_was_unsplit2 = Arc::clone(&retry_was_unsplit);
+        let sock = serve_fake_herdr(move |req| {
+            let id = req["id"].as_str().unwrap_or("");
+            match req["method"].as_str().unwrap() {
+                "tab.list" => {
+                    tab_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    // The kanban tab exists (from Stage1).
+                    json_reply(
+                        id,
+                        r#"{"type":"tab_list","tabs":[{"tab_id":"w1:t1","workspace_id":"w1","number":1,"label":"kanban","focused":true,"pane_count":1,"agent_status":"unknown"}]}"#,
+                    )
+                }
+                "pane.list" => {
+                    // On the first attempt, return Stage1's closing pane.
+                    // On retry (after pane_not_found), return empty.
+                    if agent_calls.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                        json_reply(
+                            id,
+                            r#"{"type":"pane_list","panes":[{"pane_id":"w1:p1","terminal_id":"t1","workspace_id":"w1","tab_id":"w1:t1","agent_status":"unknown"}]}"#,
+                        )
+                    } else {
+                        // Retry: tab exists but no panes → land unsplit.
+                        json_reply(id, r#"{"type":"pane_list","panes":[]}"#)
+                    }
+                }
+                "pane.layout" => json_reply(
+                    id,
+                    r#"{"type":"pane_layout","layout":{"workspace_id":"w1","tab_id":"w1:t1","zoomed":false,"area":{"x":0,"y":0,"width":200,"height":50},"focused_pane_id":"w1:p1","panes":[{"pane_id":"w1:p1","focused":true,"rect":{"x":0,"y":0,"width":200,"height":50}}],"splits":[]}}"#,
+                ),
+                "pane.focus" => json_reply(
+                    id,
+                    r#"{"type":"pane_info","pane":{"pane_id":"w1:p1","terminal_id":"t1","workspace_id":"w1","tab_id":"w1:t1","agent_status":"unknown"}}"#,
+                ),
+                "agent.start" => {
+                    let call = agent_calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    if call == 0 {
+                        // First attempt: simulate pane_not_found race.
+                        json_error(id, ERR_PANE_NOT_FOUND, "pane not found")
+                    } else {
+                        // Retry succeeds after rediscovery, without targeting
+                        // the pane that raced away.
+                        retry_was_unsplit.store(
+                            req["params"].get("split").is_none(),
+                            std::sync::atomic::Ordering::SeqCst,
+                        );
+                        json_reply(id, fake_agent_started())
+                    }
+                }
+                other => panic!("unexpected method {other}"),
+            }
+        });
+
+        let mut client = HerdrClient::connect(&sock).unwrap();
+        let req = SpawnReq {
+            name: "card-1-stage2".into(),
+            name_fallback: Some("card-1-stage2-r2".into()),
+            tab_label: Some("kanban".into()),
+            workspace_ref: Some("w1".into()),
+            argv: vec!["bash".into(), "fake-agent.sh".into()],
+            cwd: None,
+            herdr_socket: None,
+            env: Vec::new(),
+        };
+        let env = BTreeMap::new();
+
+        let result = place_in_tab(&mut client, &req, &env, "w1", "kanban");
+        assert!(
+            result.is_ok(),
+            "place_in_tab should retry on pane_not_found and succeed; got {result:?}"
+        );
+        let started: AgentStarted = result.unwrap();
+        assert_eq!(started.pane_id(), "w1:p2");
+        assert_eq!(
+            tab_calls2.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "retry must rediscover the kanban tab"
+        );
+        assert_eq!(
+            agent_calls2.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "expected exactly two agent.start calls (first fail, retry success)"
+        );
+        assert!(
+            retry_was_unsplit2.load(std::sync::atomic::Ordering::SeqCst),
+            "retry must not target the pane that raced away"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Retry `pane_not_found` by rediscovering the `kanban` tab.
- Place agents unsplit when an existing tab has no panes.
- Add regression coverage for the Stage1→Stage2 race and update the changelog.

## Test evidence
- `cargo test --workspace --all-features` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- `e2e/run-all.sh` ✅ 9/9