### PR TITLE
chore: add worktree directory to the project gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.snap.new
 daemon.log
 __pycache__/
+worktree/


### PR DESCRIPTION
Adds `.herdr-board-worktrees/` to `.gitignore` so that git worktree directories used for parallel development don't get accidentally committed.