### PR TITLE
skills: separate board usage from visual validation

### DIFF
--- a/.agents/skills/herdr-board-visual-validation/SKILL.md
+++ b/.agents/skills/herdr-board-visual-validation/SKILL.md
@@ -11,11 +11,13 @@ Read [`references/playbook.md`](references/playbook.md) before executing live He
 
 ## Non-negotiable safety
 
-1. Read repository `AGENTS.md`, `docs/herdr.md`, and `docs/testing.md` completely.
+1. Read repository `AGENTS.md`, `skill/SKILL.md`, `docs/herdr.md`, and `docs/testing.md` completely. Treat `skill/SKILL.md` as the source of truth for operating the board; do not duplicate its general CLI/TUI reference here.
 2. Verify the installed Herdr with `herdr --version`, `herdr status`, `herdr api schema --json`, and relevant `--help`; never guess command shapes.
 3. Mutate only an ephemeral named Herdr session and workspaces created inside it. Prefix every mutation log with `HERDR MUTATION:`.
 4. Isolate board state under a short `/tmp` directory via `BOARD_DB`, `BOARD_SOCKET`, and `HERDR_BOARD_CONFIG`.
-5. Prototype in a detached temporary worktree. Keep the main checkout unchanged until the user approves the comparison.
+5. Choose the validation mode before changing files:
+   - **Prototype mode:** prototype in a detached temporary worktree under `/tmp`; keep the implementation checkout unchanged until approval.
+   - **Execution-validation mode:** validate an existing implementation worktree; do not create a second implementation worktree or copy production changes into another branch.
 6. Never dispatch a paid/real agent for visual fixtures. Use `FakeBoardClient`, the fake harness, CLI-created manual cards, or direct writes only to the isolated fixture database.
 7. Capture every PID/resource needed for cleanup. Never use broad `pkill` patterns.
 
@@ -30,12 +32,23 @@ Read [`references/playbook.md`](references/playbook.md) before executing live He
 - Capture baseline states at the same terminal dimensions planned for the prototype.
 - Record Herdr version/protocol, terminal dimensions, theme, and fixture data.
 
-### 2. Create an isolated prototype
+### 2. Prepare the isolated validation source
+
+In **prototype mode**:
 
 - Create a detached worktree under `/tmp` from the current commit.
-- Build into a separate `CARGO_TARGET_DIR`; make the worktree manifest resolve that binary without replacing the main build.
+- Make only disposable prototype changes there; do not create a prototype under the repository's `worktree/` directory.
+
+In **execution-validation mode**:
+
+- Use the existing execution worktree as the source and implementation target.
+- Do not create another Git worktree for the implementation. Temporary build, board, Herdr, and capture artifacts still belong under `/tmp`.
+
+In either mode:
+
+- Build into a separate `CARGO_TARGET_DIR`; make the selected source manifest resolve that binary without replacing the main build.
 - Start an ephemeral named Herdr server with isolated board env.
-- Link the worktree plugin only inside that session.
+- Link the selected source plugin only inside that session.
 - Create a disposable workspace and open the plugin through its real action/placement.
 - Attach the disposable session in a temporary WezTerm tab after unsetting nested-Herdr environment variables.
 
@@ -71,7 +84,8 @@ Do not infer contrast from text snapshots alone; inspect attributed ANSI or a re
 
 ### 5. Iterate without promoting
 
-- Apply feedback only in the prototype worktree.
+- In prototype mode, apply feedback only in the disposable prototype worktree.
+- In execution-validation mode, apply fixes directly to the existing execution worktree and repeat isolated validation; never create a second implementation worktree.
 - Add reducer/layout tests for behavior, not only screenshots.
 - Run focused tests and clippy after each interaction change.
 - Rebuild and restart the disposable plugin pane so screenshots use the new binary.
@@ -79,8 +93,10 @@ Do not infer contrast from text snapshots alone; inspect attributed ANSI or a re
 
 ### 6. Promote after explicit approval
 
-1. Add/apply behavior tests to the main checkout first and run them red.
-2. Port the approved source changes.
+Promotion applies only to **prototype mode**. The target is the designated implementation checkout or execution worktree, not necessarily the main checkout. Execution-validation mode already validates its implementation target and must not create or port into another worktree.
+
+1. Add/apply behavior tests to the implementation target first and run them red.
+2. Port the approved source changes from the disposable prototype.
 3. Update/add deterministic snapshots, including wide/narrow and overflow states.
 4. Update README, design docs, and `CHANGELOG.md` in the same change.
 5. Run all repository gates and live e2e.
@@ -104,8 +120,8 @@ Use `~/.cargo/bin/cargo` or prepend it to `PATH` if non-login shells cannot find
 - Stop the isolated board daemon by its captured PID/socket owner.
 - Stop and delete the named Herdr session.
 - Verify no `hb-visual-*`, `hb-prototype-*`, or `hb-e2e-*` session remains.
-- Remove the linked worktree with `git worktree remove --force` only after its approved diff is promoted or intentionally discarded.
-- Recheck main `git status`.
+- In prototype mode, remove the disposable linked worktree with `git worktree remove --force` only after its approved diff is promoted or intentionally discarded. Never remove the user's execution worktree during validation cleanup.
+- Recheck the original checkout and implementation-target `git status`.
 
 ## Handoff/report format
 

--- a/.agents/skills/herdr-board-visual-validation/references/playbook.md
+++ b/.agents/skills/herdr-board-visual-validation/references/playbook.md
@@ -3,7 +3,7 @@
 ## Contents
 
 1. Preflight
-2. Isolated worktree and build
+2. Isolated validation source and build
 3. Disposable Herdr/board stack
 4. Temporary WezTerm client
 5. Fixtures and captures
@@ -39,9 +39,12 @@ herdr api snapshot | jq '.result.snapshot | {version,protocol,workspaces,tabs,la
 
 The snapshot command is read-only against the current session. Do not mutate that session.
 
-## 2. Isolated worktree and build
+## 2. Isolated validation source and build
+
+Choose one mode. Prototype mode creates a disposable detached worktree. Execution-validation mode reads changes from the user's existing execution worktree and mirrors them into a disposable non-Git plugin/build directory; fixes remain in the execution worktree, and no second implementation worktree is created.
 
 ```bash
+VALIDATION_MODE="${VALIDATION_MODE:-prototype}" # prototype | execution
 RUN_ID="$$"
 HERDR_BIN="$(command -v herdr)"
 # Reuse the standard E2E identity/name helpers without starting its stack.
@@ -54,7 +57,19 @@ WT="/tmp/herdr-board-visual-$RUN_ID"
 TARGET="/tmp/herdr-board-target-$RUN_ID"
 STATE="/tmp/hb-visual-$RUN_ID.env"
 
-git worktree add --detach "$WT" HEAD
+case "$VALIDATION_MODE" in
+  prototype)
+    git worktree add --detach "$WT" HEAD
+    ;;
+  execution)
+    : "${EXECUTION_WORKTREE:?set EXECUTION_WORKTREE to the existing implementation worktree}"
+    mkdir -p "$WT"
+    rsync -a --delete --exclude .git --exclude target \
+      "$EXECUTION_WORKTREE/" "$WT/"
+    ;;
+  *) echo "unknown VALIDATION_MODE: $VALIDATION_MODE" >&2; exit 2 ;;
+esac
+
 CARGO_TARGET_DIR="$TARGET" ~/.cargo/bin/cargo build \
   --manifest-path "$WT/Cargo.toml" --release -p board-cli
 ln -s "$TARGET" "$WT/target"
@@ -66,12 +81,14 @@ SESSION=$SESSION
 TMP=$TMP
 WT=$WT
 TARGET=$TARGET
+VALIDATION_MODE=$VALIDATION_MODE
+EXECUTION_WORKTREE=${EXECUTION_WORKTREE:-}
 EOF
 ```
 
-The symlink satisfies `herdr-plugin.toml`'s relative `./target/release/board` without overwriting the main checkout's binary.
+The symlink satisfies `herdr-plugin.toml`'s relative `./target/release/board` without overwriting the original or execution checkout's binary.
 
-For a baseline/proposal comparison, capture the baseline before editing this worktree. Then edit the same worktree and capture the proposal with identical fixture data and dimensions.
+For a baseline/proposal comparison, capture the baseline before editing. In prototype mode, edit the disposable worktree. In execution-validation mode, edit only `$EXECUTION_WORKTREE`, refresh the disposable mirror with the same `rsync` command, then rebuild and recapture with identical fixtures and dimensions.
 
 ## 3. Disposable Herdr/board stack
 
@@ -236,7 +253,7 @@ Review `.snap.new` before accepting with `INSTA_UPDATE=always`.
 
 ## 6. Rebuild/restart loop
 
-After prototype edits:
+After prototype edits, or after refreshing the execution-validation mirror from its implementation worktree:
 
 ```bash
 (cd "$WT" && ~/.cargo/bin/cargo fmt --all)
@@ -264,11 +281,13 @@ herdr --session "$SESSION" plugin action invoke open-board --plugin herdr-board
 
 ## 7. Promotion
 
-After explicit approval:
+After explicit approval in prototype mode:
 
-1. Save the worktree diff.
-2. Apply behavior tests to main first; run and record red.
-3. Apply source changes; run focused green tests.
+1. Save the disposable worktree diff.
+2. Apply behavior tests to the designated implementation checkout/worktree first; run and record red.
+3. Apply source changes there; run focused green tests.
+
+Execution-validation mode requires no promotion: its source changes already live in `$EXECUTION_WORKTREE`.
 4. Add layout/reducer tests plus narrow/wide/overflow snapshots.
 5. Update README, `docs/design.md`, and `CHANGELOG.md`.
 6. Run:
@@ -317,7 +336,11 @@ printf 'HERDR MUTATION: stop/delete disposable session %s\n' "$SESSION"
 "$HERDR_BIN" session stop "$SESSION"
 "$HERDR_BIN" session delete "$SESSION"
 
-git worktree remove --force "$WT"
+if [ "$VALIDATION_MODE" = prototype ]; then
+  git worktree remove --force "$WT"
+else
+  rm -rf "$WT"
+fi
 rm -rf "$TARGET" "$TMP"
 rm -f "$STATE"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- [#34](https://github.com/nelsonPires5/herdr-board/pull/34) Separate the operational board skill from isolated visual-development validation and avoid duplicate implementation worktrees.
 - [#33](https://github.com/nelsonPires5/herdr-board/pull/33) feat(tui): card detail word-wraps the description and each comment body at the panel border (popup and fullscreen) instead of truncating to one line; comments now scroll by wrapped row.
 
 - [#31](https://github.com/nelsonPires5/herdr-board/pull/31) Pin Herdr plugin installs to the latest released tag (`--ref v0.8.0`) and require one-line, PR-linked `CHANGELOG.md` entries.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -10,6 +10,8 @@ description: >-
 
 # herdr-board
 
+This is the operational skill for people and dispatched agents using herdr-board. It covers the TUI, CLI, cards, runs, and Herdr-backed spaces; it does not prescribe how to develop, prototype, test, or release herdr-board itself.
+
 herdr-board is a kanban board for AI coding agents. A **card** is a prompt (title +
 description) plus harness/model/effort, an optional harness-specific permission, and a target herdr space. New cards default to Pi; runs remain harness-neutral. **Columns**
 are pipeline stages; a column can be `manual` or `auto`. Each canonical Git root (or exact
@@ -40,6 +42,12 @@ board done --outcome ok --summary "feature X shipped, tests green"
 # stage goal not met:
 board done --outcome fail --summary "2 integration tests still failing; needs a schema change"
 ```
+
+## Using the TUI
+
+Run `board tui` or invoke the `open-board` Herdr plugin action. Use arrows or `h/j/k/l` to navigate, `n` to create a card, `N` to create a column, `m` to move a card, `Enter` for card detail, `e`/`E` to edit a card/column, `a` to archive or restore, `v` to change the archive filter, and `?` for the complete in-app reference. Moving a card into an automatic column dispatches its run into the workspace's `kanban` tab.
+
+Use the CLI below for scripted operations and for progress reporting from a dispatched run.
 
 ## CLI reference
 


### PR DESCRIPTION
## Summary
- keep the distributed board skill focused on CLI/TUI operation
- split visual validation into prototype and execution-validation modes
- prevent duplicate implementation worktrees while preserving isolated Herdr/WezTerm validation

## Validation
- `git diff --check`
- Rust tests not run: documentation and skill-only changes
