### PR TITLE
docs: pin Herdr plugin installs to a tag and condense the changelog convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Full layering, test placement, harness details, and how to add tests live in
 - Auto-start creates one child process-group leader (no double-fork/`setsid`); stop is an exact
   socket/identity-gated operation. The active-run summary drives TUI timers, and the always-on
   per-session supervisor reconnects and reconciles conservatively.
-- Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change.
+- Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change. Keep each `CHANGELOG.md` entry to one line prefixed by its PR number (e.g. `- #31 Pin Herdr plugin installs to a released tag.`) so the changelog links the PR rather than reproducing it — long rationale lives in the PR body. Write the one-line description first, then fill in the PR number once the PR is open.
 - Release/version changes follow [`docs/releasing.md`](docs/releasing.md). Agents must never create,
   push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its PR,
   and the **Release** workflow creates the tag only after `main` CI is green. No tag ruleset currently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Full layering, test placement, harness details, and how to add tests live in
 - Auto-start creates one child process-group leader (no double-fork/`setsid`); stop is an exact
   socket/identity-gated operation. The active-run summary drives TUI timers, and the always-on
   per-session supervisor reconnects and reconciles conservatively.
-- Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change. Keep each `CHANGELOG.md` entry to one line prefixed by its PR number (e.g. `- #31 Pin Herdr plugin installs to a released tag.`) so the changelog links the PR rather than reproducing it — long rationale lives in the PR body. Write the one-line description first, then fill in the PR number once the PR is open.
+- Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change. Keep each `CHANGELOG.md` entry to one line prefixed by a clickable link to its PR, e.g. `- [#31](https://github.com/nelsonPires5/herdr-board/pull/31) Pin Herdr plugin installs to a released tag.` (GitHub does not auto-link bare `#NN` inside rendered markdown files, so use the full link) so the changelog links the PR rather than reproducing it — long rationale lives in the PR body. Write the one-line description first, then fill in the PR link once the PR is open.
 - Release/version changes follow [`docs/releasing.md`](docs/releasing.md). Agents must never create,
   push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its PR,
   and the **Release** workflow creates the tag only after `main` CI is green. No tag ruleset currently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-- #31 Pin Herdr plugin installs to the latest released tag (`--ref v0.8.0`) and require one-line, PR-linked `CHANGELOG.md` entries.
+- [#31](https://github.com/nelsonPires5/herdr-board/pull/31) Pin Herdr plugin installs to the latest released tag (`--ref v0.8.0`) and require one-line, PR-linked `CHANGELOG.md` entries.
 
 ## [0.8.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- #31 Pin Herdr plugin installs to the latest released tag (`--ref v0.8.0`) and require one-line, PR-linked `CHANGELOG.md` entries.
+
 ## [0.8.0] - 2026-07-23
 
 - Internal Rust refactor organizes production modules and tests by responsibility: public API behavior

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The daemon checks the selected Herdr socket before workspace discovery and pane 
 any Herdr version other than 0.7.5 and any protocol other than 17; protocol 16 is not supported.
 
 ```bash
-herdr plugin install nelsonPires5/herdr-board
+herdr plugin install nelsonPires5/herdr-board --ref v0.8.0
 ```
 
 Precise live lifecycle status also requires Herdr's integration for the harness you dispatch (for
@@ -76,7 +76,7 @@ checks out the source, builds the release binary, registers the plugin, and copi
 noninteractive install is available:
 
 ```bash
-herdr plugin install nelsonPires5/herdr-board --yes
+herdr plugin install nelsonPires5/herdr-board --ref v0.8.0 --yes
 ```
 
 Set `HERDR_BOARD_CLI_INSTALL_DIR` to an absolute user bin directory before installing to override
@@ -330,7 +330,7 @@ Re-run the install command to update — Herdr has no separate update command, s
 existing plugin:
 
 ```bash
-herdr plugin install nelsonPires5/herdr-board --yes
+herdr plugin install nelsonPires5/herdr-board --ref v0.8.0 --yes
 ```
 
 The build step requests a graceful stop (`board daemon --stop`) before recompiling, so the new


### PR DESCRIPTION
Two small documentation changes.

## What

- **README** — pin all three `herdr plugin install` commands to the latest released tag (`--ref v0.8.0`), so installs are reproducible and always resolve a specific tag rather than whatever `HEAD` of the default branch happens to be.
- **AGENTS.md** — update the changelog "Definition of done" guidance: keep each `CHANGELOG.md` entry to **one line prefixed by its PR number** (e.g. `- #31 …`) so the changelog links the PR instead of reproducing it. Long rationale belongs in the PR body. The changelog has been growing large; this keeps it an index, not a duplicate of the PRs.

## Why

- Pinning to a tag is the recommended, reproducible install path.
- A PR-linked one-liner keeps the changelog scannable; the PR holds the detail.

## Notes

- Tag is hardcoded to `v0.8.0`; per discussion this is accepted as a simple change and is **not** wired into the release verifier, so it may lag between releases until manually bumped.

## Checklist

- [x] Docs only — no code/test/build changes.
- [ ] Changelog entry added (one line, PR number) — added in a follow-up commit once this PR number is known.