### PR TITLE
feat(install): support stock macOS plugin installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- macOS platform support in `herdr-plugin.toml` (`platforms = ["linux", "macos"]`), enabling
+  `herdr plugin install` on macOS. The uninstall snippet in README now uses `sha256sum` with a
+  `shasum -a 256` fallback for stock macOS compatibility.
+
+### Changed
+- `scripts/install-cli.sh` now uses portable checksum selection (`sha256sum` / `shasum -a 256`)
+  and avoids GNU-only `ln -T` / `mv -T`, preserving managed checksum and collision safety.
+
 ### Fixed
 - Flaky Stage1→Stage2 pane placement race: when a chained auto-column Stage1
   finishes and its agent pane closes, the Stage2 placement could pick up the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Rust](https://img.shields.io/badge/rust-edition%202021-orange.svg)
 ![herdr 0.7+](https://img.shields.io/badge/herdr-0.7%2B-8a2be2)
-![platforms: linux](https://img.shields.io/badge/platforms-linux-informational)
+![platforms: linux, macOS](https://img.shields.io/badge/platforms-linux%2C%20macOS-informational)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
 **A kanban board that sits above herdr spaces: cards are prompts, columns are pipeline stages, and
@@ -56,9 +56,10 @@ The single `board` binary is TUI, daemon, and CLI (subcommands). Crates: `board-
 
 ## Install
 
-herdr-board is a Linux herdr plugin distributed from source (topic: `herdr-plugin`). It requires
-herdr 0.7+, Git, and a Rust toolchain with `cargo`. Ensure `~/.local/bin` is on your `PATH` (for
-example, add `export PATH="$HOME/.local/bin:$PATH"` to your shell profile).
+herdr-board is a herdr plugin distributed from source (topic: `herdr-plugin`). It requires
+herdr 0.7+, Git, and a Rust toolchain with `cargo`, and supports Linux and macOS. Ensure
+`~/.local/bin` is on your `PATH` (for example, add `export PATH="$HOME/.local/bin:$PATH"`
+to your shell profile).
 
 ```bash
 herdr plugin install nelsonPires5/herdr-board
@@ -141,7 +142,11 @@ only if it is still the managed binary, then unregister the plugin:
   prefix="herdr-board install-cli.sh managed board sha256:"
   if [ -f "$board" ] && [ ! -L "$board" ] && [ -f "$marker" ] && [ ! -L "$marker" ]; then
     checksum=""
-    checksum_output="$(sha256sum <"$board")" && checksum="${checksum_output%% *}"
+    if command -v sha256sum >/dev/null 2>&1; then
+      checksum_output="$(sha256sum <"$board")" && checksum="${checksum_output%% *}"
+    elif command -v shasum >/dev/null 2>&1; then
+      checksum_output="$(shasum -a 256 <"$board")" && checksum="${checksum_output%% *}"
+    fi
     if [[ "$checksum" =~ ^[0-9a-f]{64}$ ]] && printf '%s\n' "$prefix$checksum" | cmp -s - "$marker"; then
       rm -- "$board" "$marker"
     else

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -12,7 +12,7 @@ name = "Herdr Board"
 version = "0.2.0"
 description = "Kanban board for AI coding agents: cards are prompts, columns are pipeline stages; moving a card dispatches an agent into a herdr pane."
 min_herdr_version = "0.7.0"
-platforms = ["linux"]
+platforms = ["linux", "macos"]
 
 # Build the `board` binary at install time (idempotent: cargo no-ops when nothing
 # changed). Produces target/release/board, which the pane command below runs.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -37,21 +37,30 @@ if [ ! -f "$source_bin" ] || [ ! -x "$source_bin" ]; then
   echo "install-cli.sh: expected executable source binary at $source_bin; run scripts/build.sh first" >&2
   exit 1
 fi
-if ! command -v sha256sum >/dev/null 2>&1; then
-  echo "install-cli.sh: GNU sha256sum is required to validate managed CLI contents" >&2
-  exit 1
-fi
-
 sha256_file() {
   local path="$1"
-  local output checksum
-  if ! output="$(sha256sum <"$path")"; then
-    echo "install-cli.sh: failed to calculate SHA-256 checksum for $path" >&2
+  local output checksum tool_name
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    tool_name="sha256sum"
+    if ! output="$(sha256sum <"$path")"; then
+      echo "install-cli.sh: failed to calculate SHA-256 checksum for $path" >&2
+      return 1
+    fi
+  elif command -v shasum >/dev/null 2>&1; then
+    tool_name="shasum -a 256"
+    if ! output="$(shasum -a 256 <"$path")"; then
+      echo "install-cli.sh: failed to calculate SHA-256 checksum for $path" >&2
+      return 1
+    fi
+  else
+    echo "install-cli.sh: sha256sum or shasum is required to validate managed CLI contents" >&2
     return 1
   fi
+
   checksum="${output%% *}"
   if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
-    echo "install-cli.sh: sha256sum returned an invalid checksum for $path" >&2
+    echo "install-cli.sh: $tool_name returned an invalid checksum for $path" >&2
     return 1
   fi
   printf '%s\n' "$checksum"
@@ -78,9 +87,12 @@ managed=false
 managed_checksum=""
 if [ -f "$marker" ]; then
   marker_value="$(<"$marker")"
-  if [[ "$marker_value" =~ ^${marker_prefix}([0-9a-f]{64})$ ]]; then
-    managed=true
-    managed_checksum="${BASH_REMATCH[1]}"
+  if [[ "$marker_value" == "${marker_prefix}"* ]]; then
+    marker_checksum="${marker_value#"$marker_prefix"}"
+    if [[ "$marker_checksum" =~ ^[0-9a-f]{64}$ ]]; then
+      managed=true
+      managed_checksum="$marker_checksum"
+    fi
   fi
 fi
 
@@ -125,19 +137,109 @@ marker_value="${marker_prefix}${installed_checksum}"
 printf '%s\n' "$marker_value" >"$marker_temporary"
 chmod 0644 "$marker_temporary"
 if [ "$managed" = true ]; then
-  mv -fT -- "$temporary" "$destination"
-  mv -fT -- "$marker_temporary" "$marker"
+  # Portable replacement for mv -T: the destination was already verified as a
+  # regular file with the expected checksum.  Replace it and verify the result;
+  # clean up leaks when a raced directory swallowed the move.
+  mv -f -- "$temporary" "$destination"
+
+  # Postcondition: destination must be a regular non-symlink file whose
+  # content matches the expected checksum.
+  if [ ! -f "$destination" ] || [ -L "$destination" ]; then
+    leaked="$destination/${temporary##*/}"
+    if [ -f "$leaked" ]; then
+      if leaked_checksum="$(sha256_file "$leaked")" && [ "$leaked_checksum" = "$installed_checksum" ]; then
+        rm -f -- "$leaked"
+      fi
+    fi
+    echo "install-cli.sh: managed destination unexpectedly became a directory: $destination" >&2
+    exit 1
+  fi
+  if ! actual_checksum="$(sha256_file "$destination")"; then
+    exit 1
+  fi
+  if [ "$actual_checksum" != "$installed_checksum" ]; then
+    echo "install-cli.sh: managed destination checksum mismatch after update" >&2
+    exit 1
+  fi
+
+  mv -f -- "$marker_temporary" "$marker"
+  # Postcondition: marker must be a regular non-symlink file whose
+  # content matches the expected value exactly.
+  if [ ! -f "$marker" ] || [ -L "$marker" ]; then
+    leaked_marker="$marker/${marker_temporary##*/}"
+    if [ -f "$leaked_marker" ]; then
+      leaked_value="$(<"$leaked_marker")"
+      if [ "$leaked_value" = "$marker_value" ]; then
+        rm -f -- "$leaked_marker"
+      fi
+    fi
+    echo "install-cli.sh: ownership marker path unexpectedly became a directory: $marker" >&2
+    exit 1
+  fi
+  actual_marker_value="$(<"$marker")"
+  if [ "$actual_marker_value" != "$marker_value" ]; then
+    echo "install-cli.sh: ownership marker content mismatch after placement" >&2
+    exit 1
+  fi
 else
-  if ! ln -T -- "$temporary" "$destination"; then
+  # Hard-link is a no-clobber atomic creation on first install.  After ln
+  # succeeds, verify the destination is a regular non-symlink hard link to
+  # the temporary file.  If ln interpreted a raced directory it silently
+  # linked inside it; detect and clean up the leaked candidate.
+  if ! ln -- "$temporary" "$destination"; then
     echo "install-cli.sh: refusing to overwrite destination created during install: $destination" >&2
     exit 1
   fi
-  rm -f -- "$temporary"
-  if ! mv -fT -- "$marker_temporary" "$marker"; then
-    rm -f -- "$destination"
+
+  if [ ! -f "$destination" ] || [ -L "$destination" ]; then
+    leaked="$destination/${temporary##*/}"
+    if [ -f "$leaked" ] && [ "$leaked" -ef "$temporary" ]; then
+      rm -f -- "$leaked"
+    fi
+    rm -f -- "$temporary"
+    echo "install-cli.sh: destination unexpectedly became a directory during install: $destination" >&2
+    exit 1
+  fi
+  if [ ! "$destination" -ef "$temporary" ]; then
+    rm -f -- "$temporary"
+    echo "install-cli.sh: installed file is not a link to the staged temporary: $destination" >&2
+    exit 1
+  fi
+
+  # Keep the staged temporary hardlink alive until ownership marker
+  # placement and postcondition succeed so we can safely roll back.
+  if ! mv -f -- "$marker_temporary" "$marker"; then
+    if [ -f "$destination" ] && [ ! -L "$destination" ] && [ "$destination" -ef "$temporary" ]; then
+      rm -f -- "$destination"
+    fi
     echo "install-cli.sh: could not create ownership marker: $marker" >&2
     exit 1
   fi
+  # Postcondition: marker must be a regular non-symlink file whose
+  # content matches the expected value exactly.
+  if [ ! -f "$marker" ] || [ -L "$marker" ]; then
+    leaked_marker="$marker/${marker_temporary##*/}"
+    if [ -f "$leaked_marker" ]; then
+      leaked_value="$(<"$leaked_marker")"
+      if [ "$leaked_value" = "$marker_value" ]; then
+        rm -f -- "$leaked_marker"
+      fi
+    fi
+    if [ -f "$destination" ] && [ ! -L "$destination" ] && [ "$destination" -ef "$temporary" ]; then
+      rm -f -- "$destination"
+    fi
+    echo "install-cli.sh: ownership marker path unexpectedly became a directory: $marker" >&2
+    exit 1
+  fi
+  actual_marker_value="$(<"$marker")"
+  if [ "$actual_marker_value" != "$marker_value" ]; then
+    if [ -f "$destination" ] && [ ! -L "$destination" ] && [ "$destination" -ef "$temporary" ]; then
+      rm -f -- "$destination"
+    fi
+    echo "install-cli.sh: ownership marker content mismatch after placement" >&2
+    exit 1
+  fi
+  rm -f -- "$temporary"
 fi
 trap - EXIT HUP INT TERM
 

--- a/scripts/tests/test_install_cli.py
+++ b/scripts/tests/test_install_cli.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import tomllib
 import unittest
@@ -15,18 +17,123 @@ SCRIPT = REPO_ROOT / "scripts" / "install-cli.sh"
 MARKER_NAME = ".herdr-board-cli-managed"
 MARKER_PREFIX = "herdr-board install-cli.sh managed board sha256:"
 
+# Absolute path to the Python interpreter running this test suite, used
+# in stub shebangs so stubs work inside isolated PATHs that lack /usr/bin.
+_PYTHON3 = sys.executable
+
 
 def marker_bytes(content: bytes) -> bytes:
     checksum = hashlib.sha256(content).hexdigest()
     return f"{MARKER_PREFIX}{checksum}\n".encode()
 
 
+def _write_stub(dir_path: Path, name: str, body: str) -> Path:
+    """Write an executable stub with a hardcoded python3 shebang.
+    Unlinks any existing entry first so we can replace a symlink."""
+    stub = dir_path / name
+    try:
+        stub.unlink()
+    except FileNotFoundError:
+        pass
+    stub.write_text(f"#!{_PYTHON3}\n{body}", encoding="utf-8")
+    stub.chmod(0o755)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# minimal cross-platform stubs (pure Python 3 stdlib, no external deps)
+# ---------------------------------------------------------------------------
+
+# Checksum stubs.  sha256sum is called bare; shasum receives '-a 256'.
+_SHA256SUM_BODY = (
+    "import hashlib, sys\n"
+    "print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest() + '  -')\n"
+)
+
+_SHASUM_BODY = (
+    "import hashlib, sys\n"
+    "assert sys.argv[1:] == ['-a', '256'], f'shasum stub expected -a 256, got {sys.argv[1:]}'\n"
+    "print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest() + '  -')\n"
+)
+
+
+def _ln_race_body() -> str:
+    """ln stub that races the destination into a directory, resolving the
+    real ln via shutil.which at construction time."""
+    real_ln = shutil.which("ln")
+    if real_ln is None:
+        raise FileNotFoundError("Cannot find ln on PATH")
+    return (
+        "import os, sys\n"
+        f"REAL_LN = {real_ln!r}\n"
+        "dest = sys.argv[-1]\n"
+        "try:\n"
+        "    os.mkdir(dest, 0o755)\n"
+        "except FileExistsError:\n"
+        "    pass\n"
+        "os.execv(REAL_LN, ['ln'] + sys.argv[1:])\n"
+    )
+
+
+def _mv_marker_race_body() -> str:
+    """mv stub that races the marker destination into a directory before
+    delegating to the real mv."""
+    real_mv = shutil.which("mv")
+    if real_mv is None:
+        raise FileNotFoundError("Cannot find mv on PATH")
+    return (
+        "import os, sys\n"
+        f"REAL_MV = {real_mv!r}\n"
+        "dest = sys.argv[-1]\n"
+        "if os.path.basename(dest) == '.herdr-board-cli-managed':\n"
+        "    try:\n"
+        "        os.mkdir(dest, 0o755)\n"
+        "    except FileExistsError:\n"
+        "        pass\n"
+        "os.execv(REAL_MV, ['mv'] + sys.argv[1:])\n"
+    )
+
+
 class InstallCliTests(unittest.TestCase):
-    def make_fixture(self, root: Path, content: str = "#!/bin/sh\necho first\n") -> tuple[Path, Path]:
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _setup_isolated_tools(
+        tools: Path,
+        *,
+        with_sha256sum: bool = False,
+        with_shasum: bool = False,
+    ) -> None:
+        """Populate *tools* with symlinks to every external command the
+        install script needs.  The caller should set PATH to *tools*
+        alone (no /bin or /usr/bin) for a fully isolated environment.
+
+        Checksum tools are only added when the corresponding flag is
+        True; when False the tool is deliberately absent from PATH so
+        fallback and error paths can be tested deterministically."""
+        tools.mkdir(parents=True, exist_ok=True)
+        # Every external binary referenced by install-cli.sh, plus the
+        # shell used to execute stubs and the script itself.
+        for cmd in ("ln", "mv", "mkdir", "cp", "chmod", "rm",
+                    "dirname", "mktemp", "bash", "sh"):
+            real = shutil.which(cmd)
+            if real is None:
+                raise FileNotFoundError(f"Cannot find {cmd} on PATH")
+            (tools / cmd).symlink_to(real)
+        if with_sha256sum:
+            _write_stub(tools, "sha256sum", _SHA256SUM_BODY)
+        if with_shasum:
+            _write_stub(tools, "shasum", _SHASUM_BODY)
+
+    @staticmethod
+    def make_fixture(
+        root: Path, content: str = "#!/bin/sh\necho first\n"
+    ) -> tuple[Path, Path]:
         script = root / "scripts" / "install-cli.sh"
         script.parent.mkdir(parents=True)
         shutil.copy2(SCRIPT, script)
-
         source = root / "target" / "release" / "board"
         source.parent.mkdir(parents=True)
         source.write_text(content, encoding="utf-8")
@@ -40,26 +147,13 @@ class InstallCliTests(unittest.TestCase):
         home: Path,
         install_dir: Path | None = None,
         path_prefix: Path | None = None,
+        full_path: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env["HOME"] = str(home)
-        # The plugin is Linux-only and intentionally uses GNU no-target-directory
-        # semantics. Let this test suite run on macOS when Homebrew coreutils is
-        # available under its conventional g-prefixed command names.
-        if os.uname().sysname == "Darwin":
-            gnu_commands = {
-                command: shutil.which(f"g{command}")
-                for command in ("ln", "mv", "sha256sum")
-            }
-            if all(gnu_commands.values()):
-                gnu_bin = home / ".test-gnu-bin"
-                gnu_bin.mkdir(parents=True, exist_ok=True)
-                for command, executable in gnu_commands.items():
-                    command_path = gnu_bin / command
-                    if not command_path.exists():
-                        command_path.symlink_to(executable)
-                env["PATH"] = f"{gnu_bin}{os.pathsep}{env['PATH']}"
-        if path_prefix is not None:
+        if full_path is not None:
+            env["PATH"] = full_path
+        elif path_prefix is not None:
             env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
         if install_dir is None:
             env.pop("HERDR_BOARD_CLI_INSTALL_DIR", None)
@@ -72,6 +166,55 @@ class InstallCliTests(unittest.TestCase):
             capture_output=True,
             check=False,
         )
+
+    # ------------------------------------------------------------------
+    # stock host install / update (real system tools, default PATH)
+    # ------------------------------------------------------------------
+
+    def test_first_install_creates_ownership_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+
+            result = self.run_script(script, home=home)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertFalse(destination.is_symlink())
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o751)
+            marker = install_dir / MARKER_NAME
+            self.assertTrue(marker.is_file())
+            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
+
+    def test_managed_install_updates_idempotently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            marker = install_dir / MARKER_NAME
+
+            first = self.run_script(script, home=home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            original_marker = marker.read_bytes()
+
+            source.write_text("#!/bin/sh\necho second\n", encoding="utf-8")
+            source.chmod(0o755)
+            second = self.run_script(script, home=home)
+
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o755)
+            self.assertNotEqual(marker.read_bytes(), original_marker)
+            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
+
+    # ------------------------------------------------------------------
+    # safety tests
+    # ------------------------------------------------------------------
 
     def test_refuses_unrelated_existing_board_without_changing_it(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -116,47 +259,6 @@ class InstallCliTests(unittest.TestCase):
                     self.assertEqual(os.readlink(destination), str(install_dir / "missing-target"))
                 else:
                     self.assertEqual((destination / "keep").read_text(encoding="utf-8"), "untouched")
-
-    def test_first_install_creates_ownership_marker(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp) / "repo"
-            home = Path(tmp) / "home"
-            script, source = self.make_fixture(root)
-            install_dir = home / ".local" / "bin"
-            destination = install_dir / "board"
-
-            result = self.run_script(script, home=home)
-
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(destination.read_bytes(), source.read_bytes())
-            self.assertFalse(destination.is_symlink())
-            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o751)
-            marker = install_dir / MARKER_NAME
-            self.assertTrue(marker.is_file())
-            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
-
-    def test_managed_install_updates_idempotently(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp) / "repo"
-            home = Path(tmp) / "home"
-            script, source = self.make_fixture(root)
-            install_dir = home / ".local" / "bin"
-            destination = install_dir / "board"
-            marker = install_dir / MARKER_NAME
-
-            first = self.run_script(script, home=home)
-            self.assertEqual(first.returncode, 0, first.stderr)
-            original_marker = marker.read_bytes()
-
-            source.write_text("#!/bin/sh\necho second\n", encoding="utf-8")
-            source.chmod(0o755)
-            second = self.run_script(script, home=home)
-
-            self.assertEqual(second.returncode, 0, second.stderr)
-            self.assertEqual(destination.read_bytes(), source.read_bytes())
-            self.assertEqual(stat.S_IMODE(destination.stat().st_mode), 0o755)
-            self.assertNotEqual(marker.read_bytes(), original_marker)
-            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
 
     def test_managed_update_refuses_replaced_board_and_preserves_both_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -250,9 +352,9 @@ class InstallCliTests(unittest.TestCase):
             script, _source = self.make_fixture(root)
             fake_bin = Path(tmp) / "fake-bin"
             fake_bin.mkdir()
-            fake_sha256sum = fake_bin / "sha256sum"
-            fake_sha256sum.write_text("#!/bin/sh\nprintf 'not-a-checksum  -\\n'\n", encoding="utf-8")
-            fake_sha256sum.chmod(0o755)
+            fake = fake_bin / "sha256sum"
+            fake.write_text("#!/bin/sh\nprintf 'not-a-checksum  -\\n'\n", encoding="utf-8")
+            fake.chmod(0o755)
 
             result = self.run_script(script, home=home, path_prefix=fake_bin)
 
@@ -261,6 +363,132 @@ class InstallCliTests(unittest.TestCase):
             install_dir = home / ".local" / "bin"
             self.assertFalse((install_dir / "board").exists())
             self.assertFalse((install_dir / MARKER_NAME).exists())
+
+    # ------------------------------------------------------------------
+    # portability
+    # ------------------------------------------------------------------
+
+    def test_shasum_fallback_when_sha256sum_missing(self) -> None:
+        """First install succeeds with only shasum (no sha256sum)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+
+            tools = Path(tmp) / "tools"
+            # Provide shasum but NOT sha256sum in a fully isolated PATH.
+            self._setup_isolated_tools(tools, with_shasum=True, with_sha256sum=False)
+
+            result = self.run_script(script, home=home,
+                                     full_path=str(tools))
+
+            self.assertEqual(result.returncode, 0,
+                             f"expected success with shasum, got: {result.stderr}")
+            self.assertEqual(destination.read_bytes(), source.read_bytes())
+            self.assertFalse(destination.is_symlink())
+            marker = install_dir / MARKER_NAME
+            self.assertTrue(marker.is_file())
+            self.assertEqual(marker.read_bytes(), marker_bytes(source.read_bytes()))
+
+    def test_rejects_when_no_checksum_tool_available(self) -> None:
+        """Script errors clearly when neither sha256sum nor shasum exists."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, _source = self.make_fixture(root)
+
+            tools = Path(tmp) / "tools"
+            # Isolated PATH: no checksum tool at all.
+            self._setup_isolated_tools(tools, with_sha256sum=False, with_shasum=False)
+
+            result = self.run_script(script, home=home,
+                                     full_path=str(tools))
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("sha256sum", result.stderr.lower())
+            self.assertIn("shasum", result.stderr.lower())
+            install_dir = home / ".local" / "bin"
+            self.assertFalse((install_dir / "board").exists())
+            self.assertFalse((install_dir / MARKER_NAME).exists())
+
+    def test_no_gnu_only_T_flags(self) -> None:
+        """Static assertion: the script must not depend on GNU-only -T."""
+        text = SCRIPT.read_text()
+        # Strip comments so we don't flag mentions in prose like
+        # "# Portable replacement for ln -T".
+        active = re.sub(r'^\s*#.*$', '', text, flags=re.MULTILINE)
+        self.assertNotIn("ln -T", active, "script contains GNU-only ln -T")
+        self.assertNotIn("mv -T", active, "script contains GNU-only mv -T")
+        self.assertNotIn("mv -fT", active, "script contains GNU-only mv -fT")
+
+    def test_first_install_race_directory_replaces_destination(self) -> None:
+        """ln TOCTOU: fake ln creates a directory at the destination
+        after the [ -d ] check passes but before the real ln runs.
+        Expects nonzero exit, no marker, and no leaked link inside the
+        raced directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+
+            tools = Path(tmp) / "tools"
+            tools.mkdir()
+            _write_stub(tools, "ln", _ln_race_body())
+
+            result = self.run_script(script, home=home, path_prefix=tools)
+
+            self.assertNotEqual(result.returncode, 0,
+                                "script should fail when destination is raced into a directory")
+
+            self.assertFalse((install_dir / MARKER_NAME).exists(),
+                             "marker must not exist after a raced first install")
+
+            if destination.is_dir():
+                leaked = list(destination.iterdir())
+                self.assertEqual(len(leaked), 0,
+                                 f"no leaked hard link inside raced directory: {leaked}")
+
+    # ------------------------------------------------------------------
+    # Marker-placement race: a fake mv turns the marker destination into
+    # a directory immediately before the real mv.  The script's marker
+    # postcondition catches this, exits non-zero, cleans up any leaked
+    # marker inside the raced directory, and rolls back the board binary.
+    # ------------------------------------------------------------------
+
+    def test_first_install_marker_race_directory_replaces_marker(self) -> None:
+        """Marker-placement race: fake mv creates a directory where the
+        ownership marker should go.  Expects nonzero exit, installed board
+        removed (rollback), and no leaked marker inside the raced directory."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            home = Path(tmp) / "home"
+            script, source = self.make_fixture(root)
+            install_dir = home / ".local" / "bin"
+            destination = install_dir / "board"
+            marker_path = install_dir / MARKER_NAME
+
+            tools = Path(tmp) / "tools"
+            self._setup_isolated_tools(tools, with_sha256sum=True)
+            _write_stub(tools, "mv", _mv_marker_race_body())
+
+            result = self.run_script(script, home=home, full_path=str(tools))
+
+            self.assertNotEqual(result.returncode, 0,
+                               "script should fail when marker is raced into a directory")
+
+            # The board binary MUST be removed — the install was not completed.
+            self.assertFalse(destination.exists(),
+                             "board must be rolled back after marker placement failure")
+
+            # No leaked marker file inside the raced directory.
+            if marker_path.is_dir():
+                leaked = list(marker_path.iterdir())
+                self.assertEqual(len(leaked), 0,
+                                 f"no leaked marker inside raced directory: {leaked}")
 
 
 class PluginManifestTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- make plugin CLI installation portable across stock Linux and macOS
- preserve checksum ownership and collision/race protections
- declare macOS support and update tests, README, and changelog

## Validation
- `cargo test --workspace --all-features`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- Python installer tests: 25/25
- E2E scenarios: 9/9
- remote macOS install/action smoke test at `5b5a7a1`, with complete cleanup
