### PR TITLE
fix(e2e): prevent Claude startup dialogs from consuming prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- The opt-in real-Claude Haiku smoke now stages only completed onboarding/theme, exact workspace
+  trust, the installed Herdr hook, credentials, and approved `remote-settings.json` bytes. This
+  prevents startup dialogs from consuming `agent.prompt` without copying broad personal Claude
+  state; it still permits exactly one no-retry Haiku/low attempt.
+
 ## [0.7.0] - 2026-07-22
 
 ### Added

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -113,7 +113,7 @@ case ↔ scenario ↔ status catalog):
 | `16-managed-p17.sh` | Pane-first protocol-17 Pi + Claude launch through checked-in no-provider fixtures: exact 0600 system files, readiness, session/idle reports, `agent.prompt`, and held layout. |
 | `17-configured-p17-runner.sh` | Unmanaged protocol-17 configured-harness bridge: exact argv/multiline env/cwd/socket values, `pane run`, held layout, and explicit `board done`. |
 | `real-pi-smoke.sh` | Separate opt-in (`E2E_REAL_PI=1`) real-provider poem smoke; never included by `run-all.sh`. |
-| `real-claude-haiku-smoke.sh` | Opt-in intended-contract smoke (`E2E_REAL_CLAUDE_HAIKU=1`): exactly one authorized Claude Haiku/low attempt, staged temporary Claude config, no retry/fallback, and exact cleanup; never included by `run-all.sh`. |
+| `real-claude-haiku-smoke.sh` | Opt-in intended-contract smoke (`E2E_REAL_CLAUDE_HAIKU=1`): exactly one authorized Claude Haiku/low attempt, stages only completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved remote-settings bytes, preventing startup dialogs from consuming `agent.prompt`; no broad personal Claude state, retry/fallback, or standard-suite inclusion. |
 | `run-all.sh` | Builds once, runs every standard no-cost scenario, prints a PASS/FAIL/SKIP summary. |
 
 Deterministic daemon tests cover working→running, blocked, Herdr's output-only `done` event →
@@ -131,8 +131,10 @@ terminal fixtures, not provider stubs that can pass at process startup: each rep
 session identity then idle, waits for Herdr readiness, and refuses to call `board done` until the
 exact card prompt arrives through `agent.prompt`. Scenario 17 proves configured harnesses remain
 unmanaged and receive exact `BOARD_PROMPT`/`BOARD_SYSTEM_PROMPT` values through the generated
-`pane run` bridge. The real-Claude smoke is separate: its intended contract is one authorized
-Haiku/low attempt with no retry or fallback.
+`pane run` bridge. The real-Claude smoke is separate: it stages only completed onboarding/theme, exact
+workspace trust, the installed Herdr hook, credentials, and approved `remote-settings.json`,
+so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied.
+Its intended contract is one authorized Haiku/low attempt with no retry or fallback.
 
 `scripts/e2e.sh` is a thin compat wrapper that `exec`s `run-all.sh`.
 
@@ -275,7 +277,7 @@ E2E_REAL_PI=1 e2e/real-pi-smoke.sh  # explicit real-provider opt-in; may incur c
 E2E_REAL_CLAUDE_HAIKU=1 e2e/real-claude-haiku-smoke.sh  # one authorized Haiku/low attempt; may incur cost
 ```
 
-- Standard suite requires **exactly Herdr 0.7.5 / socket protocol 17**, `python3`, and `cargo`. Every scenario preflights both `herdr --version` and a socket `ping`; protocol 16 and unknown/future protocols fail before dispatch. The forced-build standard suite scenarios 01–17 pass with no provider calls. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages credentials/settings under `/tmp`, authorizes exactly one Haiku/low attempt, and has no retry or fallback. Both opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
+- Standard suite requires **exactly Herdr 0.7.5 / socket protocol 17**, `python3`, and `cargo`. Every scenario preflights both `herdr --version` and a socket `ping`; protocol 16 and unknown/future protocols fail before dispatch. The forced-build standard suite scenarios 01–17 pass with no provider calls. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages minimal completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved `remote-settings.json` under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied, and it has no retry or fallback. Both opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
   the release binary once; scenarios reuse it. **No second session** is needed —
   the suite boots its own ephemeral session(s) and cleans them up.
 - Exit codes: scenario `0` = PASS, `3` = SKIP, other = FAIL; `run-all.sh` exits

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -115,8 +115,10 @@ and the `herdr session stop <n> && herdr session delete <n>` cleanup one-liner.
 Exit codes: scenario `0` = PASS, `3` = SKIP (missing precondition), anything else =
 FAIL. `run-all.sh` exits non-zero if any scenario FAILED. The suite is **not** part
 of CI (it needs Herdr 0.7.5 to boot a real ephemeral protocol-17 server) — it is
-run by a human/orchestrator. The real-Claude smoke's intended contract is one
-authorized attempt with no retry or fallback.
+run by a human/orchestrator. The real-Claude smoke stages only completed onboarding/theme,
+exact workspace trust, the installed Herdr hook, credentials, and approved
+`remote-settings.json`, so startup dialogs cannot consume `agent.prompt`; it copies no broad
+personal Claude state. Its intended contract is one authorized attempt with no retry or fallback.
 
 ## Files
 
@@ -128,7 +130,7 @@ authorized attempt with no retry or fallback.
 | `16-managed-p17.sh` | Managed pane-first Pi/Claude protocol-17 launch and no-provider boundary. |
 | `17-configured-p17-runner.sh` | Unmanaged configured-command `pane run` bridge and exact argv/env evidence. |
 | `real-pi-smoke.sh` | Fail-closed real-provider poem smoke. Detects Pi's runtime default model, passes low thinking, isolates board/Pi session output under `/tmp`, verifies integration/WezTerm, poem/comments/argv/git/settings, and supports keep mode for visual audit. Not in `run-all.sh`. |
-| `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages writable Claude state under `/tmp`, independently identity-gates the daemon and Herdr server, and cleans exact resources. Not in `run-all.sh`. |
+| `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages only completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved remote-settings bytes under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied. Independently identity-gates the daemon and Herdr server and cleans exact resources. Not in `run-all.sh`. |
 | `hrpc.py` | One-shot raw **herdr** socket RPC (honours `HERDR_SOCKET_PATH`) for structural asserts (`tab.list`/`pane.list`/`pane.layout`). |
 | `12-cwd-boards.sh` | Scoped board identity/isolation plus real TUI title/picker. |
 | `13-jump-to-pane.sh` | Same-session pane focus through a real plugin overlay. |

--- a/e2e/real-claude-haiku-smoke.sh
+++ b/e2e/real-claude-haiku-smoke.sh
@@ -12,7 +12,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd -P)"
 RUN_ID="$$"
 SESSION="hb-claude-$RUN_ID"
 EVIDENCE="/tmp/herdr-board-real-claude-haiku-evidence-$RUN_ID"
-STATE="/tmp/hb-claude-$RUN_ID.env"
 TMP=""
 WORKSPACE_DIR=""
 STAGED_CLAUDE_DIR=""
@@ -27,6 +26,7 @@ CARGO_BIN=""
 REAL_CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 REAL_CREDENTIALS=""
 REAL_SETTINGS=""
+REAL_REMOTE_SETTINGS=""
 REAL_HOOK=""
 REAL_HASHES_BEFORE=""
 BASE_STATUS=""
@@ -102,7 +102,7 @@ PY
 }
 
 hash_real_files() {
-  python3 - "$REAL_CREDENTIALS" "$REAL_SETTINGS" "$REAL_HOOK" <<'PY'
+  python3 - "$REAL_CREDENTIALS" "$REAL_SETTINGS" "$REAL_REMOTE_SETTINGS" "$REAL_HOOK" <<'PY'
 import hashlib, json, pathlib, sys
 out = {}
 for raw in sys.argv[1:]:
@@ -211,7 +211,7 @@ cleanup() {
   fi
 
   [ -z "$TMP" ] || rm -rf -- "$TMP"
-  rm -f -- "$STATE"
+  [ -z "${STATE:-}" ] || rm -f -- "$STATE"
 
   local sessions_json=""
   if ! sessions_json="$("$HERDR_BIN" session list --json 2>/dev/null)"; then
@@ -224,7 +224,7 @@ cleanup() {
   fi
   if [ -n "$TMP" ] && [ -e "$TMP" ]; then cleanup_error+="temp_remains;"; fi
   if [ -n "${SOCK:-}" ] && [ -e "${SOCK:-}" ]; then cleanup_error+="socket_remains;"; fi
-  [ ! -e "$STATE" ] || cleanup_error+="state_remains;"
+  [ -z "${STATE:-}" ] || [ ! -e "$STATE" ] || cleanup_error+="state_remains;"
 
   if [ -n "$BASE_STATUS" ] || [ -d "$ROOT/.git" ]; then
     if ! final_status="$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
@@ -237,7 +237,8 @@ cleanup() {
     cleanup_error+="repo_status_baseline_missing;"
   fi
   if [ -n "$REAL_HASHES_BEFORE" ] && [ -n "$REAL_CREDENTIALS" ] \
-      && [ -f "$REAL_CREDENTIALS" ] && [ -f "$REAL_SETTINGS" ] && [ -f "$REAL_HOOK" ]; then
+      && [ -f "$REAL_CREDENTIALS" ] && [ -f "$REAL_SETTINGS" ] \
+      && [ -f "$REAL_REMOTE_SETTINGS" ] && [ -f "$REAL_HOOK" ]; then
     hashes_after="$(hash_real_files 2>/dev/null)"
     printf '%s\n' "$hashes_after" | jq . >"$EVIDENCE/real-claude-hashes-after.json" 2>/dev/null
     if [ "$hashes_after" != "$REAL_HASHES_BEFORE" ]; then cleanup_error+="real_claude_files_changed;"; fi
@@ -317,6 +318,7 @@ if "$HERDR_BIN" session list --json | jq -e --arg session "$SESSION" \
 fi
 
 TMP="$(mktemp -d /tmp/hb-claude.XXXXXX)"
+STATE="$TMP/state.env"
 WORKSPACE_DIR="$TMP/workspace"
 STAGED_CLAUDE_DIR="$TMP/claude"
 DB="$TMP/board.db"
@@ -330,92 +332,24 @@ write_state
 
 REAL_CREDENTIALS="$REAL_CLAUDE_DIR/.credentials.json"
 REAL_SETTINGS="$REAL_CLAUDE_DIR/settings.json"
+REAL_REMOTE_SETTINGS="$REAL_CLAUDE_DIR/remote-settings.json"
 [ -f "$REAL_CREDENTIALS" ] || fail "missing real Claude credentials: $REAL_CREDENTIALS"
 [ -f "$REAL_SETTINGS" ] || fail "missing real Claude settings: $REAL_SETTINGS"
+[ -f "$REAL_REMOTE_SETTINGS" ] || fail "missing real Claude remote settings: $REAL_REMOTE_SETTINGS"
 
-# Retain only the installed Herdr SessionStart command and the user's explicit
-# dangerous-mode acknowledgement. The hook command is preserved byte-for-byte;
-# its script token must already be an absolute path.
-python3 - "$REAL_SETTINGS" "$STAGED_CLAUDE_DIR/settings.json" "$TMP/hook-path" <<'PY'
-import json, os, pathlib, shlex, sys
-src_path, out_path, hook_path_file = sys.argv[1:]
-with open(src_path, encoding="utf-8") as stream:
-    src = json.load(stream)
-if src.get("skipDangerousModePermissionPrompt") is not True:
-    raise SystemExit("real settings must acknowledge dangerous permission mode")
-session_start = src.get("hooks", {}).get("SessionStart")
-if not isinstance(session_start, list):
-    raise SystemExit("real settings have no SessionStart hook list")
-kept_groups = []
-script_paths = []
-for group in session_start:
-    if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
-        continue
-    kept_hooks = []
-    for hook in group["hooks"]:
-        if not isinstance(hook, dict) or hook.get("type") != "command":
-            continue
-        command = hook.get("command")
-        if not isinstance(command, str):
-            continue
-        try:
-            words = shlex.split(command)
-        except ValueError:
-            continue
-        matches = [word for word in words if word.endswith("/herdr-agent-state.sh")]
-        if not matches:
-            continue
-        if len(matches) != 1 or not os.path.isabs(matches[0]):
-            raise SystemExit("Herdr SessionStart hook path must be exactly one absolute script path")
-        kept_hooks.append(hook)
-        script_paths.append(matches[0])
-    if kept_hooks:
-        clean_group = {key: value for key, value in group.items() if key != "hooks"}
-        clean_group["hooks"] = kept_hooks
-        kept_groups.append(clean_group)
-if len(script_paths) != 1:
-    raise SystemExit(f"expected exactly one Herdr SessionStart command, found {len(script_paths)}")
-script = pathlib.Path(script_paths[0])
-if not script.is_file():
-    raise SystemExit(f"Herdr hook is not a file: {script}")
-out = {
-    "hooks": {"SessionStart": kept_groups},
-    "skipDangerousModePermissionPrompt": True,
-}
-with open(out_path, "w", encoding="utf-8") as stream:
-    json.dump(out, stream, indent=2)
-    stream.write("\n")
-os.chmod(out_path, 0o600)
-with open(hook_path_file, "w", encoding="utf-8") as stream:
-    stream.write(str(script))
-    stream.write("\n")
-os.chmod(hook_path_file, 0o600)
-PY
-REAL_HOOK="$(<"$TMP/hook-path")"
+# Stage only completed onboarding, the exact disposable workspace trust, the
+# dark startup theme, the installed Herdr hook, and already-approved remote settings.
+STAGED_HOOK_INFO="$(python3 "$ROOT/scripts/stage_claude_config.py" \
+  --source-config-dir "$REAL_CLAUDE_DIR" \
+  --workspace-dir "$WORKSPACE_DIR" \
+  --staged-config-dir "$STAGED_CLAUDE_DIR")"
+REAL_HOOK="$(printf '%s' "$STAGED_HOOK_INFO" | jq -er '.hook_path')"
 [ -f "$REAL_HOOK" ] || fail "configured Herdr hook is missing: $REAL_HOOK"
 
 BASE_STATUS="$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all)"
 printf '%s\n' "$BASE_STATUS" >"$EVIDENCE/git-status-before.txt"
 REAL_HASHES_BEFORE="$(hash_real_files)"
 printf '%s\n' "$REAL_HASHES_BEFORE" | jq . >"$EVIDENCE/real-claude-hashes-before.json"
-
-cp -- "$REAL_CREDENTIALS" "$STAGED_CLAUDE_DIR/.credentials.json"
-chmod 600 "$STAGED_CLAUDE_DIR/.credentials.json" "$STAGED_CLAUDE_DIR/settings.json"
-python3 - "$STAGED_CLAUDE_DIR" <<'PY'
-import os, pathlib, stat, sys
-root = pathlib.Path(sys.argv[1])
-for name in (".credentials.json", "settings.json"):
-    path = root / name
-    assert path.is_file(), path
-    assert stat.S_IMODE(path.stat().st_mode) == 0o600, (path, oct(stat.S_IMODE(path.stat().st_mode)))
-PY
-jq -e '
-  (keys | sort) == ["hooks", "skipDangerousModePermissionPrompt"] and
-  .skipDangerousModePermissionPrompt == true and
-  (.hooks | keys) == ["SessionStart"] and
-  ([.hooks.SessionStart[].hooks[]] | length) == 1
-' "$STAGED_CLAUDE_DIR/settings.json" >/dev/null \
-  || fail "staged Claude settings are not minimal"
 
 if ! CLAUDE_CONFIG_DIR="$STAGED_CLAUDE_DIR" \
     "$CLAUDE_BIN" auth status --json >"$TMP/claude-auth-status.json" 2>"$TMP/claude-auth-status.err"; then

--- a/scripts/stage_claude_config.py
+++ b/scripts/stage_claude_config.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Stage the minimal Claude state needed by the real-provider smoke test."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+
+
+class StageError(Exception):
+    pass
+
+
+def regular_file(path: Path, label: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as exc:
+        raise StageError(f"missing {label}: {path}") from exc
+    if not stat.S_ISREG(mode):
+        raise StageError(f"{label} is not a regular file: {path}")
+
+
+def validate_herdr_hook(path: Path, source: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except OSError as exc:
+        raise StageError(f"missing Herdr hook: {path}") from exc
+    if not stat.S_ISREG(mode):
+        raise StageError(f"Herdr hook is not a non-symlink regular file: {path}")
+    try:
+        canonical = path.resolve(strict=True)
+    except OSError as exc:
+        raise StageError(f"could not canonicalize Herdr hook: {path}") from exc
+    expected_parent = source / "hooks"
+    if canonical.parent != expected_parent:
+        raise StageError(
+            f"Herdr hook must be under the source hooks directory: {path}"
+        )
+
+
+def write_private(path: Path, data: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError as exc:
+        raise StageError(f"could not create staged file: {path}") from exc
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+        os.chmod(path, 0o600)
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def stage(source_dir: Path, workspace_dir: Path, staged_dir: Path) -> Path:
+    if staged_dir.is_symlink():
+        raise StageError(f"staged config directory must not be a symlink: {staged_dir}")
+    try:
+        source = source_dir.resolve(strict=True)
+        workspace = workspace_dir.resolve(strict=True)
+        staged = staged_dir.resolve(strict=True)
+    except OSError as exc:
+        raise StageError(f"could not canonicalize configuration paths: {exc}") from exc
+    if not source.is_dir():
+        raise StageError(f"source config directory is not a directory: {source}")
+    if not workspace.is_dir():
+        raise StageError(f"workspace directory is not a directory: {workspace}")
+    if not staged.is_dir():
+        raise StageError(f"staged config directory is not a directory: {staged}")
+    try:
+        if any(staged.iterdir()):
+            raise StageError(f"staged config directory is not empty: {staged}")
+        os.chmod(staged, 0o700)
+    except OSError as exc:
+        raise StageError(f"could not inspect staged config directory: {staged}") from exc
+
+    credentials_path = source / ".credentials.json"
+    remote_settings_path = source / "remote-settings.json"
+    settings_path = source / "settings.json"
+    for path, label in (
+        (credentials_path, "Claude credentials"),
+        (remote_settings_path, "approved remote settings"),
+        (settings_path, "Claude settings"),
+    ):
+        regular_file(path, label)
+
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise StageError(f"Claude settings are not valid UTF-8 JSON: {settings_path}") from exc
+    if not isinstance(settings, dict):
+        raise StageError("Claude settings root must be an object")
+    if settings.get("skipDangerousModePermissionPrompt") is not True:
+        raise StageError("Claude settings must acknowledge dangerous permission mode")
+
+    hooks = settings.get("hooks")
+    session_start = hooks.get("SessionStart") if isinstance(hooks, dict) else None
+    if not isinstance(session_start, list):
+        raise StageError("Claude settings have no SessionStart hook list")
+
+    matches: list[tuple[dict[str, object], object]] = []
+    for group in session_start:
+        if not isinstance(group, dict) or not isinstance(group.get("hooks"), list):
+            continue
+        for hook in group["hooks"]:
+            if not isinstance(hook, dict) or hook.get("type") != "command":
+                continue
+            command = hook.get("command")
+            if not isinstance(command, str):
+                continue
+            try:
+                words = shlex.split(command)
+            except ValueError as exc:
+                raise StageError("Claude SessionStart hook command is not valid shell syntax") from exc
+            script_words = [word for word in words if word.endswith("/herdr-agent-state.sh")]
+            if not script_words:
+                continue
+            if len(script_words) != 1 or not os.path.isabs(script_words[0]):
+                raise StageError(
+                    "Herdr SessionStart hook path must be exactly one absolute script path"
+                )
+            script = Path(script_words[0])
+            validate_herdr_hook(script, source)
+            matches.append((hook, group))
+
+    if len(matches) != 1:
+        raise StageError(
+            f"expected exactly one Herdr SessionStart command, found {len(matches)}"
+        )
+    hook, group = matches[0]
+    command = hook["command"]
+    assert isinstance(command, str)
+    script_words = [word for word in shlex.split(command) if word.endswith("/herdr-agent-state.sh")]
+    hook_path = Path(script_words[0])
+
+    clean_group: dict[str, object] = {"hooks": [{"type": "command", "command": command}]}
+    if isinstance(group.get("matcher"), str):
+        clean_group = {"matcher": group["matcher"], **clean_group}
+    clean_settings = {
+        "theme": "dark",
+        "skipDangerousModePermissionPrompt": True,
+        "hooks": {"SessionStart": [clean_group]},
+    }
+    files = {
+        ".credentials.json": credentials_path.read_bytes(),
+        "remote-settings.json": remote_settings_path.read_bytes(),
+        "settings.json": (json.dumps(clean_settings, indent=2) + "\n").encode("utf-8"),
+        ".claude.json": (
+            json.dumps(
+                {
+                    "hasCompletedOnboarding": True,
+                    "projects": {
+                        str(workspace): {
+                            "hasTrustDialogAccepted": True,
+                            "hasClaudeMdExternalIncludesApproved": False,
+                        }
+                    },
+                },
+                indent=2,
+            )
+            + "\n"
+        ).encode("utf-8"),
+    }
+    created: list[Path] = []
+    try:
+        for name, data in files.items():
+            path = staged / name
+            write_private(path, data)
+            created.append(path)
+        for path in staged.iterdir():
+            if not path.is_file() or path.is_symlink():
+                raise StageError(f"unexpected staged entry: {path}")
+            os.chmod(path, 0o600)
+    except (OSError, StageError) as exc:
+        for path in created:
+            path.unlink(missing_ok=True)
+        if isinstance(exc, OSError):
+            raise StageError(f"could not finish staged Claude config: {exc}") from exc
+        raise
+    return hook_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-config-dir", required=True, type=Path)
+    parser.add_argument("--workspace-dir", required=True, type=Path)
+    parser.add_argument("--staged-config-dir", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        hook_path = stage(args.source_config_dir, args.workspace_dir, args.staged_config_dir)
+    except (StageError, OSError) as exc:
+        print(f"stage_claude_config: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"hook_path": str(hook_path)}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_stage_claude_config.py
+++ b/scripts/tests/test_stage_claude_config.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+import json
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "scripts" / "stage_claude_config.py"
+REAL_CLAUDE_SMOKE = REPO_ROOT / "e2e" / "real-claude-haiku-smoke.sh"
+
+
+class StageClaudeConfigTests(unittest.TestCase):
+    """Provider-free contract tests for the real-Claude config staging boundary."""
+
+    def _fixture(self, root: Path) -> tuple[Path, Path, Path, bytes, bytes, str]:
+        source = root / "real-claude"
+        workspace = root / "disposable-workspace"
+        staged = root / "staged-claude"
+        source.mkdir(mode=0o700)
+        workspace.mkdir(mode=0o700)
+        staged.mkdir(mode=0o700)
+
+        credentials = b'{"oauthAccount": {"emailAddress": "fake@example.test"}}\n'
+        remote_settings = b'{"approved": ["fake-remote-setting"], "version": 7}\n'
+        (source / ".credentials.json").write_bytes(credentials)
+        (source / "remote-settings.json").write_bytes(remote_settings)
+        # Deliberately make the source modes too permissive: staging must set
+        # the destination mode rather than inheriting the source mode.
+        (source / ".credentials.json").chmod(0o644)
+        (source / "remote-settings.json").chmod(0o644)
+
+        hook = source / "hooks" / "herdr-agent-state.sh"
+        hook.parent.mkdir()
+        hook.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        hook.chmod(0o755)
+        herdr_hook = {
+            "type": "command",
+            "command": str(hook),
+        }
+        unrelated_hook = {"type": "command", "command": "/tmp/not-herdr.sh"}
+        settings = {
+            "theme": "light",
+            "skipDangerousModePermissionPrompt": True,
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "startup",
+                        "hooks": [herdr_hook, unrelated_hook],
+                    }
+                ]
+            },
+            "permissions": {"allow": ["Bash(*)"]},
+            "env": {"SHOULD_NOT_BE_STAGED": "yes"},
+            "someUnrelatedSetting": {"nested": True},
+        }
+        (source / "settings.json").write_text(
+            json.dumps(settings) + "\n", encoding="utf-8"
+        )
+        # A source global state file must not be copied or merged into the
+        # disposable staged config.
+        (source / ".claude.json").write_text(
+            json.dumps({"projects": {"/unrelated/source/path": {"trusted": True}}}),
+            encoding="utf-8",
+        )
+        return source, workspace, staged, credentials, remote_settings, str(hook)
+
+    def _run_helper(
+        self, source: Path, workspace: Path, staged: Path
+    ) -> subprocess.CompletedProcess[str]:
+        # This is the deliberately provider-free CLI contract for the helper.
+        return subprocess.run(
+            [
+                sys.executable,
+                str(HELPER),
+                "--source-config-dir",
+                str(source),
+                "--workspace-dir",
+                str(workspace),
+                "--staged-config-dir",
+                str(staged),
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def _assert_mode(self, path: Path, mode: int = 0o600) -> None:
+        self.assertEqual(stat.S_IMODE(path.stat().st_mode), mode, path)
+
+    def test_stages_minimal_config_and_exact_workspace_trust(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="stage-claude-test-") as tmp:
+            source, workspace, staged, credentials, remote_settings, hook = self._fixture(
+                Path(tmp)
+            )
+            # Exercise canonicalization rather than handing the helper an
+            # already-normalized path.
+            workspace_alias = workspace.parent / ".." / workspace.parent.name / workspace.name
+            result = self._run_helper(source, workspace_alias, staged)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            self.assertEqual((staged / ".credentials.json").read_bytes(), credentials)
+            self.assertEqual(
+                (staged / "remote-settings.json").read_bytes(), remote_settings
+            )
+            self._assert_mode(staged / ".credentials.json")
+            self._assert_mode(staged / "remote-settings.json")
+
+            settings = json.loads((staged / "settings.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                set(settings), {"hooks", "skipDangerousModePermissionPrompt", "theme"}
+            )
+            self.assertTrue(settings["skipDangerousModePermissionPrompt"])
+            self.assertEqual(settings["theme"], "dark")
+            session_start = settings["hooks"]["SessionStart"]
+            self.assertEqual(
+                [hook_entry for group in session_start for hook_entry in group["hooks"]],
+                [{"type": "command", "command": hook}],
+            )
+            self.assertEqual(len(session_start), 1)
+            self._assert_mode(staged / "settings.json")
+
+            claude = json.loads((staged / ".claude.json").read_text(encoding="utf-8"))
+            self.assertEqual(
+                claude,
+                {
+                    "hasCompletedOnboarding": True,
+                    "projects": {
+                        str(workspace.resolve()): {
+                            "hasTrustDialogAccepted": True,
+                            "hasClaudeMdExternalIncludesApproved": False,
+                        }
+                    },
+                },
+            )
+            self._assert_mode(staged / ".claude.json")
+            self.assertEqual(
+                {path.name for path in staged.iterdir()},
+                {
+                    ".credentials.json",
+                    "remote-settings.json",
+                    "settings.json",
+                    ".claude.json",
+                },
+            )
+
+    def test_rejects_missing_or_unsafe_prerequisites(self) -> None:
+        cases = (
+            (
+                "credentials",
+                lambda source, workspace: (source / ".credentials.json").unlink(),
+            ),
+            (
+                "remote-settings",
+                lambda source, workspace: (source / "remote-settings.json").unlink(),
+            ),
+            ("settings", lambda source, workspace: (source / "settings.json").unlink()),
+            ("workspace", lambda source, workspace: workspace.rmdir()),
+        )
+        for label, mutate in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory(
+                prefix="stage-claude-test-"
+            ) as tmp:
+                source, workspace, staged, *_ = self._fixture(Path(tmp))
+                mutate(source, workspace)
+                result = self._run_helper(source, workspace, staged)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+
+        unsafe_settings = (
+            {"type": "command", "command": "hooks/herdr-agent-state.sh"},
+            {
+                "type": "command",
+                "command": str(Path("/tmp") / "herdr-agent-state.sh"),
+            },
+        )
+        for hook in unsafe_settings:
+            with self.subTest(hook=hook), tempfile.TemporaryDirectory(
+                prefix="stage-claude-test-"
+            ) as tmp:
+                source, workspace, staged, *_ = self._fixture(Path(tmp))
+                settings = json.loads(
+                    (source / "settings.json").read_text(encoding="utf-8")
+                )
+                settings["hooks"]["SessionStart"][0]["hooks"] = [hook]
+                (source / "settings.json").write_text(
+                    json.dumps(settings), encoding="utf-8"
+                )
+                result = self._run_helper(source, workspace, staged)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_rejects_existing_out_of_tree_or_symlinked_herdr_hooks(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="stage-claude-test-") as tmp:
+            root = Path(tmp)
+            source, workspace, staged, *_ = self._fixture(root)
+            outside = root / "outside" / "herdr-agent-state.sh"
+            outside.parent.mkdir()
+            outside.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            settings = json.loads((source / "settings.json").read_text(encoding="utf-8"))
+            settings["hooks"]["SessionStart"][0]["hooks"] = [
+                {"type": "command", "command": str(outside)}
+            ]
+            (source / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+            result = self._run_helper(source, workspace, staged)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+
+        with tempfile.TemporaryDirectory(prefix="stage-claude-test-") as tmp:
+            root = Path(tmp)
+            source, workspace, staged, *_ = self._fixture(root)
+            hook = source / "hooks" / "herdr-agent-state.sh"
+            hook.unlink()
+            outside = root / "outside" / "herdr-agent-state.sh"
+            outside.parent.mkdir()
+            outside.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            hook.symlink_to(outside)
+            result = self._run_helper(source, workspace, staged)
+            self.assertNotEqual(result.returncode, 0, result.stdout)
+
+    def test_accepts_installed_hook_with_shell_arguments(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="stage-claude-test-") as tmp:
+            source, workspace, staged, *_ = self._fixture(Path(tmp))
+            hook = source / "hooks" / "herdr-agent-state.sh"
+            settings = json.loads((source / "settings.json").read_text(encoding="utf-8"))
+            settings["hooks"]["SessionStart"][0]["hooks"] = [
+                {"type": "command", "command": f"bash '{hook}' session"}
+            ]
+            (source / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+            result = self._run_helper(source, workspace, staged)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            staged_settings = json.loads(
+                (staged / "settings.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                staged_settings["hooks"]["SessionStart"][0]["hooks"][0]["command"],
+                f"bash '{hook}' session",
+            )
+
+    def test_smoke_state_file_is_private_temp_child(self) -> None:
+        source = REAL_CLAUDE_SMOKE.read_text(encoding="utf-8")
+        self.assertNotRegex(source, r'(?m)^STATE="/tmp/')
+        tmp_assignment = source.index('TMP="$(mktemp -d')
+        state_assignment = source.index('STATE="$TMP/')
+        first_write_state_use = source.index("\nwrite_state\n", source.index("write_state()"))
+        self.assertGreater(state_assignment, tmp_assignment)
+        self.assertLess(state_assignment, first_write_state_use)
+        self.assertRegex(source, r'(?m)^STATE="\$TMP/[^"/]+"$')
+
+    def test_smoke_uses_stager_and_hashes_remote_settings_before_and_after(self) -> None:
+        source = REAL_CLAUDE_SMOKE.read_text(encoding="utf-8")
+        self.assertRegex(
+            source,
+            r"python3\s+[^\n]*scripts/stage_claude_config\.py",
+            "smoke must invoke the provider-free staging helper",
+        )
+
+        hash_start = source.index("hash_real_files()")
+        hash_end = source.index("\n}", hash_start)
+        hash_block = source[hash_start:hash_end]
+        self.assertIn("REAL_REMOTE_SETTINGS", hash_block)
+        self.assertRegex(
+            source,
+            r"REAL_REMOTE_SETTINGS=.{0,120}remote-settings\.json",
+            "smoke must identify the real remote-settings file",
+        )
+        self.assertRegex(
+            source,
+            r'REAL_HASHES_BEFORE="\$\(hash_real_files\)"',
+            "the real remote-settings file must be included in the before hash",
+        )
+        self.assertRegex(
+            source,
+            r'hashes_after="\$\(hash_real_files',
+            "the real remote-settings file must be included in the after hash",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## Summary

 Fix the opt-in real-Claude Haiku smoke test, which could remain stuck because `agent.prompt` was sent while Claude Code was showing first-run dialogs.

 ## Root cause

 The temporary `CLAUDE_CONFIG_DIR` included credentials and settings but omitted the minimal state required to bypass:

 - managed-settings approval;
 - theme selection;
 - workspace trust.

 Herdr correctly started Claude and reported it as ready, but the board prompt was consumed by those startup dialogs instead of reaching the Claude chat.

 ## Changes

 - Add a fail-closed helper to stage minimal Claude configuration.
 - Preserve only completed onboarding, theme, exact disposable-workspace trust, approved remote settings, credentials, and the validated Herdr hook.
 - Keep staged sensitive files private with mode `0600`.
 - Harden temporary state-file and hook-path handling.
 - Add provider-free regression tests.
 - Update testing documentation and `CHANGELOG.md`.

 ## Validation

 - 44 Python safety/configuration tests passed.
 - `cargo fmt --all --check` passed.
 - `cargo clippy --all-targets -- -D warnings` passed.
 - `cargo test --workspace --all-features` passed.
 - All 17 provider-free live E2E scenarios passed.
 - Real Claude Haiku/low smoke passed with exactly one run and verified cleanup.