### PR TITLE
Stop the board daemon on reinstall to prevent stale-code drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project are documented here. The format is based on
   `pane.focus`. Same-session validation prevents pane-id collisions across sessions; success closes
   the overlay and errors remain as toasts.
 - Live E2E scenarios cover Git/CWD board identity and real-plugin jump-to-pane behavior.
+- `board daemon --stop` gracefully stops the running daemon over its socket (idempotent; clears a
+  stale socket if nothing is listening). The plugin `build.sh` calls it before recompiling, so a
+  reinstall replaces a stopped process rather than overwriting a binary the old daemon still has
+  mapped — the cause of stale-daemon version drift after an update. README `Maintenance` now
+  documents the update flow and a full uninstall (stop the daemon first, since Herdr's plugin
+  uninstall has no lifecycle hook and leaves the detached daemon running).
 
 ### Changed
 - Scope-sensitive CLI commands use Git root/CWD (overridable with `BOARD_SCOPE_PATH`), while

--- a/README.md
+++ b/README.md
@@ -295,12 +295,41 @@ and `{permission_mode}` are available in `argv`.
 ## Maintenance
 
 <details>
-<summary><strong>Uninstall</strong></summary>
+<summary><strong>Update</strong></summary>
 
-Herdr's plugin uninstall cannot remove the CLI copied outside its managed checkout. Remove it only
-when its checksum still matches the managed marker, then unregister the plugin:
+Re-run the install command to update — Herdr has no separate update command, so reinstall over the
+existing plugin:
 
 ```bash
+herdr plugin install nelsonPires5/herdr-board --yes
+```
+
+The build step stops the running daemon (`board daemon --stop`) before recompiling, so the new
+binary replaces a stopped process instead of overwriting one the old daemon still has mapped in
+memory. The next `board` command auto-starts a fresh daemon from the new binary.
+
+Run the install once from each named Herdr session where the plugin is registered.
+
+If you are updating from a version older than the `--stop` flag and a stale daemon is still
+serving the old code, stop it manually first, then reinstall:
+
+```bash
+pkill -f 'board daemon'
+herdr plugin install nelsonPires5/herdr-board --yes
+```
+
+</details>
+
+<details>
+<summary><strong>Uninstall</strong></summary>
+
+Herdr's plugin uninstall has no lifecycle hook and does not stop the board daemon — boardd is a
+detached process Herdr does not track, so uninstalling the plugin leaves it running (and, after a
+reinstall, serving stale code). Stop it first, then remove the CLI Herdr can't manage (only when
+its checksum still matches the managed marker), then unregister the plugin:
+
+```bash
+board daemon --stop 2>/dev/null || pkill -f 'board daemon'
 (
   if [ "${HERDR_BOARD_CLI_INSTALL_DIR+x}" = x ]; then
     install_dir="$HERDR_BOARD_CLI_INSTALL_DIR"
@@ -333,6 +362,10 @@ herdr plugin uninstall herdr-board
 
 If `HERDR_BOARD_CLI_INSTALL_DIR` was used, use the same directory for every update and cleanup.
 Uninstall the plugin from each named session where it was registered.
+
+To remove all board data (cards, columns, runs), delete the data directory — `BOARD_DB`'s default
+(`~/Library/Application Support/herdr-board` on macOS, `~/.local/share/herdr-board` on Linux).
+This is optional and never needed for a normal reinstall.
 
 </details>
 

--- a/crates/board-cli/src/main.rs
+++ b/crates/board-cli/src/main.rs
@@ -39,6 +39,11 @@ enum Cmd {
         /// Log to stderr as well as the log file, and stay attached.
         #[arg(long)]
         foreground: bool,
+        /// Stop the running daemon (graceful) and exit. The plugin build step
+        /// uses this so a reinstall replaces a stopped process instead of a
+        /// stale binary the old daemon still has mapped in memory.
+        #[arg(long)]
+        stop: bool,
     },
     /// Show daemon status.
     Status {
@@ -241,7 +246,13 @@ fn main() {
 fn real_main() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
-        Cmd::Daemon { foreground } => board_daemon::run(foreground).map_err(|e| anyhow!(e)),
+        Cmd::Daemon { foreground, stop } => {
+            if stop {
+                stop_daemon()
+            } else {
+                board_daemon::run(foreground).map_err(|e| anyhow!(e))
+            }
+        }
         Cmd::Tui => {
             let mut client = connect_or_start()?;
             let board = open_current_board(&mut client)?;
@@ -312,6 +323,52 @@ fn spawn_daemon() -> Result<()> {
     // Detach into a new process group so it outlives this CLI invocation.
     cmd.process_group(0);
     cmd.spawn()?;
+    Ok(())
+}
+
+/// `board daemon --stop`: gracefully shut down the running daemon over the
+/// socket, then wait for its listener to vanish. Idempotent — if nothing is
+/// running (or only a stale socket file remains) it cleans up and succeeds.
+/// Used by the plugin build step before a reinstall.
+fn stop_daemon() -> Result<()> {
+    let path = paths::socket_path();
+
+    let mut client = match UnixClient::connect(&path) {
+        Ok(c) => c,
+        Err(_) => {
+            // No live listener: clear any stale socket file left by a crash.
+            let _ = std::fs::remove_file(&path);
+            println!("boardd not running");
+            return Ok(());
+        }
+    };
+
+    // Ask the daemon to shut itself down. A daemon older than `daemon.stop`
+    // rejects it; tell the user to stop it manually in that case.
+    let stop_result = client.daemon_stop();
+    drop(client);
+    if let Err(e) = stop_result {
+        let _ = std::fs::remove_file(&path);
+        bail!(
+            "could not stop boardd gracefully ({e}); it may predate `daemon.stop` — \
+             stop it manually, e.g. `pkill -f 'board daemon'`"
+        );
+    }
+
+    // Wait for the listener to disappear (the daemon removes the socket on
+    // exit), so the next launch spawns a fresh process rather than racing a
+    // half-dead one still holding the single-instance lock.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut delay = Duration::from_millis(25);
+    while Instant::now() < deadline {
+        if UnixClient::connect(&path).is_err() {
+            break;
+        }
+        std::thread::sleep(delay);
+        delay = (delay * 2).min(Duration::from_millis(200));
+    }
+    let _ = std::fs::remove_file(&path);
+    println!("boardd stopped");
     Ok(())
 }
 

--- a/crates/board-daemon/src/ops.rs
+++ b/crates/board-daemon/src/ops.rs
@@ -548,6 +548,15 @@ mod tests {
     }
 
     #[test]
+    fn daemon_stop_triggers_shutdown_and_reports_stopping() {
+        let d = test_daemon(Config::default());
+        assert!(!d.is_shutdown());
+        let res = handle_request(&d, "daemon.stop", json!({})).unwrap();
+        assert_eq!(res["stopping"], true);
+        assert!(d.is_shutdown());
+    }
+
+    #[test]
     fn board_open_list_get_and_legacy_default_are_scoped() {
         let d = test_daemon(Config::default());
         let alpha = handle_request(&d, "board.open", json!({"scope_path":"/alpha"})).unwrap();

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,15 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 cd "$repo_root"
 
+# Stop a running boardd before rebuilding so the reinstall replaces a stopped
+# process rather than overwriting a binary the old daemon still has mapped in
+# memory (which would leave a stale daemon serving the previous version). This
+# is best-effort: a very old `board` without `--stop` errors here and we just
+# continue — the README documents the manual stop for that one-time case.
+if command -v board >/dev/null 2>&1; then
+  board daemon --stop >/dev/null 2>&1 || true
+fi
+
 # Prefer a user-local cargo if PATH doesn't already have one.
 if ! command -v cargo >/dev/null 2>&1; then
   export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
## Why
Reinstalling the plugin overwrites the `board` binary on disk, but a running boardd keeps the old inode mapped in memory and keeps serving the previous version. After the 0.3 → 0.5 update this left a 0.3.0 daemon answering the socket while the 0.5.0 TUI called the new `board.open` method — the board overlay flashed and closed on every open.

## Changes
- **`board daemon --stop`** (new CLI flag): connects to the boardd socket, sends the already-existing `daemon.stop` RPC, waits for the listener to vanish, and clears a stale socket. Idempotent when nothing is running.
- **`scripts/build.sh`** calls `board daemon --stop` before recompiling, so a reinstall replaces a stopped process instead of a stale mapped binary.
- **README `Maintenance`**: new Update section + expanded Uninstall (stop the daemon first; Herdr's plugin uninstall has no lifecycle hook and leaves the detached boardd running).
- Unit test pins the `daemon.stop` → shutdown contract the new flag relies on.

## Caveat
A first reinstall from a pre-`--stop` CLI no-ops the stop (the old `board` rejects `--stop`); the README documents the one-time manual `pkill -f 'board daemon'`. From the next reinstall onward it's clean.
