### PR TITLE
CLI: expose full board management and audited comment CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- Add canonical CLI parity plus schema-v13 comment CRUD, soft deletion, and immutable audit history.
 - [#40](https://github.com/nelsonPires5/herdr-board/pull/40) Reserve a durably owned shell anchor in each board-managed card tab; every stage/retry launches only from a split child, with safe anchor recovery and child-only cleanup.
 - [#39](https://github.com/nelsonPires5/herdr-board/pull/39) Per-card Herdr tabs use stable `card-<id>` labels, exact board-owned tab IDs, safe restart reconstruction, serialized first allocation, and closed-tab recreation; legacy `kanban` rows remain unchanged.
 - [#38](https://github.com/nelsonPires5/herdr-board/pull/38) docs(visual-validation): require ALWAYS-isolated board state — DB, socket, AND daemon — under a short `/tmp` dir (no exceptions for trivial or "quick peek" runs; `board tui` auto-starts its own isolated daemon) and open runnable prototypes in a visible wezterm tab for interactive validation, matching the Prototyping-column prompt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-- Add canonical CLI parity plus schema-v13 comment CRUD, soft deletion, and immutable audit history.
+- [#41](https://github.com/nelsonPires5/herdr-board/pull/41) Add canonical CLI parity plus schema-v13 comment CRUD, soft deletion, and immutable audit history.
 - [#40](https://github.com/nelsonPires5/herdr-board/pull/40) Reserve a durably owned shell anchor in each board-managed card tab; every stage/retry launches only from a split child, with safe anchor recovery and child-only cleanup.
 - [#39](https://github.com/nelsonPires5/herdr-board/pull/39) Per-card Herdr tabs use stable `card-<id>` labels, exact board-owned tab IDs, safe restart reconstruction, serialized first allocation, and closed-tab recreation; legacy `kanban` rows remain unchanged.
 - [#38](https://github.com/nelsonPires5/herdr-board/pull/38) docs(visual-validation): require ALWAYS-isolated board state — DB, socket, AND daemon — under a short `/tmp` dir (no exceptions for trivial or "quick peek" runs; `board tui` auto-starts its own isolated daemon) and open runnable prototypes in a visible wezterm tab for interactive validation, matching the Prototyping-column prompt.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ only `Todo`.
 
 Requires exactly **Herdr 0.7.5 (protocol 17)**, Git, and a Rust toolchain with `cargo`. Linux
 and macOS are supported. Ensure `~/.local/bin` is on your `PATH`. The board protocol is v1 and the
-current SQLite schema is v11; `schema.sql` defines fresh databases and the daemon applies tested
+current SQLite schema is v13; `schema.sql` defines fresh databases and the daemon applies tested
 upgrades through `board-core::db`.
 
 The daemon checks the selected Herdr socket before workspace discovery and pane launch. It rejects
@@ -102,7 +102,7 @@ regular, non-symlink `board` whose contents still match that marker.
 The same flow from the shell:
 
 ```bash
-board card new --title "Add retry to the uploader" \
+board card create --title "Add retry to the uploader" \
   -d "In src/upload.rs, retry failed PUTs 3x with backoff. Add a unit test." \
   --effort low \
   --space-kind new-workspace --space-ref uploader --space-cwd /path/to/repo
@@ -249,28 +249,134 @@ separate board stack.
 ## CLI reference
 
 <details>
-<summary><strong>Show all board commands</strong></summary>
+<summary><strong>Canonical commands, selectors, and JSON</strong></summary>
 
-```text
-board tui | daemon [--foreground] | status [--json]
-board card new --title T [-d D] [--column C] [--harness H] [--model M] [--effort E] \
-   [--permission P] [--session S] [--space-kind workspace|new-workspace] \
-   [--space-ref R] [--space-cwd DIR]      # space-cwd required for new-workspace
-board card show <ID> | card list [--column C] | card archive|restore <ID> | column list
-board comment [CARD_ID] <BODY>            # CARD_ID defaults to $BOARD_CARD_ID
-board done [CARD_ID] --outcome ok|fail [--summary S]
-board move <CARD_ID> <COLUMN> | cancel <CARD_ID> | retry <CARD_ID>
-board harness models [HARNESS] | efforts [HARNESS] --model M | permissions [HARNESS]
-board space list [--session S] | session list    # HARNESS defaults to "pi"
+`board` is one binary with a nested canonical taxonomy. Put the global selector before any command:
+
+```bash
+board --board <ID|PATH> card list --json
 ```
 
-Scope-sensitive CLI commands (`card new/list`, `column list`) use the current Git root, or the
-canonical CWD outside Git. `BOARD_SCOPE_PATH` overrides this for automation. Operations by card id
-remain independent of the caller's CWD; `move` resolves its destination in the card's own board.
+`--board` accepts a stable board id or canonical scope path. Without it, board-aware commands use the
+focused Git root (or canonical non-Git CWD; `BOARD_SCOPE_PATH` overrides both). Card-id operations
+(`show`, `edit`, `delete`, comments, and runs) infer the card's own board; `card create`, `card list`,
+`column list`, and board commands use the selected/current board.
 
-`--json` is accepted everywhere. In the TUI, `d` permanently deletes a card after confirmation;
-`D` deletes a column after asking where to move its cards, and refuses while a card is active.
-Archiving is reversible with `a`, `board card archive <ID>`, and `board card restore <ID>`.
+### Boards, templates, and cards
+
+```text
+board board list [--json]
+board board show [ID|PATH] [--json]
+board board open <PATH> [--json]
+board board rename [ID|PATH] <NAME> [--json]
+board template apply pipeline [--json]
+
+board card create --title T [-d DESC] [--column C] [--harness H] [--model M]
+  [--effort E] [--permission P] [--session S]
+  [--space-kind workspace|new-workspace] [--space-ref R] [--space-cwd DIR] [--json]
+board card edit <ID> [--title T] [-d DESC] [--clear-description]
+  [--harness H] [--model M|--clear-model] [--effort E|--clear-effort]
+  [--permission P|--clear-permission] [--session S|--clear-session]
+  [--space-ref R|--clear-space-ref] [--space-cwd DIR|--clear-space-cwd] [--json]
+board card show <ID> [--json]
+board card list [--column C] [--visibility active|all|archived] [--json]
+board card move <ID> <COLUMN> [--destination-board ID|PATH] [--json]
+board card archive|restore <ID> [--json]
+board card delete <ID> [--yes] [--json]
+```
+
+`card create` is the canonical spelling; `card new` remains an alias. A new card defaults to Pi and
+an omitted model/effort uses the harness default. `new-workspace` requires both `--space-ref` and
+`--space-cwd`; creating directly in an `auto` column dispatches a run. `card list` defaults to active
+cards; `all` includes archived cards and `archived` returns only archived cards. JSON list commands
+return arrays; `board show`/`open` return a snapshot `{board, columns, cards, active_runs}`; card
+show returns `{card, comments, runs}`. Card mutations return a card, except delete returns
+`{"deleted":true}`.
+
+Edits leave omitted fields unchanged. Use the explicit `--clear-*` flags to clear nullable values
+(`--clear-description` sets the description to an empty string). Harness cannot be cleared. Delete
+is permanent and removes history; it requires `--yes` when stdin is not a TTY, otherwise it prompts
+and cancels unless the answer is `y`/`yes`. Cards with an open run must be cancelled before edit of
+run settings, archive, or delete.
+
+### Comments and runs
+
+```text
+board card comment add <CARD_ID> <BODY> [--json]
+board card comment show <COMMENT_ID> [--json]
+board card comment edit <COMMENT_ID> <BODY> [--json]
+board card comment delete <COMMENT_ID> [--yes] [--json]
+board card comment history <COMMENT_ID> [--json]
+
+board card run done [CARD_ID] --outcome ok|fail [--summary S] [--json]
+board card run confirm [CARD_ID] [--summary S] [--json]
+board card run cancel <CARD_ID> [--json]
+board card run retry <CARD_ID> [--json]
+board card run focus <CARD_ID> [--origin-socket SOCKET] [--json]
+```
+
+Comment add returns the compact current comment (`id`, `card_id`, `author`, `body`,
+`created_at`); show/edit return the current record with those fields plus `deleted_at`; delete
+returns `{deleted:true}`; history is an array of immutable snapshots. Ordinary card detail hides soft-deleted comments. A comment created
+inside a durable run is owned by `agent:<BOARD_RUN_ID>`; with `BOARD_RUN_ID` set, that run may
+edit/delete only its own comment while the run is open. Human calls without it may edit/delete
+non-system comments. System comments and deleted comments are immutable. `card run confirm` is the
+`done --outcome ok` channel for awaiting review.
+Focus returns `{run_id, pane_id}` and requires the target run to belong to the current Herdr session;
+without `--origin-socket`, it uses `HERDR_SOCKET_PATH` or `HERDR_SOCK`.
+
+### Columns and discovery
+
+```text
+board column list [--json]
+board column create --name NAME [--prompt TEXT] [--trigger manual|auto]
+  [--on-success COLUMN] [--on-fail COLUMN] [--fresh-session|--reuse-session]
+  [--harness H] [--model M] [--effort E] [--permission P]
+  [--timeout MINUTES] [--position N] [--json]
+board column show <ID|NAME> [--json]
+board column edit <ID|NAME> [--name NAME] [--prompt TEXT|--clear-prompt]
+  [--trigger manual|auto] [--on-success COLUMN|--clear-on-success]
+  [--on-fail COLUMN|--clear-on-fail] [--fresh-session|--reuse-session]
+  [--harness H|--clear-harness] [--model M|--clear-model]
+  [--effort E|--clear-effort] [--permission P|--clear-permission]
+  [--timeout MINUTES|--clear-timeout] [--json]
+board column reorder <ID|NAME> <ZERO-BASED-POSITION> [--json]
+board column delete <ID|NAME> [--move-cards-to COLUMN] [--yes] [--json]
+board harness list|models|efforts|permissions [--json]
+board space list [--session S] [--json]
+board session list [--json]
+```
+
+Column list/reorder JSON is an ordered array; create/show/edit JSON is a column. Column transition
+references are names (case-insensitive) or ids. `--fresh-session` and `--reuse-session` are
+mutually exclusive. A column with cards requires `--move-cards-to`; any open card run blocks column
+deletion. `template apply pipeline` is atomic and only works on a board containing exactly its seed
+`Todo` column and no cards; it returns the resulting column array.
+
+### Daemon, version, skill, and compatibility aliases
+
+```text
+board daemon [--foreground] [--stop]
+board daemon status [--json]
+board version [--json]
+board skill
+```
+
+`daemon status` is the operational probe and returns `{version, db_path, herdr_connected, active_runs,
+queued_runs}`. `version` never starts boardd: it reports `{cli_version, daemon_version}`, where the
+daemon value is `null`/`unavailable` when boardd is offline. `skill` prints the exact checked-in
+`skill/SKILL.md` bytes, not a JSON envelope.
+
+The older top-level action forms remain supported: `board comment [CARD_ID] BODY` (card id defaults
+to `$BOARD_CARD_ID`), `board done`, `board move`, `board cancel`, and `board retry`. Only
+`board daemon status [--json]` is supported for daemon status. The nested forms above are canonical;
+`card new` and `--to-board` remain accepted aliases.
+
+Every command accepts `--json` where shown. Successful JSON is written to stdout. JSON errors are
+written to stderr with no stdout output and keep the stable envelope
+`{"error":{"code":N,"kind":"...","message":"...","details":...}}`; additive `kind` and
+`details` may be omitted. Codes are 1 bad request, 2 not found/CLI error, 3 invalid state, 4 Herdr
+unavailable, and 5 internal error.
 
 The pane title combines scope and filter, for example `Board [my-repo · ACTIVE]`. In card detail,
 `o` focuses the latest recorded run pane only when it belongs to the current Herdr session; errors
@@ -486,7 +592,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`AGENTS.md`](AGENTS.md) before con
 
 ## Status
 
-**v1 board protocol / schema v12.** Rust with Ratatui, Rusqlite, and Tokio. Pi is the default
+**v1 board protocol / schema v13.** Rust with Ratatui, Rusqlite, and Tokio. Pi is the default
 built-in harness and Claude Code remains explicitly selectable; config-defined harnesses are also
 supported. Execution happens in visible Herdr panes, and extension-owned state remains separate from
 Herdr's state. See [`docs/README.md`](docs/README.md) for version, source-ownership, and test-gate

--- a/crates/board-cli/src/args.rs
+++ b/crates/board-cli/src/args.rs
@@ -3,30 +3,45 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(name = "board", version, about = "herdr-board kanban for agents")]
 pub(crate) struct Cli {
+    /// Select a board by stable id or canonical scope path.
+    #[arg(long, global = true, value_name = "ID|PATH")]
+    pub(crate) board: Option<String>,
     #[command(subcommand)]
     pub(crate) cmd: Cmd,
 }
 
 #[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)] // clap arg enum; boxing hurts ergonomics
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Cmd {
     /// Open the kanban TUI (auto-starts the daemon).
     Tui,
-    /// Run the daemon in the foreground / background.
+    /// Run or inspect the daemon.
     Daemon {
         /// Log to stderr as well as the log file, and stay attached.
         #[arg(long)]
         foreground: bool,
-        /// Stop the running daemon (graceful) and exit. The plugin build step
-        /// uses this so a reinstall replaces a stopped process instead of a
-        /// stale binary the old daemon still has mapped in memory.
+        /// Stop the running daemon (graceful).
         #[arg(long)]
         stop: bool,
+        #[command(subcommand)]
+        sub: Option<DaemonCmd>,
     },
-    /// Show daemon status.
-    Status {
+    /// Report CLI and daemon versions without starting the daemon.
+    Version {
         #[arg(long)]
         json: bool,
+    },
+    /// Print the exact operational skill document.
+    Skill,
+    /// Board operations.
+    Board {
+        #[command(subcommand)]
+        sub: BoardCmd,
+    },
+    /// Apply a board template.
+    Template {
+        #[command(subcommand)]
+        sub: TemplateCmd,
     },
     /// Card operations.
     Card {
@@ -43,10 +58,6 @@ pub(crate) enum Cmd {
         json: bool,
     },
     /// Close the active run (`board done [CARD_ID] --outcome ok|fail`).
-    ///
-    /// `ok` with no on_success column marks the card `done` (with a target it
-    /// moves instead). If the agent reports done or goes idle without this
-    /// command, the card becomes `awaiting`; timeout and pane exit still fail.
     Done {
         /// Card id; defaults to $BOARD_CARD_ID.
         card_id: Option<i64>,
@@ -64,10 +75,13 @@ pub(crate) enum Cmd {
         #[arg(long)]
         run_id: i64,
     },
-    /// Move a card to a column (name — case-insensitive — or id).
+    /// Move a card to a column (name, case-insensitive, or id).
     Move {
         card_id: i64,
         column: String,
+        /// Destination board for a cross-board move. The global --board is also accepted.
+        #[arg(long, alias = "to-board", value_name = "ID|PATH")]
+        destination_board: Option<String>,
         #[arg(long)]
         json: bool,
     },
@@ -106,10 +120,59 @@ pub(crate) enum Cmd {
 }
 
 #[derive(Subcommand)]
-#[allow(clippy::large_enum_variant)] // clap arg enum; boxing hurts ergonomics
+pub(crate) enum DaemonCmd {
+    /// Show operational daemon status.
+    Status {
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum BoardCmd {
+    /// List all boards.
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show one board by id, path, or the selected/current board.
+    Show {
+        selector: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Open (or create) the board for a scope path.
+    Open {
+        path: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Rename a board by id, path, or the selected/current board.
+    Rename {
+        /// `<ID|PATH> <NAME>` or `<NAME>` with global --board/current scope.
+        #[arg(required = true, num_args = 1..=2)]
+        values: Vec<String>,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum TemplateCmd {
+    /// Apply a named template to the selected board.
+    Apply {
+        name: String,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum CardCmd {
-    /// Create a card.
-    New {
+    /// Create a card (`new` is retained as an alias).
+    #[command(alias = "new")]
+    Create {
         #[arg(long)]
         title: String,
         #[arg(long, short = 'd')]
@@ -127,14 +190,62 @@ pub(crate) enum CardCmd {
         /// herdr session name (default: the daemon's default session).
         #[arg(long)]
         session: Option<String>,
-        /// Space kind: `workspace` (open workspace) or `new-workspace`.
+        /// Space kind: `workspace` or `new-workspace`.
         #[arg(long)]
         space_kind: Option<String>,
         #[arg(long)]
         space_ref: Option<String>,
-        /// Working directory for a `new-workspace` space (required for that kind).
+        /// Working directory for a `new-workspace` space.
         #[arg(long)]
         space_cwd: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Update card fields; nullable fields are changed only with explicit clear flags.
+    Edit {
+        id: i64,
+        #[arg(long)]
+        title: Option<String>,
+        #[arg(long, short = 'd')]
+        description: Option<String>,
+        #[arg(long)]
+        clear_description: bool,
+        #[arg(long)]
+        harness: Option<String>,
+        #[arg(long)]
+        clear_harness: bool,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long)]
+        clear_model: bool,
+        #[arg(long)]
+        effort: Option<String>,
+        #[arg(long)]
+        clear_effort: bool,
+        #[arg(long)]
+        permission: Option<String>,
+        #[arg(long)]
+        clear_permission: bool,
+        #[arg(long)]
+        session: Option<String>,
+        #[arg(long)]
+        clear_session: bool,
+        #[arg(long)]
+        space_ref: Option<String>,
+        #[arg(long)]
+        clear_space_ref: bool,
+        #[arg(long)]
+        space_cwd: Option<String>,
+        #[arg(long)]
+        clear_space_cwd: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Permanently delete a card and its history.
+    Delete {
+        id: i64,
+        #[arg(long)]
+        yes: bool,
         #[arg(long)]
         json: bool,
     },
@@ -156,10 +267,111 @@ pub(crate) enum CardCmd {
         #[arg(long)]
         json: bool,
     },
-    /// List cards (optionally filtered by column name/id).
+    /// List cards (optionally filtered by column and visibility).
     List {
         #[arg(long)]
         column: Option<String>,
+        #[arg(long, value_parser = ["active", "all", "archived"])]
+        visibility: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Move a card, optionally across boards.
+    Move {
+        id: i64,
+        column: String,
+        #[arg(long, alias = "to-board", value_name = "ID|PATH")]
+        destination_board: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Nested comment operations.
+    Comment {
+        #[command(subcommand)]
+        sub: CommentCmd,
+    },
+    /// Nested run operations.
+    Run {
+        #[command(subcommand)]
+        sub: RunCmd,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum CommentCmd {
+    /// Add a comment to a card.
+    Add {
+        card_id: i64,
+        body: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a comment by id.
+    Show {
+        comment_id: i64,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Edit a comment body.
+    Edit {
+        comment_id: i64,
+        body: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Soft-delete a comment.
+    Delete {
+        comment_id: i64,
+        #[arg(long)]
+        yes: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a comment's audit history.
+    History {
+        comment_id: i64,
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub(crate) enum RunCmd {
+    /// Close the active run.
+    Done {
+        card_id: Option<i64>,
+        #[arg(long, value_parser = ["ok", "fail"])]
+        outcome: String,
+        #[arg(long)]
+        summary: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Cancel the active run.
+    Cancel {
+        card_id: i64,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Retry the card in its current column.
+    Retry {
+        card_id: i64,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Focus the newest run pane.
+    Focus {
+        card_id: i64,
+        #[arg(long)]
+        origin_socket: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Confirm an awaiting run (same completion channel as `run done --outcome ok`).
+    Confirm {
+        card_id: Option<i64>,
+        #[arg(long)]
+        summary: Option<String>,
         #[arg(long)]
         json: bool,
     },
@@ -172,18 +384,117 @@ pub(crate) enum ColumnCmd {
         #[arg(long)]
         json: bool,
     },
+    /// Create a column.
+    Create {
+        #[arg(long)]
+        name: String,
+        #[arg(long)]
+        prompt: Option<String>,
+        #[arg(long)]
+        trigger: Option<String>,
+        #[arg(long)]
+        on_success: Option<String>,
+        #[arg(long)]
+        on_fail: Option<String>,
+        #[arg(long)]
+        fresh_session: bool,
+        #[arg(long)]
+        reuse_session: bool,
+        #[arg(long)]
+        harness: Option<String>,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long)]
+        effort: Option<String>,
+        #[arg(long)]
+        permission: Option<String>,
+        #[arg(long)]
+        timeout: Option<i64>,
+        #[arg(long)]
+        position: Option<i64>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a column by id or name.
+    Show {
+        column: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Edit a column; nullable settings require explicit clear flags.
+    Edit {
+        column: String,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        prompt: Option<String>,
+        #[arg(long)]
+        clear_prompt: bool,
+        #[arg(long)]
+        trigger: Option<String>,
+        #[arg(long)]
+        on_success: Option<String>,
+        #[arg(long)]
+        clear_on_success: bool,
+        #[arg(long)]
+        on_fail: Option<String>,
+        #[arg(long)]
+        clear_on_fail: bool,
+        #[arg(long)]
+        fresh_session: bool,
+        #[arg(long)]
+        reuse_session: bool,
+        #[arg(long)]
+        harness: Option<String>,
+        #[arg(long)]
+        clear_harness: bool,
+        #[arg(long)]
+        model: Option<String>,
+        #[arg(long)]
+        clear_model: bool,
+        #[arg(long)]
+        effort: Option<String>,
+        #[arg(long)]
+        clear_effort: bool,
+        #[arg(long)]
+        permission: Option<String>,
+        #[arg(long)]
+        clear_permission: bool,
+        #[arg(long)]
+        timeout: Option<i64>,
+        #[arg(long)]
+        clear_timeout: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Reorder a column by its zero-based position.
+    Reorder {
+        column: String,
+        position: i64,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete a column.
+    Delete {
+        column: String,
+        #[arg(long)]
+        move_cards_to: Option<String>,
+        #[arg(long)]
+        yes: bool,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
 pub(crate) enum HarnessCmd {
-    /// List every available harness (built-ins `pi`/`claude` + config-defined).
+    /// List every available harness.
     List {
         #[arg(long)]
         json: bool,
     },
     /// List known models and the efforts each accepts.
     Models {
-        /// Harness name.
         #[arg(default_value = "pi")]
         harness: String,
         #[arg(long)]
@@ -191,7 +502,6 @@ pub(crate) enum HarnessCmd {
     },
     /// Show the efforts a model accepts.
     Efforts {
-        /// Harness name.
         #[arg(default_value = "pi")]
         harness: String,
         #[arg(long)]
@@ -199,9 +509,8 @@ pub(crate) enum HarnessCmd {
         #[arg(long)]
         json: bool,
     },
-    /// List the permission modes a harness understands.
+    /// List permission modes a harness understands.
     Permissions {
-        /// Harness name.
         #[arg(default_value = "pi")]
         harness: String,
         #[arg(long)]
@@ -213,7 +522,6 @@ pub(crate) enum HarnessCmd {
 pub(crate) enum SpaceCmd {
     /// List run spaces (herdr workspaces) in a session.
     List {
-        /// herdr session name (default: the daemon's default session).
         #[arg(long)]
         session: Option<String>,
         #[arg(long)]

--- a/crates/board-cli/src/commands/board.rs
+++ b/crates/board-cli/src/commands/board.rs
@@ -1,0 +1,82 @@
+use anyhow::Result;
+use board_core::client::BoardClient;
+
+use crate::args::BoardCmd;
+use crate::daemon::connect_or_start;
+use crate::helpers::print_json;
+use crate::scope::open_selected_board;
+use board_core::scope::resolve_scope_path;
+
+pub(crate) fn cmd_board(sub: BoardCmd, selector: Option<&str>) -> Result<()> {
+    let mut c = connect_or_start()?;
+    match sub {
+        BoardCmd::List { json } => {
+            let result = c.board_list()?;
+            if json {
+                print_json(&result.boards)?;
+            } else {
+                for board in result.boards {
+                    println!(
+                        "#{}\t{}{}",
+                        board.id,
+                        board.name,
+                        board
+                            .scope_path
+                            .map(|path| format!("\t{path}"))
+                            .unwrap_or_default()
+                    );
+                }
+            }
+        }
+        BoardCmd::Show {
+            selector: local,
+            json,
+        } => {
+            let board = open_selected_board(&mut c, local.as_deref().or(selector))?;
+            if json {
+                print_json(&board)?;
+            } else {
+                println!("#{}\t{}", board.board.id, board.board.name);
+                if let Some(path) = board.board.scope_path {
+                    println!("scope: {path}");
+                }
+                println!(
+                    "columns: {}\tcards: {}",
+                    board.columns.len(),
+                    board.cards.len()
+                );
+            }
+        }
+        BoardCmd::Open { path, json } => {
+            let path = resolve_scope_path(std::path::Path::new(&path))?;
+            let path = path
+                .to_str()
+                .ok_or_else(|| anyhow::anyhow!("board path is not valid UTF-8"))?;
+            let board = c.board_open(path)?;
+            if json {
+                print_json(&board)?;
+            } else {
+                println!("Opened board #{} {}", board.board.id, board.board.name);
+            }
+        }
+        BoardCmd::Rename { values, json } => {
+            let (local_selector, name) = match values.as_slice() {
+                [name] => (None, name.as_str()),
+                [local_selector, name] => (Some(local_selector.as_str()), name.as_str()),
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "board rename expects <NAME> or <ID|PATH> <NAME>"
+                    ))
+                }
+            };
+            let board = open_selected_board(&mut c, local_selector.or(selector))?;
+            let renamed = c.board_rename(board.board.id, name)?;
+            if json {
+                print_json(&renamed)?;
+            } else {
+                println!("Renamed board #{} to {}", renamed.id, renamed.name);
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/board-cli/src/commands/card.rs
+++ b/crates/board-cli/src/commands/card.rs
@@ -1,16 +1,30 @@
-use anyhow::{anyhow, Result};
+use anyhow::{bail, Result};
 use board_core::client::{BoardClient, UnixClient};
-use board_core::protocol::{CardCreateParams, Effort};
+use board_core::protocol::{CardCreateParams, CardMoveParams, CardUpdateParams, Patch};
 
 use crate::args::CardCmd;
+use crate::commands::run::{cmd_card_comment, cmd_card_run};
 use crate::daemon::connect_or_start;
-use crate::helpers::{parse_space_kind, print_json};
-use crate::scope::{open_current_board, resolve_column_in};
+use crate::helpers::{
+    confirm_action, parse_effort, parse_space_kind, parse_visibility, print_json,
+};
+use crate::scope::{open_selected_board, resolve_column_in};
 
-pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
+pub(crate) fn cmd_card(sub: CardCmd, selector: Option<&str>) -> Result<()> {
+    // Do not even auto-start boardd for a refused non-interactive deletion.
+    if let CardCmd::Delete { yes, .. } = &sub {
+        confirm_action("card deletion", *yes)?;
+    }
+    if let CardCmd::Comment {
+        sub: crate::args::CommentCmd::Delete { yes, .. },
+    } = &sub
+    {
+        confirm_action("comment deletion", *yes)?;
+    }
+
     let mut c = connect_or_start()?;
     match sub {
-        CardCmd::New {
+        CardCmd::Create {
             title,
             description,
             column,
@@ -24,21 +38,11 @@ pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
             space_cwd,
             json,
         } => {
-            let board = open_current_board(&mut c)?;
-            let column_id = match column {
-                Some(s) => Some(resolve_column_in(&board, &s)?),
-                None => None,
-            };
-            let effort = match effort {
-                Some(s) => {
-                    Some(Effort::parse_str(&s).ok_or_else(|| anyhow!("invalid effort: {s}"))?)
-                }
-                None => None,
-            };
-            let space_kind = match space_kind {
-                Some(s) => Some(parse_space_kind(&s)?),
-                None => None,
-            };
+            let board = open_selected_board(&mut c, selector)?;
+            let column_id = column
+                .as_deref()
+                .map(|value| resolve_column_in(&board, value))
+                .transpose()?;
             let p = CardCreateParams {
                 title,
                 board_id: Some(board.board.id),
@@ -46,10 +50,10 @@ pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
                 column_id,
                 harness,
                 model,
-                effort,
+                effort: parse_effort(effort)?,
                 permission_mode: permission,
                 session,
-                space_kind,
+                space_kind: space_kind.as_deref().map(parse_space_kind).transpose()?,
                 space_ref,
                 space_cwd,
                 position: None,
@@ -64,63 +68,127 @@ pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
                 );
             }
         }
+        CardCmd::Edit {
+            id,
+            title,
+            description,
+            clear_description,
+            harness,
+            clear_harness,
+            model,
+            clear_model,
+            effort,
+            clear_effort,
+            permission,
+            clear_permission,
+            session,
+            clear_session,
+            space_ref,
+            clear_space_ref,
+            space_cwd,
+            clear_space_cwd,
+            json,
+        } => {
+            if clear_harness {
+                bail!("--clear-harness is not supported: harness is required")
+            }
+            let p = CardUpdateParams {
+                id,
+                title,
+                description: if clear_description {
+                    Some(String::new())
+                } else {
+                    description
+                },
+                harness,
+                model: patch(clear_model, model),
+                effort: patch(clear_effort, parse_effort(effort)?),
+                permission_mode: patch(clear_permission, permission),
+                session: patch(clear_session, session),
+                space_kind: None,
+                space_ref: patch(clear_space_ref, space_ref),
+                space_cwd: patch(clear_space_cwd, space_cwd),
+            };
+            let card = c.card_update(&p)?;
+            if json {
+                print_json(&card)?;
+            } else {
+                println!("Updated card #{}", card.id);
+            }
+        }
+        CardCmd::Delete { id, json, .. } => {
+            let result = c.card_delete(id)?;
+            if json {
+                print_json(&result)?;
+            } else {
+                println!("Deleted card #{id}");
+            }
+        }
         CardCmd::Archive { id, json } => card_archive(&mut c, id, true, json)?,
         CardCmd::Restore { id, json } => card_archive(&mut c, id, false, json)?,
         CardCmd::Show { id, json } => {
-            let d = c.card_get(id)?;
+            let detail = c.card_get(id)?;
             if json {
-                print_json(&d)?;
+                print_json(&detail)?;
             } else {
                 println!(
                     "#{} {}  [{}{}]",
-                    d.card.id,
-                    d.card.title,
-                    d.card.status,
-                    if d.card.archived_at.is_some() {
+                    detail.card.id,
+                    detail.card.title,
+                    detail.card.status,
+                    if detail.card.archived_at.is_some() {
                         ", archived"
                     } else {
                         ""
                     }
                 );
-                if let Some(session) = &d.card.session {
+                if let Some(session) = &detail.card.session {
                     println!("session: {session}");
                 }
-                if !d.card.description.is_empty() {
-                    println!("\n{}", d.card.description);
+                if !detail.card.description.is_empty() {
+                    println!("\n{}", detail.card.description);
                 }
-                if !d.comments.is_empty() {
+                if !detail.comments.is_empty() {
                     println!("\nComments:");
-                    for cm in &d.comments {
+                    for comment in &detail.comments {
                         println!(
                             "  [{}] {} ({}): {}",
-                            cm.id, cm.author, cm.created_at, cm.body
+                            comment.id, comment.author, comment.created_at, comment.body
                         );
                     }
                 }
-                if !d.runs.is_empty() {
+                if !detail.runs.is_empty() {
                     println!("\nRuns:");
-                    for r in &d.runs {
+                    for run in &detail.runs {
                         println!(
                             "  #{} col={} {} started={:?} ended={:?}",
-                            r.id,
-                            r.column_id,
-                            r.outcome
-                                .map(|o| o.to_string())
+                            run.id,
+                            run.column_id,
+                            run.outcome
+                                .map(|outcome| outcome.to_string())
                                 .unwrap_or_else(|| "-".into()),
-                            r.started_at,
-                            r.ended_at
+                            run.started_at,
+                            run.ended_at
                         );
                     }
                 }
             }
         }
-        CardCmd::List { column, json } => {
-            let board = open_current_board(&mut c)?;
-            let column_id = match column {
-                Some(s) => Some(resolve_column_in(&board, &s)?),
-                None => None,
-            };
-            let cards = c.card_list_for_board(Some(board.board.id), column_id)?;
+        CardCmd::List {
+            column,
+            visibility,
+            json,
+        } => {
+            let board = open_selected_board(&mut c, selector)?;
+            let column_id = column
+                .as_deref()
+                .map(|value| resolve_column_in(&board, value))
+                .transpose()?;
+            let cards = c.card_list_for_board_visible(
+                Some(board.board.id),
+                column_id,
+                parse_visibility(visibility)?,
+            )?;
             if json {
                 print_json(&cards)?;
             } else {
@@ -128,7 +196,7 @@ pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
                     let session = card
                         .session
                         .as_deref()
-                        .map(|s| format!("\tsession={s}"))
+                        .map(|value| format!("\tsession={value}"))
                         .unwrap_or_default();
                     let archived = if card.archived_at.is_some() {
                         "\tarchived"
@@ -142,8 +210,32 @@ pub(crate) fn cmd_card(sub: CardCmd) -> Result<()> {
                 }
             }
         }
+        CardCmd::Move {
+            id,
+            column,
+            destination_board,
+            json,
+        } => cmd_move(
+            &mut c,
+            id,
+            &column,
+            destination_board.as_deref().or(selector),
+            json,
+        )?,
+        CardCmd::Comment { sub } => cmd_card_comment(sub)?,
+        CardCmd::Run { sub } => cmd_card_run(sub)?,
     }
     Ok(())
+}
+
+fn patch<T>(clear: bool, value: Option<T>) -> Patch<T> {
+    if clear {
+        Patch::Clear
+    } else if let Some(value) = value {
+        Patch::Set(value)
+    } else {
+        Patch::Unchanged
+    }
 }
 
 fn card_archive(c: &mut UnixClient, id: i64, archived: bool, json: bool) -> Result<()> {
@@ -154,6 +246,36 @@ fn card_archive(c: &mut UnixClient, id: i64, archived: bool, json: bool) -> Resu
         println!("Archived card #{}", card.id);
     } else {
         println!("Restored card #{}", card.id);
+    }
+    Ok(())
+}
+
+pub(crate) fn cmd_move(
+    c: &mut UnixClient,
+    card_id: i64,
+    column: &str,
+    destination_selector: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let card = c.card_get(card_id)?.card;
+    let board = match destination_selector {
+        Some(selector) => open_selected_board(c, Some(selector))?,
+        None => c.board_get_by_id(card.board_id)?,
+    };
+    let column_id = resolve_column_in(&board, column)?;
+    let card = c.card_move(&CardMoveParams {
+        id: card_id,
+        column_id,
+        board_id: Some(board.board.id),
+        position: None,
+    })?;
+    if json {
+        print_json(&card)?;
+    } else {
+        println!(
+            "Moved card #{} to column {} [{}]",
+            card.id, card.column_id, card.status
+        );
     }
     Ok(())
 }

--- a/crates/board-cli/src/commands/column.rs
+++ b/crates/board-cli/src/commands/column.rs
@@ -1,26 +1,218 @@
-use anyhow::Result;
+use anyhow::{anyhow, bail, Result};
+use board_core::client::BoardClient;
+use board_core::protocol::{ColumnCreateParams, ColumnUpdateParams, Patch};
 
 use crate::args::ColumnCmd;
 use crate::daemon::connect_or_start;
-use crate::helpers::print_json;
-use crate::scope::open_current_board;
+use crate::helpers::{confirm_action, parse_effort, parse_trigger, print_json};
+use crate::scope::{open_selected_board, resolve_column_in};
 
-pub(crate) fn cmd_column(sub: ColumnCmd) -> Result<()> {
+pub(crate) fn cmd_column(sub: ColumnCmd, selector: Option<&str>) -> Result<()> {
+    if let ColumnCmd::Delete { yes, .. } = &sub {
+        confirm_action("column deletion", *yes)?;
+    }
+
     let mut c = connect_or_start()?;
     match sub {
         ColumnCmd::List { json } => {
-            let snap = open_current_board(&mut c)?;
+            let board = open_selected_board(&mut c, selector)?;
             if json {
-                print_json(&snap.columns)?;
+                print_json(&board.columns)?;
             } else {
-                for col in &snap.columns {
-                    println!(
-                        "#{}\tpos={}\t[{}]\t{}",
-                        col.id, col.position, col.trigger, col.name
-                    );
+                for column in &board.columns {
+                    print_column(column);
                 }
+            }
+        }
+        ColumnCmd::Create {
+            name,
+            prompt,
+            trigger,
+            on_success,
+            on_fail,
+            fresh_session,
+            reuse_session,
+            harness,
+            model,
+            effort,
+            permission,
+            timeout,
+            position,
+            json,
+        } => {
+            if fresh_session && reuse_session {
+                bail!("--fresh-session and --reuse-session are mutually exclusive")
+            }
+            let board = open_selected_board(&mut c, selector)?;
+            let params = ColumnCreateParams {
+                name,
+                board_id: Some(board.board.id),
+                position,
+                system_prompt: prompt,
+                trigger: parse_trigger(trigger)?,
+                on_success_column_id: resolve_optional_column(&board, on_success)?,
+                on_fail_column_id: resolve_optional_column(&board, on_fail)?,
+                fresh_session: bool_option(fresh_session, reuse_session),
+                harness_override: harness,
+                model_override: model,
+                effort_override: parse_effort(effort)?.map(|value| value.to_string()),
+                permission_override: permission,
+                timeout_minutes: timeout,
+            };
+            let column = c.column_create(&params)?;
+            if json {
+                print_json(&column)?;
+            } else {
+                println!("Created column #{} {}", column.id, column.name);
+            }
+        }
+        ColumnCmd::Show { column, json } => {
+            let board = open_selected_board(&mut c, selector)?;
+            let id = resolve_column_in(&board, &column)?;
+            let column = board
+                .columns
+                .iter()
+                .find(|candidate| candidate.id == id)
+                .ok_or_else(|| anyhow!("column {id} not found"))?;
+            if json {
+                print_json(column)?;
+            } else {
+                print_column(column);
+            }
+        }
+        ColumnCmd::Edit {
+            column,
+            name,
+            prompt,
+            clear_prompt,
+            trigger,
+            on_success,
+            clear_on_success,
+            on_fail,
+            clear_on_fail,
+            fresh_session,
+            reuse_session,
+            harness,
+            clear_harness,
+            model,
+            clear_model,
+            effort,
+            clear_effort,
+            permission,
+            clear_permission,
+            timeout,
+            clear_timeout,
+            json,
+        } => {
+            if fresh_session && reuse_session {
+                bail!("--fresh-session and --reuse-session are mutually exclusive")
+            }
+            let board = open_selected_board(&mut c, selector)?;
+            let id = resolve_column_reference(&board, &column)?;
+            let params = ColumnUpdateParams {
+                id,
+                name,
+                position: None,
+                system_prompt: patch(clear_prompt, prompt),
+                trigger: parse_trigger(trigger)?,
+                on_success_column_id: patch(
+                    clear_on_success,
+                    resolve_optional_column(&board, on_success)?,
+                ),
+                on_fail_column_id: patch(clear_on_fail, resolve_optional_column(&board, on_fail)?),
+                fresh_session: bool_option(fresh_session, reuse_session),
+                harness_override: patch(clear_harness, harness),
+                model_override: patch(clear_model, model),
+                effort_override: patch(
+                    clear_effort,
+                    parse_effort(effort)?.map(|value| value.to_string()),
+                ),
+                permission_override: patch(clear_permission, permission),
+                timeout_minutes: patch(clear_timeout, timeout),
+            };
+            let column = c.column_update(&params)?;
+            if json {
+                print_json(&column)?;
+            } else {
+                println!("Updated column #{} {}", column.id, column.name);
+            }
+        }
+        ColumnCmd::Reorder {
+            column,
+            position,
+            json,
+        } => {
+            let board = open_selected_board(&mut c, selector)?;
+            let id = resolve_column_reference(&board, &column)?;
+            let columns = c.column_reorder(id, position)?;
+            if json {
+                print_json(&columns)?;
+            } else {
+                for column in columns {
+                    print_column(&column);
+                }
+            }
+        }
+        ColumnCmd::Delete {
+            column,
+            move_cards_to,
+            json,
+            ..
+        } => {
+            let board = open_selected_board(&mut c, selector)?;
+            let id = resolve_column_reference(&board, &column)?;
+            let destination = resolve_optional_column(&board, move_cards_to)?;
+            let result = c.column_delete(id, destination)?;
+            if json {
+                print_json(&result)?;
+            } else {
+                println!("Deleted column #{id}");
             }
         }
     }
     Ok(())
+}
+
+fn resolve_optional_column(
+    board: &board_core::protocol::BoardSnapshot,
+    value: Option<String>,
+) -> Result<Option<i64>> {
+    value
+        .as_deref()
+        .map(|value| resolve_column_reference(board, value))
+        .transpose()
+}
+
+fn resolve_column_reference(
+    board: &board_core::protocol::BoardSnapshot,
+    value: &str,
+) -> Result<i64> {
+    resolve_column_in(board, value)
+}
+
+fn bool_option(fresh: bool, reuse: bool) -> Option<bool> {
+    if fresh {
+        Some(true)
+    } else if reuse {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn patch<T>(clear: bool, value: Option<T>) -> Patch<T> {
+    if clear {
+        Patch::Clear
+    } else if let Some(value) = value {
+        Patch::Set(value)
+    } else {
+        Patch::Unchanged
+    }
+}
+
+fn print_column(column: &board_core::model::Column) {
+    println!(
+        "#{}\tpos={}\t[{}]\t{}",
+        column.id, column.position, column.trigger, column.name
+    );
 }

--- a/crates/board-cli/src/commands/mod.rs
+++ b/crates/board-cli/src/commands/mod.rs
@@ -1,4 +1,6 @@
+pub(crate) mod board;
 pub(crate) mod card;
 pub(crate) mod column;
 pub(crate) mod discovery;
 pub(crate) mod run;
+pub(crate) mod template;

--- a/crates/board-cli/src/commands/run.rs
+++ b/crates/board-cli/src/commands/run.rs
@@ -1,27 +1,122 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result};
 use board_core::client::BoardClient;
-use board_core::protocol::{CardMoveParams, RunOutcome};
+use board_core::protocol::RunOutcome;
 
+use crate::args::{CommentCmd, RunCmd};
 use crate::daemon::connect_or_start;
-use crate::helpers::{env_card_id, print_json};
-use crate::scope::resolve_column_in;
+use crate::helpers::{
+    actor_author, actor_run_id, env_card_id, origin_socket as resolve_origin_socket, parse_outcome,
+    print_json,
+};
 
+/// Legacy top-level comment command.
 pub(crate) fn cmd_comment(first: String, body: Option<String>, json: bool) -> Result<()> {
     let (card_id, body) = match body {
-        Some(b) => (first.parse::<i64>().context("card id")?, b),
+        Some(body) => (first.parse::<i64>().context("card id")?, body),
         None => (env_card_id()?, first),
     };
-    let author = std::env::var("BOARD_RUN_ID")
-        .ok()
-        .map(|r| format!("agent:{r}"));
     let mut c = connect_or_start()?;
-    let comment = c.comment_add(card_id, &body, author.as_deref())?;
+    let run_id = actor_run_id()?;
+    let author = actor_author(run_id);
+    let comment = c.comment_add_for_run(card_id, &body, author.as_deref(), run_id)?;
     if json {
         print_json(&comment)?;
     } else {
         println!("Commented on card #{card_id} (comment #{})", comment.id);
     }
     Ok(())
+}
+
+pub(crate) fn cmd_card_comment(sub: CommentCmd) -> Result<()> {
+    let mut c = connect_or_start()?;
+    let actor = actor_run_id()?;
+    let result: Result<()> = (|| {
+        match sub {
+            CommentCmd::Add {
+                card_id,
+                body,
+                json,
+            } => {
+                let author = actor_author(actor);
+                let comment = c.comment_add_for_run(card_id, &body, author.as_deref(), actor)?;
+                if json {
+                    print_json(&comment)?;
+                } else {
+                    println!("Commented on card #{card_id} (comment #{})", comment.id);
+                }
+            }
+            CommentCmd::Show { comment_id, json } => {
+                let comment = c.comment_get(comment_id)?;
+                if json {
+                    print_json(&comment)?;
+                } else {
+                    print_comment(&comment);
+                }
+            }
+            CommentCmd::Edit {
+                comment_id,
+                body,
+                json,
+            } => {
+                let comment = c.comment_update(comment_id, &body, actor)?;
+                if json {
+                    print_json(&comment)?;
+                } else {
+                    println!("Updated comment #{}", comment.id);
+                }
+            }
+            CommentCmd::Delete {
+                comment_id, json, ..
+            } => {
+                let result = c.comment_delete(comment_id, actor)?;
+                if json {
+                    print_json(&result)?;
+                } else {
+                    println!("Deleted comment #{comment_id}");
+                }
+            }
+            CommentCmd::History { comment_id, json } => {
+                let history = c.comment_history(comment_id)?;
+                if json {
+                    print_json(&history)?;
+                } else {
+                    for entry in history {
+                        println!(
+                            "#{} comment=#{} {} ({}): {}{}",
+                            entry.id,
+                            entry.comment_id,
+                            entry.author,
+                            entry.created_at,
+                            entry.body,
+                            if entry.deleted_at.is_some() {
+                                " [deleted]"
+                            } else {
+                                ""
+                            }
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    })();
+    result.context("comment operation")
+}
+
+fn print_comment(comment: &board_core::model::CommentRecord) {
+    println!(
+        "#{} card={} {} ({}): {}{}",
+        comment.id,
+        comment.card_id,
+        comment.author,
+        comment.created_at,
+        comment.body,
+        if comment.deleted_at.is_some() {
+            " [deleted]"
+        } else {
+            ""
+        }
+    );
 }
 
 pub(crate) fn cmd_done(
@@ -31,62 +126,54 @@ pub(crate) fn cmd_done(
     json: bool,
 ) -> Result<()> {
     let card_id = match card_id {
-        Some(id) => id,
+        Some(card_id) => card_id,
         None => env_card_id()?,
     };
-    let outcome = RunOutcome::parse_str(&outcome).ok_or_else(|| anyhow!("invalid outcome"))?;
-    let run_id = match std::env::var("BOARD_RUN_ID") {
-        Ok(value) => Some(
-            value
-                .parse::<i64>()
-                .map_err(|_| anyhow!("invalid $BOARD_RUN_ID '{value}': expected an integer"))?,
-        ),
-        Err(std::env::VarError::NotPresent) => None,
-        Err(std::env::VarError::NotUnicode(_)) => {
-            bail!("invalid $BOARD_RUN_ID: value is not valid UTF-8")
-        }
-    };
+    let outcome = parse_outcome(&outcome)?;
+    let run_id = actor_run_id()?;
     let mut c = connect_or_start()?;
-    let res = c.run_done_for_run(card_id, outcome, summary.as_deref(), run_id)?;
-    if json {
-        print_json(&res)?;
-    } else {
-        println!(
-            "Run #{} closed ({}); card #{} now [{}] in column {}",
-            res.run.id, outcome, res.card.id, res.card.status, res.card.column_id
-        );
+    let result = c.run_done_for_run(card_id, outcome, summary.as_deref(), run_id)?;
+    print_run_result(&result, outcome, json)
+}
+
+pub(crate) fn cmd_card_run(sub: RunCmd) -> Result<()> {
+    match sub {
+        RunCmd::Done {
+            card_id,
+            outcome,
+            summary,
+            json,
+        } => cmd_done(card_id, outcome, summary, json),
+        RunCmd::Confirm {
+            card_id,
+            summary,
+            json,
+        } => cmd_done(card_id, "ok".into(), summary, json),
+        RunCmd::Cancel { card_id, json } => cmd_run_action(card_id, json, false),
+        RunCmd::Retry { card_id, json } => cmd_run_action(card_id, json, true),
+        RunCmd::Focus {
+            card_id,
+            origin_socket,
+            json,
+        } => {
+            let socket = resolve_origin_socket(origin_socket)?;
+            let result = connect_or_start()?.run_focus(card_id, &socket)?;
+            if json {
+                print_json(&result)?;
+            } else {
+                println!("Focused run #{} pane {}", result.run_id, result.pane_id);
+            }
+            Ok(())
+        }
     }
-    Ok(())
 }
 
 pub(crate) fn cmd_pane_exited(card_id: Option<i64>, run_id: i64) -> Result<()> {
     let card_id = match card_id {
-        Some(id) => id,
+        Some(card_id) => card_id,
         None => env_card_id()?,
     };
     connect_or_start()?.run_pane_exited(card_id, run_id)?;
-    Ok(())
-}
-
-pub(crate) fn cmd_move(card_id: i64, column: String, json: bool) -> Result<()> {
-    let mut c = connect_or_start()?;
-    let card = c.card_get(card_id)?.card;
-    let board = c.board_get_by_id(card.board_id)?;
-    let column_id = resolve_column_in(&board, &column)?;
-    let card = c.card_move(&CardMoveParams {
-        id: card_id,
-        column_id,
-        board_id: None,
-        position: None,
-    })?;
-    if json {
-        print_json(&card)?;
-    } else {
-        println!(
-            "Moved card #{} to column {} [{}]",
-            card.id, card.column_id, card.status
-        );
-    }
     Ok(())
 }
 
@@ -102,6 +189,22 @@ pub(crate) fn cmd_run_action(card_id: i64, json: bool, retry: bool) -> Result<()
     } else {
         let action = if retry { "Retried" } else { "Cancelled" };
         println!("{action} card #{card_id}");
+    }
+    Ok(())
+}
+
+fn print_run_result(
+    result: &board_core::protocol::RunActionResult,
+    outcome: RunOutcome,
+    json: bool,
+) -> Result<()> {
+    if json {
+        print_json(result)?;
+    } else {
+        println!(
+            "Run #{} closed ({}); card #{} now [{}] in column {}",
+            result.run.id, outcome, result.card.id, result.card.status, result.card.column_id
+        );
     }
     Ok(())
 }

--- a/crates/board-cli/src/commands/template.rs
+++ b/crates/board-cli/src/commands/template.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use board_core::client::BoardClient;
+
+use crate::args::TemplateCmd;
+use crate::daemon::connect_or_start;
+use crate::helpers::print_json;
+use crate::scope::open_selected_board;
+
+pub(crate) fn cmd_template(sub: TemplateCmd, selector: Option<&str>) -> Result<()> {
+    let mut c = connect_or_start()?;
+    match sub {
+        TemplateCmd::Apply { name, json } => {
+            let board = open_selected_board(&mut c, selector)?;
+            let columns = c.template_apply_for_board(&name, Some(board.board.id))?;
+            if json {
+                print_json(&columns)?;
+            } else {
+                println!("Applied template {name} to board #{}", board.board.id);
+                for column in columns {
+                    println!("#{}\t{}", column.id, column.name);
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/board-cli/src/helpers.rs
+++ b/crates/board-cli/src/helpers.rs
@@ -1,7 +1,9 @@
+use std::io::{self, IsTerminal, Write};
+
 use anyhow::{anyhow, bail, Result};
 use board_core::capability::HarnessCapabilities;
 use board_core::client::{BoardClient, UnixClient};
-use board_core::protocol::{Effort, SpaceKind};
+use board_core::protocol::{CardVisibility, Effort, RunOutcome, SpaceKind, Trigger};
 
 /// Fetch a harness's capability catalog (`harness.capabilities`).
 pub(crate) fn harness_capabilities(
@@ -41,14 +43,81 @@ pub(crate) fn env_card_id() -> Result<i64> {
         .ok_or_else(|| anyhow!("no card id given and $BOARD_CARD_ID is unset"))
 }
 
-/// Parse a `--space-kind` CLI value. Accepts `workspace` and `new-workspace`
-/// (the wire form `new_workspace` is also tolerated); anything else is an error.
+pub(crate) fn actor_run_id() -> Result<Option<i64>> {
+    match std::env::var("BOARD_RUN_ID") {
+        Ok(value) => Ok(Some(value.parse::<i64>().map_err(|_| {
+            anyhow!("invalid $BOARD_RUN_ID '{value}': expected an integer")
+        })?)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            bail!("invalid $BOARD_RUN_ID: value is not valid UTF-8")
+        }
+    }
+}
+
+pub(crate) fn actor_author(run_id: Option<i64>) -> Option<String> {
+    run_id.map(|id| format!("agent:{id}"))
+}
+
+/// Parse a `--space-kind` CLI value.
 pub(crate) fn parse_space_kind(s: &str) -> Result<SpaceKind> {
     match s {
         "workspace" => Ok(SpaceKind::Workspace),
         "new-workspace" | "new_workspace" => Ok(SpaceKind::NewWorkspace),
         other => bail!("invalid space-kind '{other}' (expected: workspace, new-workspace)"),
     }
+}
+
+pub(crate) fn parse_effort(s: Option<String>) -> Result<Option<Effort>> {
+    s.map(|value| Effort::parse_str(&value).ok_or_else(|| anyhow!("invalid effort: {value}")))
+        .transpose()
+}
+
+pub(crate) fn parse_trigger(s: Option<String>) -> Result<Option<Trigger>> {
+    s.map(|value| Trigger::parse_str(&value).ok_or_else(|| anyhow!("invalid trigger: {value}")))
+        .transpose()
+}
+
+pub(crate) fn parse_outcome(s: &str) -> Result<RunOutcome> {
+    RunOutcome::parse_str(s).ok_or_else(|| anyhow!("invalid outcome '{s}' (expected: ok or fail)"))
+}
+
+pub(crate) fn parse_visibility(s: Option<String>) -> Result<Option<CardVisibility>> {
+    s.map(|value| {
+        CardVisibility::parse_str(&value).ok_or_else(|| {
+            anyhow!("invalid visibility '{value}' (expected: active, all, archived)")
+        })
+    })
+    .transpose()
+}
+
+/// Require `--yes` in automation, while retaining a normal TTY prompt for
+/// humans. This is deliberately performed before connecting to boardd.
+pub(crate) fn confirm_action(kind: &str, yes: bool) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    if !io::stdin().is_terminal() {
+        bail!("{kind} requires confirmation; pass --yes when stdin is not a TTY")
+    }
+    eprint!("Delete {kind}? [y/N] ");
+    io::stderr().flush()?;
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    if matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(())
+    } else {
+        bail!("{kind} cancelled")
+    }
+}
+
+pub(crate) fn origin_socket(explicit: Option<String>) -> Result<String> {
+    if let Some(socket) = explicit {
+        return Ok(socket);
+    }
+    std::env::var("HERDR_SOCKET_PATH")
+        .or_else(|_| std::env::var("HERDR_SOCK"))
+        .map_err(|_| anyhow!("--origin-socket is required outside a Herdr session"))
 }
 
 pub(crate) fn print_json<T: serde::Serialize>(v: &T) -> Result<()> {

--- a/crates/board-cli/src/main.rs
+++ b/crates/board-cli/src/main.rs
@@ -1,8 +1,4 @@
 //! board — the single CLI binary.
-//!
-//! clap subcommands over the boardd socket: `tui`, `daemon`, `status`, and the
-//! agent/user verbs (`card`, `comment`, `done`, `move`, `cancel`, `retry`,
-//! `column`). Every connecting command auto-starts the daemon if it is absent.
 
 mod args;
 mod commands;
@@ -10,41 +6,71 @@ mod daemon;
 mod helpers;
 mod scope;
 
+use std::io::Write;
+
 use anyhow::{anyhow, Result};
-use clap::Parser;
+use board_core::client::{BoardClient, RpcClientError, UnixClient};
+use clap::{error::ErrorKind, Parser};
+use serde_json::{json, Value};
 
 use args::{Cli, Cmd};
-use commands::card::cmd_card;
+use commands::board::cmd_board;
+use commands::card::{cmd_card, cmd_move};
 use commands::column::cmd_column;
 use commands::discovery::{cmd_harness, cmd_session, cmd_space, cmd_status};
-use commands::run::{cmd_comment, cmd_done, cmd_move, cmd_pane_exited, cmd_run_action};
+use commands::run::{cmd_comment, cmd_done, cmd_pane_exited, cmd_run_action};
+use commands::template::cmd_template;
 use daemon::{connect_or_start, stop_daemon};
-use scope::open_current_board;
+use scope::open_selected_board;
 
 fn main() {
-    if let Err(e) = real_main() {
-        eprintln!("board: {e:#}");
+    let json_requested = std::env::args().any(|arg| arg == "--json");
+    if let Err(error) = real_main() {
+        render_error(error, json_requested);
         std::process::exit(1);
     }
 }
 
 fn real_main() -> Result<()> {
-    let cli = Cli::parse();
-    match cli.cmd {
-        Cmd::Daemon { foreground, stop } => {
-            if stop {
-                stop_daemon()
-            } else {
-                board_daemon::run(foreground).map_err(|e| anyhow!(e))
-            }
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            ) =>
+        {
+            print!("{error}");
+            return Ok(());
         }
+        Err(error) => return Err(anyhow!(error.to_string())),
+    };
+    let selector = cli.board.as_deref();
+    match cli.cmd {
+        Cmd::Daemon {
+            foreground,
+            stop,
+            sub,
+        } => match sub {
+            Some(args::DaemonCmd::Status { json }) => cmd_status(json),
+            None => {
+                if stop {
+                    stop_daemon()
+                } else {
+                    board_daemon::run(foreground).map_err(|e| anyhow!(e))
+                }
+            }
+        },
         Cmd::Tui => {
             let mut client = connect_or_start()?;
-            let board = open_current_board(&mut client)?;
+            let board = open_selected_board(&mut client, selector)?;
             board_tui::run_with_board(Box::new(client), board)
         }
-        Cmd::Status { json } => cmd_status(json),
-        Cmd::Card { sub } => cmd_card(sub),
+        Cmd::Version { json } => cmd_version(json),
+        Cmd::Skill => print_skill(),
+        Cmd::Board { sub } => cmd_board(sub, selector),
+        Cmd::Template { sub } => cmd_template(sub, selector),
+        Cmd::Card { sub } => cmd_card(sub, selector),
         Cmd::Comment { first, body, json } => cmd_comment(first, body, json),
         Cmd::Done {
             card_id,
@@ -56,13 +82,94 @@ fn real_main() -> Result<()> {
         Cmd::Move {
             card_id,
             column,
+            destination_board,
             json,
-        } => cmd_move(card_id, column, json),
+        } => {
+            let destination = destination_board.as_deref().or(selector);
+            let mut client = connect_or_start()?;
+            cmd_move(&mut client, card_id, &column, destination, json)
+        }
         Cmd::Cancel { card_id, json } => cmd_run_action(card_id, json, false),
         Cmd::Retry { card_id, json } => cmd_run_action(card_id, json, true),
-        Cmd::Column { sub } => cmd_column(sub),
+        Cmd::Column { sub } => cmd_column(sub, selector),
         Cmd::Harness { sub } => cmd_harness(sub),
         Cmd::Space { sub } => cmd_space(sub),
         Cmd::Session { sub } => cmd_session(sub),
     }
+}
+
+fn cmd_version(json_output: bool) -> Result<()> {
+    let daemon_version = match UnixClient::connect(&board_core::paths::socket_path()) {
+        Ok(mut client) => client.daemon_status().ok().map(|status| status.version),
+        Err(_) => None,
+    };
+    if json_output {
+        print_json(&json!({
+            "cli_version": env!("CARGO_PKG_VERSION"),
+            "daemon_version": daemon_version,
+        }))
+    } else {
+        println!("cli {}", env!("CARGO_PKG_VERSION"));
+        println!(
+            "daemon {}",
+            daemon_version.as_deref().unwrap_or("unavailable")
+        );
+        Ok(())
+    }
+}
+
+fn print_skill() -> Result<()> {
+    std::io::stdout().write_all(include_bytes!("../../../skill/SKILL.md"))?;
+    Ok(())
+}
+
+fn print_json<T: serde::Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn render_error(error: anyhow::Error, json_requested: bool) {
+    if !json_requested {
+        eprintln!("board: {error:#}");
+        return;
+    }
+
+    let rpc = error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<RpcClientError>());
+    let payload = if let Some(rpc) = rpc {
+        let mut error_object = serde_json::Map::new();
+        error_object.insert("code".into(), json!(rpc.code));
+        if let Some(kind) = &rpc.kind {
+            error_object.insert("kind".into(), json!(kind));
+        }
+        let message = if error.chain().count() > 1 {
+            format!("{error:#}")
+        } else {
+            rpc.message.clone()
+        };
+        error_object.insert("message".into(), json!(message));
+        if let Some(details) = &rpc.details {
+            error_object.insert("details".into(), details.clone());
+        }
+        Value::Object({
+            let mut root = serde_json::Map::new();
+            root.insert("error".into(), Value::Object(error_object));
+            root
+        })
+    } else {
+        json!({
+            "error": {
+                "code": 2,
+                "kind": "cli",
+                "message": format!("{error:#}"),
+            }
+        })
+    };
+    eprintln!(
+        "{}",
+        serde_json::to_string(&payload).unwrap_or_else(|_| {
+            r#"{"error":{"code":2,"message":"board command failed"}}"#.into()
+        })
+    );
 }

--- a/crates/board-cli/src/scope.rs
+++ b/crates/board-cli/src/scope.rs
@@ -18,8 +18,26 @@ pub(crate) fn current_scope_path() -> Result<String> {
     })
 }
 
-pub(crate) fn open_current_board(c: &mut UnixClient) -> Result<BoardSnapshot> {
-    c.board_open(&current_scope_path()?)
+/// Resolve an ID-or-path board selector. Paths are normalized in the same way
+/// as the daemon's current-scope fallback, so all board-aware commands share
+/// one selection rule.
+pub(crate) fn open_selected_board(
+    c: &mut UnixClient,
+    selector: Option<&str>,
+) -> Result<BoardSnapshot> {
+    match selector {
+        Some(value) => {
+            if let Ok(id) = value.parse::<i64>() {
+                return c.board_get_by_id(id);
+            }
+            let path = resolve_scope_path(std::path::Path::new(value))?;
+            let path = path
+                .to_str()
+                .ok_or_else(|| anyhow!("board path is not valid UTF-8: {}", path.display()))?;
+            c.board_open(path)
+        }
+        None => c.board_open(&current_scope_path()?),
+    }
 }
 
 /// Resolve a column reference within one board snapshot.

--- a/crates/board-cli/tests/integration.rs
+++ b/crates/board-cli/tests/integration.rs
@@ -6,6 +6,10 @@
 mod support;
 pub(crate) use support::*;
 
+#[path = "integration/cli_contract.rs"]
+mod cli_contract;
+#[path = "integration/compat.rs"]
+mod compat;
 #[path = "integration/events.rs"]
 mod events;
 #[path = "integration/harness.rs"]

--- a/crates/board-cli/tests/integration/cli_contract.rs
+++ b/crates/board-cli/tests/integration/cli_contract.rs
@@ -1,0 +1,878 @@
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixListener;
+use std::process::{Command, Output, Stdio};
+
+use board_core::client::BoardClient;
+use board_core::protocol::{
+    CardCreateParams, CardStatus, ColumnCreateParams, Effort, Request, Response, Trigger,
+};
+use serde_json::Value;
+
+use super::{col, poll, todo_id, TestDaemon};
+
+fn json_output(out: &Output) -> Value {
+    assert!(
+        out.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("command should emit JSON")
+}
+
+fn json_error(out: &Output) -> Value {
+    assert!(!out.status.success(), "command unexpectedly succeeded");
+    assert!(out.stdout.is_empty(), "JSON errors must leave stdout empty");
+    serde_json::from_slice(&out.stderr).expect("JSON error should be emitted on stderr")
+}
+
+#[test]
+fn top_level_status_is_rejected() {
+    let td = TestDaemon::start(&[]);
+    let output = td.board(&["status"]);
+
+    assert!(
+        !output.status.success(),
+        "top-level status unexpectedly succeeded"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("status"),
+        "parse error should identify the rejected command: {:?}",
+        output.stderr
+    );
+}
+
+fn old_card(td: &TestDaemon, title: &str) -> i64 {
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        title,
+        "--harness",
+        "fake",
+        "--json",
+    ]);
+    let card = json_output(&out);
+    card["id"].as_i64().expect("created card id")
+}
+
+fn json_card_ids(out: &Output) -> Vec<i64> {
+    json_output(out)
+        .as_array()
+        .expect("card list JSON is an array")
+        .iter()
+        .map(|card| card["id"].as_i64().expect("card id"))
+        .collect()
+}
+
+#[test]
+fn board_commands_list_show_open_and_rename() {
+    let td = TestDaemon::start(&[]);
+    let project = td._dir.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+
+    let mut client = td.client();
+    let opened = client.board_open(project.to_str().unwrap()).unwrap().board;
+
+    let listed = json_output(&td.board(&["board", "list", "--json"]));
+    let boards = listed.as_array().expect("board list JSON is an array");
+    assert!(boards.iter().any(|board| board["id"] == opened.id));
+
+    let shown = json_output(&td.board(&["board", "show", &opened.id.to_string(), "--json"]));
+    assert_eq!(shown["board"]["id"], opened.id);
+
+    let reopened = json_output(&td.board(&["board", "open", project.to_str().unwrap(), "--json"]));
+    assert_eq!(reopened["board"]["id"], opened.id);
+
+    let renamed = json_output(&td.board(&[
+        "board",
+        "rename",
+        &opened.id.to_string(),
+        "Project board",
+        "--json",
+    ]));
+    assert_eq!(renamed["name"], "Project board");
+}
+
+#[test]
+fn global_board_selector_accepts_id_and_path() {
+    let td = TestDaemon::start(&[]);
+    let project = td._dir.path().join("selected-project");
+    std::fs::create_dir_all(&project).unwrap();
+    let project = project.canonicalize().unwrap();
+    let mut client = td.client();
+    let board = client.board_open(project.to_str().unwrap()).unwrap().board;
+    let card = client
+        .card_create(&CardCreateParams {
+            board_id: Some(board.id),
+            title: "selected card".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let by_id = td.board(&["--board", &board.id.to_string(), "card", "list", "--json"]);
+    let by_id = json_output(&by_id);
+    assert_eq!(by_id.as_array().unwrap().len(), 1);
+    assert_eq!(by_id[0]["id"], card.id);
+
+    let by_path = td.board_in(
+        td._dir.path(),
+        &[
+            "--board",
+            project.to_str().unwrap(),
+            "card",
+            "list",
+            "--json",
+        ],
+    );
+    let by_path = json_output(&by_path);
+    assert_eq!(by_path.as_array().unwrap().len(), 1);
+    assert_eq!(by_path[0]["id"], card.id);
+}
+
+#[test]
+fn canonical_card_create_edit_move_and_delete() {
+    let td = TestDaemon::start(&[]);
+
+    let created = json_output(&td.board(&[
+        "card",
+        "create",
+        "--title",
+        "canonical card",
+        "--description",
+        "initial description",
+        "--harness",
+        "fake",
+        "--json",
+    ]));
+    let id = created["id"].as_i64().expect("created card id");
+    assert_eq!(created["title"], "canonical card");
+
+    let edited = json_output(&td.board(&[
+        "card",
+        "edit",
+        &id.to_string(),
+        "--title",
+        "edited card",
+        "--description",
+        "edited description",
+        "--json",
+    ]));
+    assert_eq!(edited["title"], "edited card");
+    assert_eq!(edited["description"], "edited description");
+
+    let moved = json_output(&td.board(&["card", "move", &id.to_string(), "Todo", "--json"]));
+    assert_eq!(moved["id"], id);
+
+    let deleted = json_output(&td.board(&["card", "delete", &id.to_string(), "--yes", "--json"]));
+    assert_eq!(deleted["deleted"], true);
+    assert!(!td.client().card_get(id).is_ok());
+}
+
+#[test]
+fn card_edit_sets_and_explicitly_clears_nullable_patches() {
+    let td = TestDaemon::start(&[]);
+    let card = td
+        .client()
+        .card_create(&CardCreateParams {
+            title: "patch card".into(),
+            harness: Some("claude".into()),
+            model: Some("sonnet".into()),
+            effort: Some(Effort::Low),
+            permission_mode: Some("acceptEdits".into()),
+            session: Some("initial-session".into()),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let set = json_output(&td.board(&[
+        "card",
+        "edit",
+        &card.id.to_string(),
+        "--title",
+        "patched card",
+        "--description",
+        "patched description",
+        "--model",
+        "haiku",
+        "--effort",
+        "high",
+        "--permission",
+        "plan",
+        "--session",
+        "review-session",
+        "--json",
+    ]));
+    assert_eq!(set["title"], "patched card");
+    assert_eq!(set["description"], "patched description");
+    assert_eq!(set["model"], "haiku");
+    assert_eq!(set["effort"], "high");
+    assert_eq!(set["permission_mode"], "plan");
+    assert_eq!(set["session"], "review-session");
+
+    let cleared = json_output(&td.board(&[
+        "card",
+        "edit",
+        &card.id.to_string(),
+        "--clear-model",
+        "--clear-effort",
+        "--clear-permission",
+        "--clear-session",
+        "--json",
+    ]));
+    assert_eq!(cleared["model"], Value::Null);
+    assert_eq!(cleared["effort"], Value::Null);
+    assert_eq!(cleared["permission_mode"], Value::Null);
+    assert_eq!(cleared["session"], Value::Null);
+    assert_eq!(cleared["title"], "patched card");
+    assert_eq!(cleared["description"], "patched description");
+}
+
+#[test]
+fn card_list_visibility_is_active_all_or_archived() {
+    let td = TestDaemon::start(&[]);
+    let active = old_card(&td, "active");
+    let archived = old_card(&td, "archived");
+    td.client().card_archive(archived, true).unwrap();
+
+    let active_ids =
+        json_card_ids(&td.board(&["card", "list", "--visibility", "active", "--json"]));
+    assert!(active_ids.contains(&active));
+    assert!(!active_ids.contains(&archived));
+
+    let all_ids = json_card_ids(&td.board(&["card", "list", "--visibility", "all", "--json"]));
+    assert!(all_ids.contains(&active));
+    assert!(all_ids.contains(&archived));
+
+    let archived_ids =
+        json_card_ids(&td.board(&["card", "list", "--visibility", "archived", "--json"]));
+    assert!(!archived_ids.contains(&active));
+    assert_eq!(archived_ids, vec![archived]);
+}
+
+#[test]
+fn canonical_card_comment_lifecycle_has_history() {
+    let td = TestDaemon::start(&[]);
+    let card_id = old_card(&td, "commented");
+
+    let added = json_output(&td.board(&[
+        "card",
+        "comment",
+        "add",
+        &card_id.to_string(),
+        "first body",
+        "--json",
+    ]));
+    let comment_id = added["id"].as_i64().expect("comment id");
+    assert_eq!(added["body"], "first body");
+
+    let shown =
+        json_output(&td.board(&["card", "comment", "show", &comment_id.to_string(), "--json"]));
+    assert_eq!(shown["id"], comment_id);
+    assert_eq!(shown["body"], "first body");
+
+    let edited = json_output(&td.board(&[
+        "card",
+        "comment",
+        "edit",
+        &comment_id.to_string(),
+        "edited body",
+        "--json",
+    ]));
+    assert_eq!(edited["body"], "edited body");
+
+    let history = json_output(&td.board(&[
+        "card",
+        "comment",
+        "history",
+        &comment_id.to_string(),
+        "--json",
+    ]));
+    let history = history.as_array().expect("comment history is an array");
+    assert!(history.iter().any(|entry| entry["body"] == "first body"));
+    assert!(history.iter().any(|entry| entry["body"] == "edited body"));
+
+    let deleted = json_output(&td.board(&[
+        "card",
+        "comment",
+        "delete",
+        &comment_id.to_string(),
+        "--yes",
+        "--json",
+    ]));
+    assert_eq!(deleted["deleted"], true);
+}
+
+#[test]
+fn nested_comment_json_errors_preserve_structured_rpc_fields() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("comment-error.sock");
+    let listener = UnixListener::bind(&socket).unwrap();
+    let server = std::thread::spawn(move || {
+        // `board card ...` opens its command client before dispatching the
+        // nested operation, so accept and close that unused connection first.
+        let (first, _) = listener.accept().unwrap();
+        drop(first);
+
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut line = String::new();
+        BufReader::new(stream.try_clone().unwrap())
+            .read_line(&mut line)
+            .unwrap();
+        let request: Request = serde_json::from_str(line.trim_end()).unwrap();
+
+        let response = Response::err_with_details(
+            request.id,
+            73,
+            Some("comment_forbidden"),
+            "comment belongs to another run",
+            Some(serde_json::json!({"comment_id": 41, "owner_run_id": 9})),
+        );
+        let mut wire = serde_json::to_string(&response).unwrap();
+        wire.push('\n');
+        stream.write_all(wire.as_bytes()).unwrap();
+        stream.flush().unwrap();
+    });
+
+    let out = Command::new(super::BOARD_BIN)
+        .args(["card", "comment", "edit", "41", "replacement", "--json"])
+        .current_dir(dir.path())
+        .env("BOARD_SOCKET", &socket)
+        .env("BOARD_DB", dir.path().join("board.db"))
+        .env("HERDR_BOARD_CONFIG", dir.path().join("missing-config.toml"))
+        .env("HOME", dir.path())
+        .env_remove("BOARD_SCOPE_PATH")
+        .env_remove("HERDR_PLUGIN_CONTEXT_JSON")
+        .env_remove("BOARD_RUN_ID")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    let error = json_error(&out);
+    assert_eq!(error["error"]["code"], 73);
+    assert_eq!(error["error"]["kind"], "comment_forbidden");
+    assert_eq!(
+        error["error"]["details"],
+        serde_json::json!({"comment_id": 41, "owner_run_id": 9})
+    );
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("comment operation"));
+}
+
+#[test]
+fn comment_mutations_enforce_agent_run_ownership_and_reject_system_comments() {
+    let td = TestDaemon::start(&[]);
+    let card_id = old_card(&td, "comment authorization");
+
+    let own = json_output(&td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "add",
+            &card_id.to_string(),
+            "own comment",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    ));
+    assert_eq!(own["author"], "agent:41");
+    let own_id = own["id"].as_i64().expect("own comment id");
+
+    let other = json_output(&td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "add",
+            &card_id.to_string(),
+            "other comment",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "42")],
+    ));
+    assert_eq!(other["author"], "agent:42");
+    let other_id = other["id"].as_i64().expect("other comment id");
+
+    let system = td
+        .client()
+        .comment_add(card_id, "system comment", Some("system"))
+        .unwrap();
+
+    let edited_own = json_output(&td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "edit",
+            &own_id.to_string(),
+            "edited by owner",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    ));
+    assert_eq!(edited_own["body"], "edited by owner");
+    assert_eq!(edited_own["author"], "agent:41");
+
+    let denied_edit = td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "edit",
+            &other_id.to_string(),
+            "illegally edited",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    );
+    let denied_edit = json_error(&denied_edit);
+    assert!(denied_edit["error"]["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("comment"));
+
+    let denied_delete = td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "delete",
+            &other_id.to_string(),
+            "--yes",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    );
+    json_error(&denied_delete);
+
+    let deleted_own = json_output(&td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "delete",
+            &own_id.to_string(),
+            "--yes",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    ));
+    assert_eq!(deleted_own["deleted"], true);
+
+    let human_edit = json_output(&td.board(&[
+        "card",
+        "comment",
+        "edit",
+        &other_id.to_string(),
+        "edited by human",
+        "--json",
+    ]));
+    assert_eq!(human_edit["body"], "edited by human");
+    assert_eq!(human_edit["author"], "agent:42");
+
+    let system_edit = td.board(&[
+        "card",
+        "comment",
+        "edit",
+        &system.id.to_string(),
+        "cannot edit system",
+        "--json",
+    ]);
+    json_error(&system_edit);
+
+    let system_delete = td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "delete",
+            &system.id.to_string(),
+            "--yes",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "41")],
+    );
+    json_error(&system_delete);
+
+    let detail = td.client().card_get(card_id).unwrap();
+    assert!(detail
+        .comments
+        .iter()
+        .any(|comment| { comment.id == other_id && comment.body == "edited by human" }));
+    assert!(!detail.comments.iter().any(|comment| comment.id == own_id));
+    assert!(detail
+        .comments
+        .iter()
+        .any(|comment| comment.id == system.id));
+}
+
+#[test]
+fn canonical_card_run_done_cancel_and_retry() {
+    let td = TestDaemon::start(&[("FAKE_AGENT_SLEEP", "10")]);
+    let mut client = td.client();
+    let todo = todo_id(&mut client);
+    let work = client
+        .column_create(&ColumnCreateParams {
+            name: "run-work".into(),
+            trigger: Some(Trigger::Auto),
+            ..Default::default()
+        })
+        .unwrap();
+    let card = client
+        .card_create(&CardCreateParams {
+            title: "run card".into(),
+            harness: Some("fake".into()),
+            column_id: Some(todo),
+            ..Default::default()
+        })
+        .unwrap();
+    client
+        .card_move(&board_core::protocol::CardMoveParams {
+            id: card.id,
+            column_id: work.id,
+            board_id: None,
+            position: None,
+        })
+        .unwrap();
+    assert!(poll(&mut client, 10, |c| {
+        c.card_get(card.id).unwrap().card.status == CardStatus::Running
+    }));
+
+    let done = json_output(&td.board(&[
+        "card",
+        "run",
+        "done",
+        &card.id.to_string(),
+        "--outcome",
+        "ok",
+        "--json",
+    ]));
+    assert_eq!(done["card"]["id"], card.id);
+
+    let retried = json_output(&td.board(&["card", "run", "retry", &card.id.to_string(), "--json"]));
+    assert_eq!(retried["card"]["id"], card.id);
+
+    assert!(poll(&mut client, 10, |c| {
+        c.card_get(card.id).unwrap().runs.len() >= 2
+    }));
+    let cancelled =
+        json_output(&td.board(&["card", "run", "cancel", &card.id.to_string(), "--json"]));
+    assert_eq!(cancelled["card"]["id"], card.id);
+}
+
+#[test]
+fn canonical_column_create_edit_reorder_and_delete_with_destination() {
+    let td = TestDaemon::start(&[]);
+
+    let created = json_output(&td.board(&[
+        "column",
+        "create",
+        "--name",
+        "Canonical review",
+        "--trigger",
+        "manual",
+        "--json",
+    ]));
+    let id = created["id"].as_i64().expect("column id");
+
+    let edited = json_output(&td.board(&[
+        "column",
+        "edit",
+        &id.to_string(),
+        "--name",
+        "Edited review",
+        "--json",
+    ]));
+    assert_eq!(edited["name"], "Edited review");
+
+    let reordered = json_output(&td.board(&["column", "reorder", &id.to_string(), "0", "--json"]));
+    assert!(reordered.is_array());
+
+    let mut client = td.client();
+    let scope_path = td._dir.path().canonicalize().unwrap();
+    let board_id = client
+        .board_open(scope_path.to_str().unwrap())
+        .unwrap()
+        .board
+        .id;
+    let mut source_params = col("source", Trigger::Manual);
+    source_params.board_id = Some(board_id);
+    let source = client.column_create(&source_params).unwrap();
+    let mut destination_params = col("destination", Trigger::Manual);
+    destination_params.board_id = Some(board_id);
+    let destination = client.column_create(&destination_params).unwrap();
+    let card = client
+        .card_create(&CardCreateParams {
+            board_id: Some(board_id),
+            title: "move before delete".into(),
+            column_id: Some(source.id),
+            ..Default::default()
+        })
+        .unwrap();
+    let delete_output = td.board(&[
+        "column",
+        "delete",
+        &source.id.to_string(),
+        "--move-cards-to",
+        &destination.id.to_string(),
+        "--yes",
+        "--json",
+    ]);
+    let deleted = json_output(&delete_output);
+    assert_eq!(deleted["deleted"], true);
+    assert_eq!(
+        td.client().card_get(card.id).unwrap().card.column_id,
+        destination.id
+    );
+}
+
+#[test]
+fn column_transition_targets_must_belong_to_the_current_board() {
+    let td = TestDaemon::start(&[]);
+    let alpha_path = td._dir.path().join("alpha");
+    let beta_path = td._dir.path().join("beta");
+    std::fs::create_dir_all(&alpha_path).unwrap();
+    std::fs::create_dir_all(&beta_path).unwrap();
+    let alpha_path = alpha_path.canonicalize().unwrap();
+    let beta_path = beta_path.canonicalize().unwrap();
+
+    let mut client = td.client();
+    let alpha = client
+        .board_open(alpha_path.to_str().unwrap())
+        .unwrap()
+        .board;
+    let beta = client
+        .board_open(beta_path.to_str().unwrap())
+        .unwrap()
+        .board;
+    let alpha_source = client
+        .column_create(&ColumnCreateParams {
+            board_id: Some(alpha.id),
+            name: "alpha source".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let beta_target = client
+        .column_create(&ColumnCreateParams {
+            board_id: Some(beta.id),
+            name: "beta target".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let rejected_create = td.board_in(
+        &alpha_path,
+        &[
+            "column",
+            "create",
+            "--name",
+            "must not exist",
+            "--on-success",
+            &beta_target.id.to_string(),
+            "--json",
+        ],
+    );
+    assert!(!rejected_create.status.success());
+    json_error(&rejected_create);
+
+    let alpha_after_create = client.board_get_by_id(alpha.id).unwrap();
+    assert!(!alpha_after_create
+        .columns
+        .iter()
+        .any(|column| column.name == "must not exist"));
+    let beta_after_create = client.board_get_by_id(beta.id).unwrap();
+    assert!(!beta_after_create
+        .columns
+        .iter()
+        .any(|column| column.name == "must not exist"));
+
+    let rejected_edit = td.board_in(
+        &alpha_path,
+        &[
+            "column",
+            "edit",
+            &alpha_source.id.to_string(),
+            "--on-success",
+            &beta_target.id.to_string(),
+            "--json",
+        ],
+    );
+    assert!(!rejected_edit.status.success());
+    json_error(&rejected_edit);
+
+    let alpha_after_edit = client.board_get_by_id(alpha.id).unwrap();
+    let source_after = alpha_after_edit
+        .columns
+        .iter()
+        .find(|column| column.id == alpha_source.id)
+        .unwrap();
+    assert_eq!(source_after.on_success_column_id, None);
+}
+
+#[test]
+fn column_edit_covers_all_settings_and_explicit_clears() {
+    let td = TestDaemon::start(&[]);
+    let mut client = td.client();
+    let scope_path = td._dir.path().canonicalize().unwrap();
+    let board_id = client
+        .board_open(scope_path.to_str().unwrap())
+        .unwrap()
+        .board
+        .id;
+    let mut success_params = col("success target", Trigger::Manual);
+    success_params.board_id = Some(board_id);
+    let success = client.column_create(&success_params).unwrap();
+    let mut failure_params = col("failure target", Trigger::Manual);
+    failure_params.board_id = Some(board_id);
+    let failure = client.column_create(&failure_params).unwrap();
+
+    let created = json_output(&td.board(&[
+        "column",
+        "create",
+        "--name",
+        "Configured stage",
+        "--prompt",
+        "run the configured stage",
+        "--trigger",
+        "auto",
+        "--on-success",
+        &success.id.to_string(),
+        "--on-fail",
+        &failure.id.to_string(),
+        "--harness",
+        "claude",
+        "--model",
+        "sonnet",
+        "--effort",
+        "low",
+        "--permission",
+        "acceptEdits",
+        "--timeout",
+        "12",
+        "--fresh-session",
+        "--json",
+    ]));
+    let id = created["id"].as_i64().expect("configured column id");
+    assert_eq!(created["system_prompt"], "run the configured stage");
+    assert_eq!(created["trigger"], "auto");
+    assert_eq!(created["on_success_column_id"], success.id);
+    assert_eq!(created["on_fail_column_id"], failure.id);
+    assert_eq!(created["harness_override"], "claude");
+    assert_eq!(created["model_override"], "sonnet");
+    assert_eq!(created["effort_override"], "low");
+    assert_eq!(created["permission_override"], "acceptEdits");
+    assert_eq!(created["timeout_minutes"], 12);
+    assert_eq!(created["fresh_session"], true);
+
+    let cleared = json_output(&td.board(&[
+        "column",
+        "edit",
+        &id.to_string(),
+        "--trigger",
+        "manual",
+        "--reuse-session",
+        "--clear-prompt",
+        "--clear-on-success",
+        "--clear-on-fail",
+        "--clear-harness",
+        "--clear-model",
+        "--clear-effort",
+        "--clear-permission",
+        "--clear-timeout",
+        "--json",
+    ]));
+    assert_eq!(cleared["trigger"], "manual");
+    assert_eq!(cleared["fresh_session"], false);
+    assert_eq!(cleared["system_prompt"], Value::Null);
+    assert_eq!(cleared["on_success_column_id"], Value::Null);
+    assert_eq!(cleared["on_fail_column_id"], Value::Null);
+    assert_eq!(cleared["harness_override"], Value::Null);
+    assert_eq!(cleared["model_override"], Value::Null);
+    assert_eq!(cleared["effort_override"], Value::Null);
+    assert_eq!(cleared["permission_override"], Value::Null);
+    assert_eq!(cleared["timeout_minutes"], Value::Null);
+}
+
+#[test]
+fn template_apply_is_a_canonical_command() {
+    let td = TestDaemon::start(&[]);
+    let result = json_output(&td.board(&["template", "apply", "pipeline", "--json"]));
+    let columns = result.as_array().expect("template result is columns");
+    assert!(columns.iter().any(|column| column["name"] == "Todo"));
+    assert!(columns.iter().any(|column| column["name"] == "Execute"));
+}
+
+#[test]
+fn card_delete_requires_yes_when_stdin_is_not_a_tty() {
+    let td = TestDaemon::start(&[]);
+    let id = old_card(&td, "must confirm");
+
+    let refused = td.board(&["card", "delete", &id.to_string()]);
+    assert!(
+        !refused.status.success(),
+        "non-TTY delete must require --yes"
+    );
+    assert!(
+        String::from_utf8_lossy(&refused.stderr).contains("--yes")
+            || String::from_utf8_lossy(&refused.stdout).contains("--yes")
+    );
+    assert!(
+        td.client().card_get(id).is_ok(),
+        "refused delete is non-mutating"
+    );
+
+    let deleted = json_output(&td.board(&["card", "delete", &id.to_string(), "--yes", "--json"]));
+    assert_eq!(deleted["deleted"], true);
+}
+
+#[test]
+fn board_version_reports_cli_and_daemon_versions_without_forcing_autostart() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket = dir.path().join("offline-boardd.sock");
+    let offline = Command::new(super::BOARD_BIN)
+        .args(["version", "--json"])
+        .env("BOARD_SOCKET", &socket)
+        .env("BOARD_DB", dir.path().join("board.db"))
+        .env("HERDR_BOARD_CONFIG", dir.path().join("missing-config.toml"))
+        .env("HOME", dir.path())
+        .env_remove("BOARD_SCOPE_PATH")
+        .env_remove("BOARD_RUN_ID")
+        .output()
+        .expect("run offline board version");
+    let offline = json_output(&offline);
+    assert_eq!(offline["cli_version"], env!("CARGO_PKG_VERSION"));
+    let offline_daemon = offline
+        .get("daemon_version")
+        .expect("offline version still reports daemon_version");
+    assert!(offline_daemon.is_null() || offline_daemon == "unavailable");
+    assert!(!socket.exists(), "board version must not autostart boardd");
+
+    let td = TestDaemon::start(&[]);
+    let online = json_output(&td.board(&["version", "--json"]));
+    assert_eq!(online["cli_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(online["daemon_version"], env!("CARGO_PKG_VERSION"));
+
+    // The daemon status command remains a separate operational probe.
+    let status = json_output(&td.board(&["daemon", "status", "--json"]));
+    assert_eq!(status["version"], env!("CARGO_PKG_VERSION"));
+    assert!(status.get("active_runs").is_some());
+}
+
+#[test]
+fn skill_prints_the_operational_skill_byte_for_byte() {
+    let out = Command::new(super::BOARD_BIN)
+        .arg("skill")
+        .output()
+        .expect("run board skill");
+    assert!(out.status.success());
+    assert!(out.stderr.is_empty());
+    assert_eq!(out.stdout, include_bytes!("../../../../skill/SKILL.md"));
+}
+
+#[test]
+fn json_errors_have_a_stable_code_and_message_shape() {
+    let td = TestDaemon::start(&[]);
+    let out = td.board(&["card", "show", "999999", "--json"]);
+    let error = json_error(&out);
+    assert_eq!(error["error"]["code"], 2);
+    assert!(error["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("999999"));
+}

--- a/crates/board-cli/tests/integration/compat.rs
+++ b/crates/board-cli/tests/integration/compat.rs
@@ -1,0 +1,101 @@
+use board_core::client::BoardClient;
+use board_core::protocol::{CardCreateParams, CardStatus, ColumnCreateParams, Trigger};
+
+use super::{poll, todo_id, TestDaemon};
+
+fn old_card(td: &TestDaemon, title: &str) -> i64 {
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        title,
+        "--harness",
+        "fake",
+        "--json",
+    ]);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&out.stdout).unwrap()["id"]
+        .as_i64()
+        .unwrap()
+}
+
+fn assert_json_success(out: std::process::Output) -> serde_json::Value {
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).expect("legacy alias should emit JSON")
+}
+
+#[test]
+fn top_level_comment_and_move_aliases_remain_supported() {
+    let td = TestDaemon::start(&[]);
+    let card_id = old_card(&td, "legacy aliases");
+
+    let comment = assert_json_success(td.board(&[
+        "comment",
+        &card_id.to_string(),
+        "legacy comment",
+        "--json",
+    ]));
+    assert_eq!(comment["card_id"], card_id);
+    assert_eq!(comment["body"], "legacy comment");
+
+    let moved = assert_json_success(td.board(&["move", &card_id.to_string(), "Todo", "--json"]));
+    assert_eq!(moved["id"], card_id);
+}
+
+#[test]
+fn top_level_done_cancel_and_retry_aliases_remain_supported() {
+    let td = TestDaemon::start(&[("FAKE_AGENT_SLEEP", "10")]);
+    let mut client = td.client();
+    let todo = todo_id(&mut client);
+    let work = client
+        .column_create(&ColumnCreateParams {
+            name: "legacy-work".into(),
+            trigger: Some(Trigger::Auto),
+            ..Default::default()
+        })
+        .unwrap();
+    let card = client
+        .card_create(&CardCreateParams {
+            title: "legacy run aliases".into(),
+            harness: Some("fake".into()),
+            column_id: Some(todo),
+            ..Default::default()
+        })
+        .unwrap();
+    client
+        .card_move(&board_core::protocol::CardMoveParams {
+            id: card.id,
+            column_id: work.id,
+            board_id: None,
+            position: None,
+        })
+        .unwrap();
+    assert!(poll(&mut client, 10, |c| {
+        c.card_get(card.id).unwrap().card.status == CardStatus::Running
+    }));
+
+    let comment =
+        assert_json_success(td.board(&["comment", &card.id.to_string(), "before done", "--json"]));
+    assert_eq!(comment["card_id"], card.id);
+
+    let done =
+        assert_json_success(td.board(&["done", &card.id.to_string(), "--outcome", "ok", "--json"]));
+    assert_eq!(done["card"]["id"], card.id);
+
+    let retry = assert_json_success(td.board(&["retry", &card.id.to_string(), "--json"]));
+    assert_eq!(retry["card"]["id"], card.id);
+    assert!(poll(&mut client, 10, |c| {
+        c.card_get(card.id).unwrap().runs.len() >= 2
+    }));
+
+    let cancel = assert_json_success(td.board(&["cancel", &card.id.to_string(), "--json"]));
+    assert_eq!(cancel["card"]["id"], card.id);
+}

--- a/crates/board-cli/tests/integration/support.rs
+++ b/crates/board-cli/tests/integration/support.rs
@@ -95,9 +95,26 @@ impl TestDaemon {
         self.board_in(self._dir.path(), args)
     }
 
+    pub(crate) fn board_with_env(
+        &self,
+        args: &[&str],
+        envs: &[(&str, &str)],
+    ) -> std::process::Output {
+        self.board_in_with_env(self._dir.path(), args, envs)
+    }
+
     pub(crate) fn board_in(&self, cwd: &std::path::Path, args: &[&str]) -> std::process::Output {
-        Command::new(BOARD_BIN)
-            .args(args)
+        self.board_in_with_env(cwd, args, &[])
+    }
+
+    pub(crate) fn board_in_with_env(
+        &self,
+        cwd: &std::path::Path,
+        args: &[&str],
+        envs: &[(&str, &str)],
+    ) -> std::process::Output {
+        let mut cmd = Command::new(BOARD_BIN);
+        cmd.args(args)
             .current_dir(cwd)
             .env("BOARD_SOCKET", &self.socket)
             .env("BOARD_DB", self._dir.path().join("board.db"))
@@ -105,9 +122,14 @@ impl TestDaemon {
             .env("HOME", self._dir.path())
             .env_remove("BOARD_SCOPE_PATH")
             .env_remove("HERDR_PLUGIN_CONTEXT_JSON")
-            .stdin(Stdio::null())
-            .output()
-            .expect("run board binary")
+            // A test process should be a human context unless it opts in
+            // explicitly below; do not inherit an agent's ambient identity.
+            .env_remove("BOARD_RUN_ID")
+            .stdin(Stdio::null());
+        for (key, value) in envs {
+            cmd.env(key, value);
+        }
+        cmd.output().expect("run board binary")
     }
 }
 

--- a/crates/board-core/src/client/fake.rs
+++ b/crates/board-core/src/client/fake.rs
@@ -5,11 +5,12 @@ use crate::db::{Db, FinalizeEffects, FinalizeRun, BOARD_ID};
 use crate::engine;
 
 use crate::protocol::{
-    BoardGetParams, BoardListResult, BoardOpenParams, BoardSnapshot, CardArchiveParams,
-    CardCreateParams, CardDetail, CardListParams, CardMoveParams, CardUpdateParams,
-    ColumnCreateParams, ColumnDeleteParams, ColumnReorderParams, ColumnUpdateParams,
-    CommentAddParams, DeletedResult, Event, RunActionResult, RunDoneParams, RunFocusParams,
-    RunFocusResult,
+    BoardGetParams, BoardListResult, BoardOpenParams, BoardRenameParams, BoardSnapshot,
+    CardArchiveParams, CardCreateParams, CardDetail, CardListParams, CardMoveParams,
+    CardUpdateParams, ColumnCreateParams, ColumnDeleteParams, ColumnReorderParams,
+    ColumnUpdateParams, CommentAddParams, CommentDeleteParams, CommentGetParams,
+    CommentHistoryParams, CommentUpdateParams, DeletedResult, Event, RunActionResult,
+    RunDoneParams, RunFocusParams, RunFocusResult,
 };
 
 use super::BoardClient;
@@ -19,6 +20,53 @@ use super::BoardClient;
 /// store — but there is no dispatch: moving into an auto column just moves.
 pub struct FakeBoardClient {
     db: Db,
+}
+
+/// Validate an agent actor exactly as the daemon does. The fake harness may
+/// invoke the board before its lifecycle row exists, so retain that narrow
+/// compatibility path only for fake cards with no open durable run.
+fn require_agent_run(db: &Db, actor_run_id: i64, card_id: i64, author: &str) -> anyhow::Result<()> {
+    let expected_author = format!("agent:{actor_run_id}");
+    if author != expected_author {
+        anyhow::bail!("agent run {actor_run_id} may only act as {expected_author}");
+    }
+
+    match db.get_run(actor_run_id) {
+        Ok(run) => {
+            if run.card_id != card_id {
+                anyhow::bail!("agent run {actor_run_id} does not belong to comment card {card_id}");
+            }
+            if run.ended_at.is_some() {
+                anyhow::bail!("agent run {actor_run_id} is no longer open");
+            }
+            Ok(())
+        }
+        Err(crate::Error::NotFound(_)) => {
+            let card = db
+                .get_card(card_id)?
+                .ok_or_else(|| anyhow::anyhow!("card {card_id} not found"))?;
+            if card.harness == "fake" && db.open_run_for_card(card_id)?.is_none() {
+                Ok(())
+            } else {
+                anyhow::bail!("run {actor_run_id} not found");
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn comment_for_mutation(
+    db: &Db,
+    id: i64,
+    actor_run_id: Option<i64>,
+) -> anyhow::Result<crate::model::CommentRecord> {
+    let comment = db
+        .get_comment(id)?
+        .ok_or_else(|| anyhow::anyhow!("comment {id} not found"))?;
+    if let Some(run_id) = actor_run_id {
+        require_agent_run(db, run_id, comment.card_id, &comment.author)?;
+    }
+    Ok(comment)
 }
 
 impl FakeBoardClient {
@@ -62,6 +110,10 @@ impl BoardClient for FakeBoardClient {
             "board.list" => serde_json::to_value(BoardListResult {
                 boards: db.list_boards()?,
             })?,
+            "board.rename" => {
+                let p: BoardRenameParams = serde_json::from_value(params)?;
+                serde_json::to_value(db.rename_board(p.board_id, &p.name)?)?
+            }
             "column.create" => {
                 let p: ColumnCreateParams = serde_json::from_value(params)?;
                 serde_json::to_value(db.create_column(&p)?)?
@@ -136,6 +188,9 @@ impl BoardClient for FakeBoardClient {
             "card.list" => {
                 let p: CardListParams = serde_json::from_value(params)?;
                 let board_id = p.board_id.unwrap_or(BOARD_ID);
+                let visibility = p
+                    .visibility
+                    .unwrap_or(crate::protocol::CardVisibility::Active);
                 let cards = match p.column_id {
                     Some(c) => {
                         let column = db
@@ -144,9 +199,9 @@ impl BoardClient for FakeBoardClient {
                         if column.board_id != board_id {
                             anyhow::bail!("column {c} belongs to another board");
                         }
-                        db.list_cards_in_column(c)?
+                        db.list_cards_in_column_visible(c, visibility)?
                     }
-                    None => db.list_cards(board_id)?,
+                    None => db.list_cards_visible(board_id, visibility)?,
                 };
                 serde_json::to_value(cards)?
             }
@@ -194,8 +249,41 @@ impl BoardClient for FakeBoardClient {
             }
             "comment.add" => {
                 let p: CommentAddParams = serde_json::from_value(params)?;
-                let author = p.author.as_deref().unwrap_or("user");
-                serde_json::to_value(db.add_comment(p.card_id, author, &p.body)?)?
+                let author = match p.actor_run_id {
+                    Some(run_id) => {
+                        let expected = format!("agent:{run_id}");
+                        if let Some(author) = p.author.as_deref() {
+                            require_agent_run(db, run_id, p.card_id, author)?;
+                        } else {
+                            require_agent_run(db, run_id, p.card_id, &expected)?;
+                        }
+                        expected
+                    }
+                    None => p.author.unwrap_or_else(|| "user".into()),
+                };
+                serde_json::to_value(db.add_comment(p.card_id, &author, &p.body)?)?
+            }
+            "comment.get" => {
+                let p: CommentGetParams = serde_json::from_value(params)?;
+                serde_json::to_value(
+                    db.get_comment(p.id)?
+                        .ok_or_else(|| anyhow::anyhow!("comment {} not found", p.id))?,
+                )?
+            }
+            "comment.update" => {
+                let p: CommentUpdateParams = serde_json::from_value(params)?;
+                comment_for_mutation(db, p.id, p.actor_run_id)?;
+                serde_json::to_value(db.update_comment(p.id, &p.body)?)?
+            }
+            "comment.delete" => {
+                let p: CommentDeleteParams = serde_json::from_value(params)?;
+                comment_for_mutation(db, p.id, p.actor_run_id)?;
+                db.soft_delete_comment(p.id)?;
+                serde_json::to_value(DeletedResult { deleted: true })?
+            }
+            "comment.history" => {
+                let p: CommentHistoryParams = serde_json::from_value(params)?;
+                serde_json::to_value(db.list_comment_history(p.id)?)?
             }
             other => anyhow::bail!("FakeBoardClient: unsupported method {other}"),
         };

--- a/crates/board-core/src/client/mod.rs
+++ b/crates/board-core/src/client/mod.rs
@@ -8,4 +8,4 @@ mod unix;
 #[cfg(feature = "fake-client")]
 pub use fake::FakeBoardClient;
 pub use traits::BoardClient;
-pub use unix::{EventStream, UnixClient};
+pub use unix::{BoardRpcError, EventStream, RpcClientError, RpcError, UnixClient};

--- a/crates/board-core/src/client/traits.rs
+++ b/crates/board-core/src/client/traits.rs
@@ -2,16 +2,17 @@ use serde_json::{json, Value};
 
 use crate::capability::HarnessCapabilities;
 
-use crate::model::{Card, Column, Comment};
+use crate::model::{Card, Column, Comment, CommentHistory, CommentRecord};
 
 use crate::protocol::{
-    BoardGetParams, BoardListResult, BoardOpenParams, BoardSnapshot, CardArchiveParams,
-    CardCreateParams, CardDetail, CardListParams, CardMoveParams, CardUpdateParams,
-    ColumnCreateParams, ColumnDeleteParams, ColumnReorderParams, ColumnUpdateParams,
-    CommentAddParams, DaemonStatus, DeletedResult, Event, HarnessCapabilitiesParams,
-    HarnessListResult, RunActionResult, RunCardParams, RunDoneParams, RunFocusParams,
-    RunFocusResult, RunOutcome, RunPaneExitedParams, SessionListResult, SpaceListParams,
-    SpaceListResult, StopResult, TemplateApplyParams,
+    BoardGetParams, BoardListResult, BoardOpenParams, BoardRenameParams, BoardSnapshot,
+    CardArchiveParams, CardCreateParams, CardDetail, CardListParams, CardMoveParams,
+    CardUpdateParams, CardVisibility, ColumnCreateParams, ColumnDeleteParams, ColumnReorderParams,
+    ColumnUpdateParams, CommentAddParams, CommentDeleteParams, CommentGetParams,
+    CommentHistoryParams, CommentUpdateParams, DaemonStatus, DeletedResult, Event,
+    HarnessCapabilitiesParams, HarnessListResult, RunActionResult, RunCardParams, RunDoneParams,
+    RunFocusParams, RunFocusResult, RunOutcome, RunPaneExitedParams, SessionListResult,
+    SpaceListParams, SpaceListResult, StopResult, TemplateApplyParams,
 };
 
 /// Blocking client to boardd. Object-safe so the TUI can hold `Box<dyn BoardClient>`.
@@ -59,6 +60,15 @@ pub trait BoardClient {
     }
     fn board_list(&mut self) -> anyhow::Result<BoardListResult> {
         Ok(serde_json::from_value(self.call("board.list", json!({}))?)?)
+    }
+    fn board_rename(&mut self, board_id: i64, name: &str) -> anyhow::Result<crate::model::Board> {
+        let p = BoardRenameParams {
+            board_id,
+            name: name.to_string(),
+        };
+        Ok(serde_json::from_value(
+            self.call("board.rename", serde_json::to_value(p)?)?,
+        )?)
     }
 
     fn harness_capabilities(&mut self, harness: &str) -> anyhow::Result<HarnessCapabilities> {
@@ -188,9 +198,25 @@ pub trait BoardClient {
         board_id: Option<i64>,
         column_id: Option<i64>,
     ) -> anyhow::Result<Vec<Card>> {
+        self.card_list_for_board_visible(board_id, column_id, None)
+    }
+    fn card_list_visible(
+        &mut self,
+        column_id: Option<i64>,
+        visibility: CardVisibility,
+    ) -> anyhow::Result<Vec<Card>> {
+        self.card_list_for_board_visible(None, column_id, Some(visibility))
+    }
+    fn card_list_for_board_visible(
+        &mut self,
+        board_id: Option<i64>,
+        column_id: Option<i64>,
+        visibility: Option<CardVisibility>,
+    ) -> anyhow::Result<Vec<Card>> {
         let p = CardListParams {
             board_id,
             column_id,
+            visibility,
         };
         Ok(serde_json::from_value(
             self.call("card.list", serde_json::to_value(p)?)?,
@@ -203,13 +229,61 @@ pub trait BoardClient {
         body: &str,
         author: Option<&str>,
     ) -> anyhow::Result<Comment> {
+        self.comment_add_for_run(card_id, body, author, None)
+    }
+    fn comment_add_for_run(
+        &mut self,
+        card_id: i64,
+        body: &str,
+        author: Option<&str>,
+        actor_run_id: Option<i64>,
+    ) -> anyhow::Result<Comment> {
         let p = CommentAddParams {
             card_id,
             body: body.to_string(),
             author: author.map(str::to_string),
+            actor_run_id,
         };
         Ok(serde_json::from_value(
             self.call("comment.add", serde_json::to_value(p)?)?,
+        )?)
+    }
+
+    fn comment_get(&mut self, id: i64) -> anyhow::Result<CommentRecord> {
+        let p = CommentGetParams { id };
+        Ok(serde_json::from_value(
+            self.call("comment.get", serde_json::to_value(p)?)?,
+        )?)
+    }
+    fn comment_update(
+        &mut self,
+        id: i64,
+        body: &str,
+        actor_run_id: Option<i64>,
+    ) -> anyhow::Result<CommentRecord> {
+        let p = CommentUpdateParams {
+            id,
+            body: body.to_string(),
+            actor_run_id,
+        };
+        Ok(serde_json::from_value(
+            self.call("comment.update", serde_json::to_value(p)?)?,
+        )?)
+    }
+    fn comment_delete(
+        &mut self,
+        id: i64,
+        actor_run_id: Option<i64>,
+    ) -> anyhow::Result<DeletedResult> {
+        let p = CommentDeleteParams { id, actor_run_id };
+        Ok(serde_json::from_value(
+            self.call("comment.delete", serde_json::to_value(p)?)?,
+        )?)
+    }
+    fn comment_history(&mut self, id: i64) -> anyhow::Result<Vec<CommentHistory>> {
+        let p = CommentHistoryParams { id };
+        Ok(serde_json::from_value(
+            self.call("comment.history", serde_json::to_value(p)?)?,
         )?)
     }
 

--- a/crates/board-core/src/client/unix.rs
+++ b/crates/board-core/src/client/unix.rs
@@ -4,11 +4,86 @@ use std::os::unix::net::UnixStream;
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::protocol::{Event, Request, Response};
+use crate::protocol::{Event, Request};
 
 use super::BoardClient;
+
+/// Structured error returned by boardd over the Unix RPC transport.
+///
+/// This is deliberately a public `std::error::Error` so callers retaining the
+/// existing `anyhow::Result` APIs can still downcast and render protocol
+/// failures without parsing an opaque display string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RpcClientError {
+    pub code: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl RpcClientError {
+    pub fn new(code: i32, kind: Option<String>, message: String, details: Option<Value>) -> Self {
+        Self {
+            code,
+            kind,
+            message,
+            details,
+        }
+    }
+
+    pub fn kind(&self) -> Option<&str> {
+        self.kind.as_deref()
+    }
+
+    pub fn details(&self) -> Option<&Value> {
+        self.details.as_ref()
+    }
+}
+
+impl std::fmt::Display for RpcClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "boardd error {}", self.code)?;
+        if let Some(kind) = &self.kind {
+            write!(f, " ({kind})")?;
+        }
+        write!(f, ": {}", self.message)?;
+        if let Some(details) = &self.details {
+            write!(f, " [{details}]")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for RpcClientError {}
+
+/// Compatibility aliases for callers that prefer a transport- or board-
+/// oriented name. All aliases downcast to the same concrete error.
+pub type BoardRpcError = RpcClientError;
+pub type RpcError = RpcClientError;
+
+#[derive(Debug, Deserialize)]
+struct WireResponse {
+    id: String,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<WireRpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WireRpcError {
+    code: i32,
+    #[serde(default)]
+    kind: Option<String>,
+    message: String,
+    #[serde(default)]
+    details: Option<Value>,
+}
 
 /// The real Unix-socket client.
 pub struct UnixClient {
@@ -56,7 +131,7 @@ impl BoardClient for UnixClient {
                 anyhow::bail!("boardd connection closed");
             }
             // Skip anything that isn't a matching response (e.g. event lines).
-            let resp: Response = match serde_json::from_str(buf.trim_end()) {
+            let resp: WireResponse = match serde_json::from_str(buf.trim_end()) {
                 Ok(r) => r,
                 Err(_) => continue,
             };
@@ -64,7 +139,12 @@ impl BoardClient for UnixClient {
                 continue;
             }
             if let Some(err) = resp.error {
-                anyhow::bail!("boardd error {}: {}", err.code, err.message);
+                return Err(anyhow::Error::new(RpcClientError::new(
+                    err.code,
+                    err.kind,
+                    err.message,
+                    err.details,
+                )));
             }
             return Ok(resp.result.unwrap_or(Value::Null));
         }

--- a/crates/board-core/src/db/boards_columns.rs
+++ b/crates/board-core/src/db/boards_columns.rs
@@ -1,7 +1,7 @@
-use rusqlite::params;
+use rusqlite::{params, OptionalExtension};
 
 use super::rows;
-use super::{Db, BOARD_ID};
+use super::{ColumnTarget, ColumnWiring, Db, BOARD_ID};
 use crate::model::{Board, Column};
 use crate::protocol::{ColumnCreateParams, ColumnUpdateParams, Patch, Trigger};
 use crate::{Error, Result};
@@ -20,6 +20,19 @@ impl Db {
                 rusqlite::Error::QueryReturnedNoRows => Error::NotFound(format!("board {id}")),
                 other => Error::Sqlite(other),
             })
+    }
+
+    /// Rename a board without changing its id, scope identity, columns, or
+    /// cards. SQLite's existing UNIQUE constraint remains the final guard
+    /// against duplicate names.
+    pub fn rename_board(&self, id: i64, name: &str) -> Result<Board> {
+        if name.trim().is_empty() {
+            return Err(Error::BadRequest("board name must not be empty".into()));
+        }
+        self.get_board(id)?;
+        self.conn
+            .execute("UPDATE boards SET name=?1 WHERE id=?2", params![name, id])?;
+        self.get_board(id)
     }
 
     pub fn list_boards(&self) -> Result<Vec<Board>> {
@@ -232,29 +245,132 @@ impl Db {
         Ok(())
     }
 
+    /// Create a set of columns and wire their transitions as one database
+    /// unit of work. The targets may refer to columns already on the board or
+    /// to another column in this batch. This is deliberately a DB-only
+    /// boundary: callers must do validation and all external I/O before it.
+    pub fn apply_template_columns_uow(
+        &self,
+        board_id: i64,
+        specs: &[ColumnCreateParams],
+        wiring: &[ColumnWiring],
+    ) -> Result<Vec<Column>> {
+        self.get_board(board_id)?;
+        for spec in specs {
+            if spec.board_id.unwrap_or(BOARD_ID) != board_id {
+                return Err(Error::InvalidState(format!(
+                    "column belongs to another board, expected {board_id}"
+                )));
+            }
+            if spec.position.is_some() {
+                return Err(Error::BadRequest(
+                    "template columns cannot specify positions".into(),
+                ));
+            }
+        }
+
+        let tx = self.conn.unchecked_transaction()?;
+        let mut ids = Vec::with_capacity(specs.len());
+        for spec in specs {
+            let position: i64 = tx.query_row(
+                "SELECT COALESCE(MAX(position)+1, 0) FROM columns WHERE board_id=?1",
+                params![board_id],
+                |row| row.get(0),
+            )?;
+            let trigger = spec.trigger.unwrap_or(Trigger::Manual).as_str();
+            let fresh = i64::from(spec.fresh_session.unwrap_or(false));
+            tx.execute(
+                "INSERT INTO columns
+                 (board_id,name,position,system_prompt,trigger,on_success_column_id,on_fail_column_id,
+                  fresh_session,harness_override,model_override,effort_override,permission_override,timeout_minutes)
+                 VALUES (?1,?2,?3,?4,?5,NULL,NULL,?6,?7,?8,?9,?10,?11)",
+                params![
+                    board_id,
+                    spec.name,
+                    position,
+                    spec.system_prompt,
+                    trigger,
+                    fresh,
+                    spec.harness_override,
+                    spec.model_override,
+                    spec.effort_override,
+                    spec.permission_override,
+                    spec.timeout_minutes,
+                ],
+            )?;
+            ids.push(tx.last_insert_rowid());
+        }
+
+        let resolve = |target: Option<ColumnTarget>| -> Result<Option<i64>> {
+            let Some(target) = target else {
+                return Ok(None);
+            };
+            let id = match target {
+                ColumnTarget::Created(index) => ids.get(index).copied().ok_or_else(|| {
+                    Error::BadRequest(format!("template target index {index} is out of range"))
+                })?,
+                ColumnTarget::Existing(id) => {
+                    let target_board: Option<i64> = tx
+                        .query_row(
+                            "SELECT board_id FROM columns WHERE id=?1",
+                            params![id],
+                            |row| row.get(0),
+                        )
+                        .optional()?;
+                    let target_board =
+                        target_board.ok_or_else(|| Error::NotFound(format!("column {id}")))?;
+                    if target_board != board_id {
+                        return Err(Error::InvalidState(format!(
+                            "column {id} belongs to board {target_board}, expected {board_id}"
+                        )));
+                    }
+                    id
+                }
+            };
+            Ok(Some(id))
+        };
+
+        for wire in wiring {
+            let column_id = ids.get(wire.column_index).copied().ok_or_else(|| {
+                Error::BadRequest(format!(
+                    "template source index {} is out of range",
+                    wire.column_index
+                ))
+            })?;
+            let on_success = resolve(wire.on_success)?;
+            let on_fail = resolve(wire.on_fail)?;
+            tx.execute(
+                "UPDATE columns SET on_success_column_id=?1,on_fail_column_id=?2 WHERE id=?3",
+                params![on_success, on_fail, column_id],
+            )?;
+        }
+        tx.commit()?;
+        self.list_columns(board_id)
+    }
+
     /// Move a column to `position` and compact the whole board's ordering.
     pub fn reorder_column(&self, id: i64, position: i64) -> Result<Vec<Column>> {
         let board_id = self.require_column(id)?.board_id;
-        let mut ids: Vec<i64> = self
-            .conn
+        let tx = self.conn.unchecked_transaction()?;
+        let mut ids: Vec<i64> = tx
             .prepare("SELECT id FROM columns WHERE board_id=?1 AND id<>?2 ORDER BY position, id")?
             .query_map(params![board_id, id], |r| r.get(0))?
             .collect::<rusqlite::Result<_>>()?;
         let idx = (position.max(0) as usize).min(ids.len());
         ids.insert(idx, id);
         for (i, cid) in ids.iter().enumerate() {
-            self.conn.execute(
+            tx.execute(
                 "UPDATE columns SET position=?1 WHERE id=?2",
                 params![i as i64, cid],
             )?;
         }
+        tx.commit()?;
         self.list_columns(board_id)
     }
 
     /// Delete a column, optionally moving its cards to `move_cards_to` first.
     /// Callers should validate with the engine beforehand.
     pub fn delete_column(&self, id: i64, move_cards_to: Option<i64>) -> Result<()> {
-        let tx = self.conn.unchecked_transaction()?;
         let board_id = self.require_column(id)?.board_id;
         if let Some(dst) = move_cards_to {
             let destination = self.require_column(dst)?;
@@ -263,25 +379,29 @@ impl Db {
                     "destination column {dst} belongs to another board"
                 )));
             }
-            let card_ids: Vec<i64> = self
-                .conn
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        if let Some(dst) = move_cards_to {
+            let card_ids: Vec<i64> = tx
                 .prepare("SELECT id FROM cards WHERE column_id=?1 ORDER BY position, id")?
                 .query_map(params![id], |r| r.get(0))?
                 .collect::<rusqlite::Result<_>>()?;
             for cid in card_ids {
-                self.move_card(cid, dst, None)?;
+                tx.execute(
+                    "UPDATE cards SET column_id=?1, updated_at=datetime('now') WHERE id=?2",
+                    params![dst, cid],
+                )?;
+                Db::place_card_in_column_tx(&tx, cid, dst, None)?;
             }
         }
-        self.conn
-            .execute("DELETE FROM columns WHERE id=?1", params![id])?;
+        tx.execute("DELETE FROM columns WHERE id=?1", params![id])?;
         // Compact remaining columns.
-        let ids: Vec<i64> = self
-            .conn
+        let ids: Vec<i64> = tx
             .prepare("SELECT id FROM columns WHERE board_id=?1 ORDER BY position, id")?
             .query_map(params![board_id], |r| r.get(0))?
             .collect::<rusqlite::Result<_>>()?;
         for (i, cid) in ids.iter().enumerate() {
-            self.conn.execute(
+            tx.execute(
                 "UPDATE columns SET position=?1 WHERE id=?2",
                 params![i as i64, cid],
             )?;

--- a/crates/board-core/src/db/cards_comments.rs
+++ b/crates/board-core/src/db/cards_comments.rs
@@ -1,23 +1,65 @@
 use rusqlite::{params, OptionalExtension};
 
 use super::rows;
-use super::{Db, BOARD_ID};
-use crate::model::{Card, Comment};
+use super::{Db, EnqueueRun, BOARD_ID};
+use crate::model::{Card, Comment, CommentHistory, CommentRecord};
 use crate::protocol::{
-    AwaitingReason, CardCreateParams, CardStatus, CardUpdateParams, Effort, Patch, SpaceKind,
+    AwaitingReason, CardCreateParams, CardDetail, CardStatus, CardUpdateParams, CardVisibility,
+    Effort, Patch, SpaceKind,
 };
 use crate::{Error, Result};
 
 impl Db {
     // -- cards ---------------------------------------------------------------
 
+    /// List every card on a board for board snapshots, including archived
+    /// cards. Callers that expose an archive filter should use
+    /// [`Self::list_cards_visible`] explicitly.
     pub fn list_cards(&self, board_id: i64) -> Result<Vec<Card>> {
-        let mut stmt = self.conn.prepare(
+        self.list_cards_visible(board_id, CardVisibility::All)
+    }
+
+    /// List cards in one board according to an explicit archive visibility.
+    pub fn list_cards_visible(
+        &self,
+        board_id: i64,
+        visibility: CardVisibility,
+    ) -> Result<Vec<Card>> {
+        let archived_clause = match visibility {
+            CardVisibility::Active => "AND c.archived_at IS NULL",
+            CardVisibility::All => "",
+            CardVisibility::Archived => "AND c.archived_at IS NOT NULL",
+        };
+        let sql = format!(
             "SELECT c.* FROM cards c JOIN columns col ON col.id=c.column_id
-             WHERE c.board_id=?1 ORDER BY col.position, c.position, c.id",
-        )?;
+             WHERE c.board_id=?1 {archived_clause}
+             ORDER BY col.position, c.position, c.id"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt
             .query_map(params![board_id], rows::row_to_card)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Column-scoped equivalent used by card-list filters. Internal lifecycle
+    /// callers can continue using [`Self::list_cards_in_column`] for all rows.
+    pub fn list_cards_in_column_visible(
+        &self,
+        column_id: i64,
+        visibility: CardVisibility,
+    ) -> Result<Vec<Card>> {
+        let archived_clause = match visibility {
+            CardVisibility::Active => "AND archived_at IS NULL",
+            CardVisibility::All => "",
+            CardVisibility::Archived => "AND archived_at IS NOT NULL",
+        };
+        let sql = format!(
+            "SELECT * FROM cards WHERE column_id=?1 {archived_clause} ORDER BY position, id"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map(params![column_id], rows::row_to_card)?
             .collect::<rusqlite::Result<Vec<_>>>()?;
         Ok(rows)
     }
@@ -111,6 +153,74 @@ impl Db {
             self.move_card(id, column_id, Some(pos))?;
         }
         self.require_card(id)
+    }
+
+    /// Create a card and its initial queued run in one transaction. The run's
+    /// `card_id` is replaced with the newly allocated card id; all other run
+    /// fields are supplied by the caller after any pure preparation has
+    /// completed. No external I/O belongs in this unit of work.
+    pub fn create_card_and_enqueue_uow(
+        &self,
+        p: &CardCreateParams,
+        run: &EnqueueRun<'_>,
+    ) -> Result<(Card, crate::model::Run)> {
+        let board_id = p.board_id.unwrap_or(BOARD_ID);
+        self.get_board(board_id)?;
+        let column_id = p.column_id.unwrap_or(self.default_column_id(board_id)?);
+        let column = self.require_column(column_id)?;
+        if column.board_id != board_id {
+            return Err(Error::InvalidState(format!(
+                "column {column_id} belongs to board {}, expected {board_id}",
+                column.board_id
+            )));
+        }
+        if run.column_id != column_id {
+            return Err(Error::InvalidState(
+                "queued run column does not match new card column".into(),
+            ));
+        }
+
+        let end: i64 = self.conn.query_row(
+            "SELECT COALESCE(MAX(position)+1, 0) FROM cards WHERE column_id=?1",
+            params![column_id],
+            |r| r.get(0),
+        )?;
+        let description = p.description.clone().unwrap_or_default();
+        let harness = p
+            .harness
+            .clone()
+            .unwrap_or_else(|| crate::harness::DEFAULT_HARNESS.to_string());
+        let space_kind = p.space_kind.unwrap_or(SpaceKind::Workspace).as_str();
+        let effort = p.effort.map(|e| e.as_str());
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "INSERT INTO cards
+             (board_id,column_id,position,title,description,harness,model,effort,permission_mode,
+              session,space_kind,space_ref,space_cwd,status,session_id)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,'idle',NULL)",
+            params![
+                board_id,
+                column_id,
+                end,
+                p.title,
+                description,
+                harness,
+                p.model,
+                effort,
+                p.permission_mode,
+                p.session,
+                space_kind,
+                p.space_ref,
+                p.space_cwd,
+            ],
+        )?;
+        let card_id = tx.last_insert_rowid();
+        if p.position.is_some() {
+            Self::place_card_in_column_tx(&tx, card_id, column_id, p.position)?;
+        }
+        let run_id = self.enqueue_run_tx(&tx, card_id, run)?;
+        tx.commit()?;
+        Ok((self.require_card(card_id)?, self.get_run(run_id)?))
     }
 
     pub fn update_card(&self, p: &CardUpdateParams) -> Result<Card> {
@@ -220,15 +330,99 @@ impl Db {
             )));
         }
         let old_column = card.column_id;
-        self.conn.execute(
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
             "UPDATE cards SET column_id=?1, updated_at=datetime('now') WHERE id=?2",
             params![target_column, id],
         )?;
-        self.place_card_in_column(id, target_column, position)?;
+        Self::place_card_in_column_tx(&tx, id, target_column, position)?;
         if old_column != target_column {
-            self.renumber_column_cards(old_column)?;
+            Self::renumber_column_cards_tx(&tx, old_column)?;
         }
+        tx.commit()?;
         self.require_card(id)
+    }
+
+    /// Move a card and enqueue its next run in one transaction. The caller
+    /// prepares all run values before entering this DB-only unit of work.
+    pub fn move_card_and_enqueue_uow(
+        &self,
+        id: i64,
+        target_column: i64,
+        position: Option<i64>,
+        run: &EnqueueRun<'_>,
+    ) -> Result<(Card, crate::model::Run)> {
+        let card = self.require_card(id)?;
+        let target = self.require_column(target_column)?;
+        if target.board_id != card.board_id {
+            return Err(Error::InvalidState(format!(
+                "column {target_column} belongs to board {}, card {id} belongs to board {}",
+                target.board_id, card.board_id
+            )));
+        }
+        if run.card_id != id || run.column_id != target_column {
+            return Err(Error::InvalidState(
+                "queued run does not match moved card and destination column".into(),
+            ));
+        }
+        if self.open_run_for_card(id)?.is_some() {
+            return Err(Error::InvalidState("card already has an open run".into()));
+        }
+
+        let old_column = card.column_id;
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "UPDATE cards SET column_id=?1, updated_at=datetime('now') WHERE id=?2",
+            params![target_column, id],
+        )?;
+        Self::place_card_in_column_tx(&tx, id, target_column, position)?;
+        if old_column != target_column {
+            Self::renumber_column_cards_tx(&tx, old_column)?;
+        }
+        let run_id = self.enqueue_run_tx(&tx, id, run)?;
+        tx.commit()?;
+        Ok((self.require_card(id)?, self.get_run(run_id)?))
+    }
+
+    /// Transfer a card and enqueue its next run in one transaction. This is
+    /// the cross-board counterpart to [`Self::move_card_and_enqueue_uow`].
+    pub fn transfer_card_and_enqueue_uow(
+        &self,
+        id: i64,
+        target_board: i64,
+        target_column: i64,
+        position: Option<i64>,
+        run: &EnqueueRun<'_>,
+    ) -> Result<(Card, crate::model::Run)> {
+        let card = self.require_card(id)?;
+        self.get_board(target_board)?;
+        let target = self.require_column(target_column)?;
+        if target.board_id != target_board {
+            return Err(Error::InvalidState(format!(
+                "column {target_column} belongs to board {}, declared destination board is {target_board}",
+                target.board_id
+            )));
+        }
+        if run.card_id != id || run.column_id != target_column {
+            return Err(Error::InvalidState(
+                "queued run does not match moved card and destination column".into(),
+            ));
+        }
+        if self.open_run_for_card(id)?.is_some() {
+            return Err(Error::InvalidState("card already has an open run".into()));
+        }
+
+        let old_column = card.column_id;
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "UPDATE cards SET board_id=?1, column_id=?2, updated_at=datetime('now') WHERE id=?3",
+            params![target_board, target_column, id],
+        )?;
+        Self::place_card_in_column_tx(&tx, id, target_column, position)?;
+        Self::renumber_column_cards_tx(&tx, old_column)?;
+        let run_id = self.enqueue_run_tx(&tx, id, run)?;
+        tx.commit()?;
+        Ok((self.require_card(id)?, self.get_run(run_id)?))
     }
 
     /// Transfer a card to `target_column` (which must belong to `target_board`)
@@ -254,12 +448,12 @@ impl Db {
             )));
         }
         let old_column = card.column_id;
-        self.conn.execute(
+        tx.execute(
             "UPDATE cards SET board_id=?1, column_id=?2, updated_at=datetime('now') WHERE id=?3",
             params![target_board, target_column, id],
         )?;
-        self.place_card_in_column(id, target_column, position)?;
-        self.renumber_column_cards(old_column)?;
+        Self::place_card_in_column_tx(&tx, id, target_column, position)?;
+        Self::renumber_column_cards_tx(&tx, old_column)?;
         tx.commit()?;
         self.require_card(id)
     }
@@ -267,14 +461,13 @@ impl Db {
     /// (Re)place `id` within `target_column` at `position` (append if `None`),
     /// zero-basing every card's position in that column. Shared by move and
     /// transfer. Caller must already have set the card's `column_id`.
-    fn place_card_in_column(
-        &self,
+    pub(super) fn place_card_in_column_tx(
+        tx: &rusqlite::Transaction<'_>,
         id: i64,
         target_column: i64,
         position: Option<i64>,
     ) -> Result<()> {
-        let mut ids: Vec<i64> = self
-            .conn
+        let mut ids: Vec<i64> = tx
             .prepare("SELECT id FROM cards WHERE column_id=?1 AND id<>?2 ORDER BY position, id")?
             .query_map(params![target_column, id], |r| r.get(0))?
             .collect::<rusqlite::Result<_>>()?;
@@ -284,7 +477,24 @@ impl Db {
             .min(ids.len());
         ids.insert(idx, id);
         for (i, cid) in ids.iter().enumerate() {
-            self.conn.execute(
+            tx.execute(
+                "UPDATE cards SET position=?1 WHERE id=?2",
+                params![i as i64, cid],
+            )?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn renumber_column_cards_tx(
+        tx: &rusqlite::Transaction<'_>,
+        column_id: i64,
+    ) -> Result<()> {
+        let ids: Vec<i64> = tx
+            .prepare("SELECT id FROM cards WHERE column_id=?1 ORDER BY position, id")?
+            .query_map(params![column_id], |r| r.get(0))?
+            .collect::<rusqlite::Result<_>>()?;
+        for (i, cid) in ids.iter().enumerate() {
+            tx.execute(
                 "UPDATE cards SET position=?1 WHERE id=?2",
                 params![i as i64, cid],
             )?;
@@ -293,17 +503,9 @@ impl Db {
     }
 
     pub(super) fn renumber_column_cards(&self, column_id: i64) -> Result<()> {
-        let ids: Vec<i64> = self
-            .conn
-            .prepare("SELECT id FROM cards WHERE column_id=?1 ORDER BY position, id")?
-            .query_map(params![column_id], |r| r.get(0))?
-            .collect::<rusqlite::Result<_>>()?;
-        for (i, cid) in ids.iter().enumerate() {
-            self.conn.execute(
-                "UPDATE cards SET position=?1 WHERE id=?2",
-                params![i as i64, cid],
-            )?;
-        }
+        let tx = self.conn.unchecked_transaction()?;
+        Self::renumber_column_cards_tx(&tx, column_id)?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -422,10 +624,104 @@ impl Db {
         .ok_or_else(|| Error::NotFound(format!("comment {id}")))
     }
 
-    pub fn list_comments(&self, card_id: i64) -> Result<Vec<Comment>> {
+    /// Get a comment's current row, including a soft-deletion marker. Unlike
+    /// [`Self::list_comments`], this deliberately includes deleted records.
+    pub fn get_comment(&self, id: i64) -> Result<Option<CommentRecord>> {
+        rows::opt(self.conn.query_row(
+            "SELECT * FROM comments WHERE id=?1",
+            params![id],
+            rows::row_to_comment_record,
+        ))
+    }
+
+    /// Edit a user/agent comment while retaining its original owner. Every
+    /// successful edit appends a snapshot; system comments are immutable at the
+    /// store boundary regardless of which caller invokes this method.
+    pub fn update_comment(&self, id: i64, body: &str) -> Result<CommentRecord> {
+        let current = self
+            .get_comment(id)?
+            .ok_or_else(|| Error::NotFound(format!("comment {id}")))?;
+        if current.author == "system" {
+            return Err(Error::InvalidState("system comments are immutable".into()));
+        }
+        if current.deleted_at.is_some() {
+            return Err(Error::InvalidState("deleted comments are immutable".into()));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        let changed = tx.execute(
+            "UPDATE comments SET body=?1 WHERE id=?2 AND deleted_at IS NULL",
+            params![body, id],
+        )?;
+        if changed != 1 {
+            return Err(Error::NotFound(format!("comment {id}")));
+        }
+        tx.execute(
+            "INSERT INTO comment_history(comment_id,card_id,author,body,created_at,deleted_at)
+             VALUES(?1,?2,?3,?4,datetime('now'),NULL)",
+            params![id, current.card_id, current.author, body],
+        )?;
+        tx.commit()?;
+        self.get_comment(id)?
+            .ok_or_else(|| Error::NotFound(format!("comment {id}")))
+    }
+
+    /// Soft-delete a user/agent comment and mark its latest audit snapshot.
+    pub fn soft_delete_comment(&self, id: i64) -> Result<CommentRecord> {
+        let current = self
+            .get_comment(id)?
+            .ok_or_else(|| Error::NotFound(format!("comment {id}")))?;
+        if current.author == "system" {
+            return Err(Error::InvalidState("system comments are immutable".into()));
+        }
+        if current.deleted_at.is_some() {
+            return Err(Error::InvalidState("comment is already deleted".into()));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "UPDATE comments SET deleted_at=datetime('now') WHERE id=?1",
+            params![id],
+        )?;
+        tx.execute(
+            "UPDATE comment_history SET deleted_at=datetime('now')
+             WHERE id=(SELECT MAX(id) FROM comment_history WHERE comment_id=?1)",
+            params![id],
+        )?;
+        tx.commit()?;
+        self.get_comment(id)?
+            .ok_or_else(|| Error::NotFound(format!("comment {id}")))
+    }
+
+    /// Return immutable snapshots from creation through the current edit.
+    /// Deletion annotates the final snapshot rather than adding a duplicate
+    /// body, keeping the history a state timeline.
+    pub fn list_comment_history(&self, comment_id: i64) -> Result<Vec<CommentHistory>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT * FROM comments WHERE card_id=?1 ORDER BY created_at, id")?;
+            .prepare("SELECT * FROM comment_history WHERE comment_id=?1 ORDER BY id")?;
+        let rows = stmt
+            .query_map(params![comment_id], rows::row_to_comment_history)?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows)
+    }
+
+    /// Card detail uses the ordinary current-comment projection, so deleted
+    /// comments never leak into prompts or normal card views.
+    pub fn get_card_detail(&self, id: i64) -> Result<CardDetail> {
+        let card = self
+            .get_card(id)?
+            .ok_or_else(|| Error::NotFound(format!("card {id}")))?;
+        Ok(CardDetail {
+            card,
+            comments: self.list_comments(id)?,
+            runs: self.list_runs(id)?,
+        })
+    }
+
+    pub fn list_comments(&self, card_id: i64) -> Result<Vec<Comment>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT * FROM comments
+             WHERE card_id=?1 AND deleted_at IS NULL ORDER BY created_at, id",
+        )?;
         let rows = stmt
             .query_map(params![card_id], rows::row_to_comment)?
             .collect::<rusqlite::Result<Vec<_>>>()?;

--- a/crates/board-core/src/db/migrations.rs
+++ b/crates/board-core/src/db/migrations.rs
@@ -8,7 +8,7 @@ use crate::{Error, Result};
 const SCHEMA_SQL: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../schema.sql"));
 
 /// The latest schema version embedded in [`SCHEMA_SQL`].
-const SCHEMA_VERSION: i64 = 12;
+const SCHEMA_VERSION: i64 = 13;
 
 /// v1 → v2 migration. SQLite cannot alter a CHECK constraint or drop a column
 /// in place, so `cards` is rebuilt. Legacy `space_kind` values `cwd`/`worktree`
@@ -208,6 +208,31 @@ const V11_MIGRATION_SQL: &str = "ALTER TABLE runs ADD COLUMN launch_spec_json TE
 /// Existing runs remain NULL because their launch never recorded an anchor.
 const V12_MIGRATION_SQL: &str = "ALTER TABLE runs ADD COLUMN herdr_anchor_pane_id TEXT";
 
+/// v12 → v13: retain current comment identity while adding soft deletion and
+/// immutable audit snapshots. Existing rows seed the initial snapshot before
+/// the insert trigger is installed for future comment writers.
+const V13_MIGRATION_SQL: &str = "
+ALTER TABLE comments ADD COLUMN deleted_at TEXT;
+CREATE TABLE comment_history (
+  id         INTEGER PRIMARY KEY,
+  comment_id INTEGER NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  card_id    INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+  author     TEXT NOT NULL,
+  body       TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT
+);
+INSERT INTO comment_history(comment_id,card_id,author,body,created_at,deleted_at)
+  SELECT id,card_id,author,body,created_at,deleted_at FROM comments;
+CREATE INDEX idx_comment_history_comment ON comment_history(comment_id, id);
+CREATE TRIGGER comments_audit_insert
+AFTER INSERT ON comments
+BEGIN
+  INSERT INTO comment_history(comment_id,card_id,author,body,created_at,deleted_at)
+  VALUES(NEW.id,NEW.card_id,NEW.author,NEW.body,NEW.created_at,NEW.deleted_at);
+END;
+";
+
 impl Db {
     /// Apply migrations gated on `PRAGMA user_version`. Idempotent.
     ///
@@ -366,6 +391,56 @@ impl Db {
                 )?;
                 if !has_anchor {
                     tx.execute_batch(V12_MIGRATION_SQL)?;
+                }
+            }
+            if version < 13 {
+                let has_deleted_at: bool = tx.query_row(
+                    "SELECT EXISTS(SELECT 1 FROM pragma_table_info('comments') WHERE name='deleted_at')",
+                    [],
+                    |r| r.get(0),
+                )?;
+                if !has_deleted_at {
+                    tx.execute_batch(V13_MIGRATION_SQL)?;
+                } else {
+                    // Complete a partially applied shape without duplicating
+                    // an already-created table or trigger.
+                    let has_history: bool = tx.query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                         WHERE type='table' AND name='comment_history')",
+                        [],
+                        |r| r.get(0),
+                    )?;
+                    if !has_history {
+                        tx.execute_batch(
+                            "CREATE TABLE comment_history (
+                               id INTEGER PRIMARY KEY,
+                               comment_id INTEGER NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+                               card_id INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+                               author TEXT NOT NULL, body TEXT NOT NULL,
+                               created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                               deleted_at TEXT
+                             );
+                             INSERT INTO comment_history(comment_id,card_id,author,body,created_at,deleted_at)
+                               SELECT id,card_id,author,body,created_at,deleted_at FROM comments;
+                             CREATE INDEX idx_comment_history_comment ON comment_history(comment_id,id);",
+                        )?;
+                    }
+                    let has_trigger: bool = tx.query_row(
+                        "SELECT EXISTS(SELECT 1 FROM sqlite_master
+                         WHERE type='trigger' AND name='comments_audit_insert')",
+                        [],
+                        |r| r.get(0),
+                    )?;
+                    if !has_trigger {
+                        tx.execute_batch(
+                            "CREATE TRIGGER comments_audit_insert
+                             AFTER INSERT ON comments
+                             BEGIN
+                               INSERT INTO comment_history(comment_id,card_id,author,body,created_at,deleted_at)
+                               VALUES(NEW.id,NEW.card_id,NEW.author,NEW.body,NEW.created_at,NEW.deleted_at);
+                             END;",
+                        )?;
+                    }
                 }
             }
             tx.pragma_update(None, "user_version", SCHEMA_VERSION)?;

--- a/crates/board-core/src/db/mod.rs
+++ b/crates/board-core/src/db/mod.rs
@@ -41,6 +41,23 @@ pub struct EnqueueRun<'a> {
     pub session: Option<&'a str>,
 }
 
+/// A target used by [`Db::apply_template_columns_uow`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnTarget {
+    /// A column that already exists on the board.
+    Existing(i64),
+    /// A column in the batch, addressed by its zero-based input index.
+    Created(usize),
+}
+
+/// One transition wiring update in [`Db::apply_template_columns_uow`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnWiring {
+    pub column_index: usize,
+    pub on_success: Option<ColumnTarget>,
+    pub on_fail: Option<ColumnTarget>,
+}
+
 /// Optional next run inserted atomically with finalization (an auto hop).
 pub struct FinalizeRun<'a> {
     pub run_id: i64,

--- a/crates/board-core/src/db/rows.rs
+++ b/crates/board-core/src/db/rows.rs
@@ -1,7 +1,7 @@
 use rusqlite::{types::Type, Error as SqliteError, Result as SqliteResult, Row};
 
 use super::conv_err;
-use crate::model::{Board, Card, Column, Comment, Run};
+use crate::model::{Board, Card, Column, Comment, CommentHistory, CommentRecord, Run};
 use crate::protocol::{AwaitingReason, CardStatus, Effort, RunOutcome, SpaceKind, Trigger};
 use crate::{Error, Result};
 
@@ -86,6 +86,29 @@ pub(super) fn row_to_comment(row: &Row) -> SqliteResult<Comment> {
         author: row.get("author")?,
         body: row.get("body")?,
         created_at: row.get("created_at")?,
+    })
+}
+
+pub(super) fn row_to_comment_record(row: &Row) -> SqliteResult<CommentRecord> {
+    Ok(CommentRecord {
+        id: row.get("id")?,
+        card_id: row.get("card_id")?,
+        author: row.get("author")?,
+        body: row.get("body")?,
+        created_at: row.get("created_at")?,
+        deleted_at: row.get("deleted_at")?,
+    })
+}
+
+pub(super) fn row_to_comment_history(row: &Row) -> SqliteResult<CommentHistory> {
+    Ok(CommentHistory {
+        id: row.get("id")?,
+        comment_id: row.get("comment_id")?,
+        card_id: row.get("card_id")?,
+        author: row.get("author")?,
+        body: row.get("body")?,
+        created_at: row.get("created_at")?,
+        deleted_at: row.get("deleted_at")?,
     })
 }
 

--- a/crates/board-core/src/db/runs.rs
+++ b/crates/board-core/src/db/runs.rs
@@ -20,24 +20,36 @@ impl Db {
             ));
         }
         let tx = self.conn.unchecked_transaction()?;
+        let id = self.enqueue_run_tx(&tx, p.card_id, p)?;
+        tx.commit()?;
+        self.get_run(id)
+    }
+
+    /// Insert a queued run and update its card while an enclosing transaction
+    /// is active. The caller owns the transaction boundary.
+    pub(super) fn enqueue_run_tx(
+        &self,
+        tx: &rusqlite::Transaction<'_>,
+        card_id: i64,
+        p: &EnqueueRun<'_>,
+    ) -> Result<i64> {
         tx.execute(
             "INSERT INTO runs
              (card_id,column_id,harness,argv_json,prompt_snapshot,system_prompt_snapshot,launch_spec_json,session_id,session)
              VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
-            params![p.card_id,p.column_id,p.harness,p.argv_json,p.prompt_snapshot,
+            params![card_id,p.column_id,p.harness,p.argv_json,p.prompt_snapshot,
                     p.system_prompt_snapshot,p.launch_spec_json,p.session_id,p.session],
         )?;
         let id = tx.last_insert_rowid();
         self.lifecycle_fault(LifecycleFaultPoint::EnqueueAfterRunInsert)?;
         let changed = tx.execute(
             "UPDATE cards SET status='queued',awaiting_reason=NULL,session_id=COALESCE(?2,session_id),updated_at=datetime('now') WHERE id=?1",
-            params![p.card_id, p.session_id],
+            params![card_id, p.session_id],
         )?;
         if changed != 1 {
-            return Err(Error::NotFound(format!("card {}", p.card_id)));
+            return Err(Error::NotFound(format!("card {card_id}")));
         }
-        tx.commit()?;
-        self.get_run(id)
+        Ok(id)
     }
 
     /// Atomically promote an exact queued run and its card to running.

--- a/crates/board-core/src/model.rs
+++ b/crates/board-core/src/model.rs
@@ -83,6 +83,10 @@ pub struct Card {
 }
 
 /// A timestamped note; author is `user`, `agent:<run_id>`, or `system`.
+///
+/// This is the compact, non-deleted projection used by prompts and ordinary
+/// card lists. Deleted comments are intentionally not representable here so
+/// existing prompt/client callers cannot accidentally render them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Comment {
     pub id: i64,
@@ -91,6 +95,39 @@ pub struct Comment {
     pub body: String,
     pub created_at: String,
 }
+
+/// The current comment row, including its soft-deletion marker. This separate
+/// projection keeps the original `Comment` struct source-compatible for prompt
+/// builders while exposing deletion state at management/audit boundaries.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentRecord {
+    pub id: i64,
+    pub card_id: i64,
+    pub author: String,
+    pub body: String,
+    pub created_at: String,
+    pub deleted_at: Option<String>,
+}
+
+/// Alias emphasizing that this is the current (as opposed to historical)
+/// comment projection.
+pub type CurrentComment = CommentRecord;
+pub type CommentCurrent = CommentRecord;
+
+/// One immutable snapshot in a comment's audit trail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentHistory {
+    pub id: i64,
+    pub comment_id: i64,
+    pub card_id: i64,
+    pub author: String,
+    pub body: String,
+    pub created_at: String,
+    pub deleted_at: Option<String>,
+}
+
+pub type CommentHistoryEntry = CommentHistory;
+pub type CommentAudit = CommentHistory;
 
 /// One agent execution of a card in a column.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/board-core/src/protocol.rs
+++ b/crates/board-core/src/protocol.rs
@@ -9,7 +9,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use crate::model::{Board, Card, Column, Comment, Run};
+use crate::model::{Board, Card, Column, Comment, CommentHistory, CommentRecord, Run};
 
 /// A nullable field in a partial update.
 ///
@@ -138,6 +138,15 @@ pub enum RunOutcome {
     Lost,
 }
 
+/// Which archived-card set a card list should expose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CardVisibility {
+    Active,
+    All,
+    Archived,
+}
+
 /// Reasoning effort level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -184,6 +193,9 @@ str_enum!(AwaitingReason {
 str_enum!(RunOutcome {
     Ok => "ok", Fail => "fail", Cancelled => "cancelled", Lost => "lost",
 });
+str_enum!(CardVisibility {
+    Active => "active", All => "all", Archived => "archived",
+});
 str_enum!(Effort {
     Off => "off", Minimal => "minimal", Low => "low", Medium => "medium",
     High => "high", Xhigh => "xhigh", Max => "max",
@@ -221,22 +233,41 @@ impl Response {
         }
     }
     pub fn err(id: impl Into<String>, code: i32, message: impl Into<String>) -> Self {
+        Self::err_with_details(id, code, None::<String>, message, None)
+    }
+
+    /// Construct an additive structured error without changing the legacy
+    /// `Response::err` call sites.
+    pub fn err_with_details(
+        id: impl Into<String>,
+        code: i32,
+        kind: Option<impl Into<String>>,
+        message: impl Into<String>,
+        details: Option<serde_json::Value>,
+    ) -> Self {
         Response {
             id: id.into(),
             result: None,
             error: Some(RpcError {
                 code,
+                kind: kind.map(Into::into),
                 message: message.into(),
+                details,
             }),
         }
     }
 }
 
-/// Structured error payload.
+/// Structured error payload. `kind` and `details` are optional additions so
+/// protocol-v1 clients that only know `code` and `message` remain readable.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RpcError {
     pub code: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +344,15 @@ pub struct SubscribeResult {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BoardOpenParams {
     pub scope_path: String,
+}
+
+/// `board.rename` params. The board id is stable; only its display name is
+/// changed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BoardRenameParams {
+    #[serde(alias = "id")]
+    pub board_id: i64,
+    pub name: String,
 }
 
 /// `board.get` params. Omitted id preserves the legacy Global default.
@@ -540,6 +580,9 @@ pub struct CardListParams {
     pub board_id: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub column_id: Option<i64>,
+    /// Omitted preserves the active-only board view.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<CardVisibility>,
 }
 
 /// `card.get` result.
@@ -561,7 +604,49 @@ pub struct CommentAddParams {
     pub body: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
+    /// Optional daemon-supplied actor identity used to authorize agent-owned
+    /// comments. It is additive and absent for human callers.
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "run_id")]
+    pub actor_run_id: Option<i64>,
 }
+
+/// `comment.get`, `comment.delete`, and `comment.history` id params.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentIdParams {
+    #[serde(alias = "comment_id")]
+    pub id: i64,
+}
+
+pub type CommentGetParams = CommentIdParams;
+pub type CommentHistoryParams = CommentIdParams;
+
+/// `comment.delete` params.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentDeleteParams {
+    #[serde(alias = "comment_id")]
+    pub id: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "run_id")]
+    pub actor_run_id: Option<i64>,
+}
+
+/// `comment.update` params.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommentUpdateParams {
+    #[serde(alias = "comment_id")]
+    pub id: i64,
+    pub body: String,
+    #[serde(default, skip_serializing_if = "Option::is_none", alias = "run_id")]
+    pub actor_run_id: Option<i64>,
+}
+
+/// Current comment returned by management methods.
+pub type CommentResult = CommentRecord;
+pub type CommentGetResult = CommentRecord;
+pub type CommentUpdateResult = CommentRecord;
+pub type CommentDeleteResult = DeletedResult;
+
+/// Audit snapshots returned by `comment.history`.
+pub type CommentHistoryResult = Vec<CommentHistory>;
 
 /// `run.done` params.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/board-core/tests/comments_boards_contract.rs
+++ b/crates/board-core/tests/comments_boards_contract.rs
@@ -1,0 +1,235 @@
+//! RED contract tests for board identity and comment lifecycle semantics.
+//!
+//! These are intentionally written against the public `Db` surface.  The
+//! daemon/client layers must preserve the same rules when they expose the
+//! corresponding typed protocol methods.
+
+use board_core::db::{Db, BOARD_ID};
+use board_core::protocol::{CardCreateParams, CardVisibility};
+
+fn mem() -> Db {
+    Db::open_in_memory().expect("in-memory board database")
+}
+
+fn card(db: &Db, title: &str) -> board_core::model::Card {
+    db.create_card(&CardCreateParams {
+        title: title.into(),
+        ..Default::default()
+    })
+    .expect("card")
+}
+
+#[test]
+fn board_rename_preserves_identity_scope_columns_and_cards() {
+    let db = mem();
+    let board = db.open_board("/repo/project").expect("scoped board");
+    let card = db
+        .create_card(&CardCreateParams {
+            board_id: Some(board.id),
+            title: "kept card".into(),
+            ..Default::default()
+        })
+        .expect("card");
+
+    let renamed = db.rename_board(board.id, "Project board").expect("rename");
+
+    assert_eq!(renamed.id, board.id);
+    assert_eq!(renamed.name, "Project board");
+    assert_eq!(renamed.scope_path.as_deref(), Some("/repo/project"));
+    assert_eq!(db.get_board(board.id).expect("board").name, "Project board");
+    assert_eq!(
+        db.open_board("/repo/project").expect("same scope").id,
+        board.id
+    );
+    assert_eq!(db.list_columns(board.id).expect("columns").len(), 1);
+    assert_eq!(
+        db.get_card(card.id)
+            .expect("card")
+            .expect("present")
+            .board_id,
+        board.id
+    );
+}
+
+#[test]
+fn board_rename_keeps_names_unique() {
+    let db = mem();
+    let one = db.open_board("/one").expect("board one");
+    let two = db.open_board("/two").expect("board two");
+
+    assert!(db.rename_board(one.id, two.name.as_str()).is_err());
+    assert_eq!(db.get_board(one.id).expect("board").name, one.name);
+}
+
+#[test]
+fn comments_support_get_update_soft_delete_and_history() {
+    let db = mem();
+    let card = card(&db, "comment lifecycle");
+    let comment = db
+        .add_comment(card.id, "user", "original body")
+        .expect("comment");
+
+    assert_eq!(
+        db.get_comment(comment.id)
+            .expect("get comment")
+            .expect("comment exists")
+            .body,
+        "original body"
+    );
+
+    let edited = db
+        .update_comment(comment.id, "edited body")
+        .expect("edit comment");
+    assert_eq!(edited.body, "edited body");
+    assert_eq!(edited.author, "user");
+
+    let history = db
+        .list_comment_history(comment.id)
+        .expect("comment history");
+    assert_eq!(
+        history
+            .iter()
+            .map(|entry| entry.body.as_str())
+            .collect::<Vec<_>>(),
+        vec!["original body", "edited body"]
+    );
+
+    let deleted = db
+        .soft_delete_comment(comment.id)
+        .expect("soft delete comment");
+    assert!(deleted.deleted_at.is_some());
+    assert!(db
+        .get_comment(comment.id)
+        .expect("get deleted comment")
+        .expect("audit record remains")
+        .deleted_at
+        .is_some());
+    assert!(db
+        .list_comments(card.id)
+        .expect("ordinary comments")
+        .is_empty());
+
+    let history_after_delete = db
+        .list_comment_history(comment.id)
+        .expect("history after delete");
+    assert_eq!(
+        history_after_delete
+            .iter()
+            .map(|entry| entry.body.as_str())
+            .collect::<Vec<_>>(),
+        vec!["original body", "edited body"]
+    );
+    assert!(history_after_delete
+        .last()
+        .expect("history row")
+        .deleted_at
+        .is_some());
+}
+
+#[test]
+fn card_detail_hides_deleted_comments_but_shows_current_edits() {
+    let db = mem();
+    let card = card(&db, "card detail");
+    let edited = db
+        .add_comment(card.id, "user", "before edit")
+        .expect("editable comment");
+    let deleted = db
+        .add_comment(card.id, "user", "remove from detail")
+        .expect("deletable comment");
+
+    db.update_comment(edited.id, "after edit").expect("edit");
+    db.soft_delete_comment(deleted.id).expect("delete");
+
+    let detail = db.get_card_detail(card.id).expect("card detail");
+    assert_eq!(detail.comments.len(), 1);
+    assert_eq!(detail.comments[0].id, edited.id);
+    assert_eq!(detail.comments[0].body, "after edit");
+    assert!(!detail
+        .comments
+        .iter()
+        .any(|comment| comment.id == deleted.id));
+
+    let deleted_audit = db
+        .list_comment_history(deleted.id)
+        .expect("deleted comment audit");
+    assert!(deleted_audit
+        .iter()
+        .any(|entry| entry.body == "remove from detail" && entry.deleted_at.is_some()));
+}
+
+#[test]
+fn system_comments_are_immutable_at_the_store_boundary() {
+    let db = mem();
+    let card = card(&db, "system comment");
+    let system = db
+        .add_comment(card.id, "system", "run transitioned")
+        .expect("system comment");
+
+    assert!(db.update_comment(system.id, "rewritten").is_err());
+    assert!(db.soft_delete_comment(system.id).is_err());
+    let current = db
+        .get_comment(system.id)
+        .expect("get system comment")
+        .expect("system comment remains");
+    assert_eq!(current.author, "system");
+    assert_eq!(current.body, "run transitioned");
+}
+
+#[test]
+fn agent_comment_ownership_survives_edits_and_history() {
+    let db = mem();
+    let card = card(&db, "agent comment");
+    let agent = db
+        .add_comment(card.id, "agent:42", "agent output")
+        .expect("agent comment");
+
+    // The update API accepts a body, not a replacement author.  An edit must
+    // remain owned by the run that created the comment in both projections.
+    let edited = db
+        .update_comment(agent.id, "revised agent output")
+        .expect("edit");
+    assert_eq!(edited.author, "agent:42");
+    let history = db.list_comment_history(agent.id).expect("agent history");
+    assert!(history.iter().all(|entry| entry.author == "agent:42"));
+}
+
+#[test]
+fn active_all_and_archived_visibility_has_one_shared_contract() {
+    let db = mem();
+    let active = card(&db, "active");
+    let archived = card(&db, "archived");
+    db.set_card_archived(archived.id, true).expect("archive");
+
+    assert_eq!(
+        serde_json::to_string(&CardVisibility::Active).expect("visibility wire"),
+        "\"active\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CardVisibility::All).expect("visibility wire"),
+        "\"all\""
+    );
+    assert_eq!(
+        serde_json::to_string(&CardVisibility::Archived).expect("visibility wire"),
+        "\"archived\""
+    );
+
+    let snapshot_cards = db.list_cards(BOARD_ID).expect("board snapshot cards");
+    assert_eq!(
+        snapshot_cards
+            .iter()
+            .map(|card| (card.id, card.title.as_str()))
+            .collect::<Vec<_>>(),
+        vec![(active.id, "active"), (archived.id, "archived")]
+    );
+
+    let titles = |visibility| {
+        db.list_cards_visible(BOARD_ID, visibility)
+            .expect("visible cards")
+            .into_iter()
+            .map(|card| card.title)
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(titles(CardVisibility::Active), vec!["active"]);
+    assert_eq!(titles(CardVisibility::All), vec!["active", "archived"]);
+    assert_eq!(titles(CardVisibility::Archived), vec!["archived"]);
+}

--- a/crates/board-core/tests/comments_migration_contract.rs
+++ b/crates/board-core/tests/comments_migration_contract.rs
@@ -1,0 +1,177 @@
+//! RED migration contract for the v12 -> v13 comment audit schema.
+
+use board_core::db::Db;
+use rusqlite::Connection;
+
+// Keep the fixture deliberately independent from the current fresh-schema
+// path.  This is the public `Db::open` migration boundary, not a private
+// migration-function test.
+const V12_SCHEMA: &str = r#"
+PRAGMA foreign_keys = ON;
+CREATE TABLE boards (
+  id INTEGER PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  scope_path TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX idx_boards_scope_path ON boards(scope_path) WHERE scope_path IS NOT NULL;
+CREATE TABLE columns (
+  id INTEGER PRIMARY KEY,
+  board_id INTEGER NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  position INTEGER NOT NULL,
+  system_prompt TEXT,
+  trigger TEXT NOT NULL DEFAULT 'manual' CHECK (trigger IN ('manual','auto')),
+  on_success_column_id INTEGER REFERENCES columns(id) ON DELETE SET NULL,
+  on_fail_column_id INTEGER REFERENCES columns(id) ON DELETE SET NULL,
+  fresh_session INTEGER NOT NULL DEFAULT 0,
+  harness_override TEXT,
+  model_override TEXT,
+  effort_override TEXT,
+  permission_override TEXT,
+  timeout_minutes INTEGER,
+  UNIQUE (board_id, name)
+);
+CREATE TABLE cards (
+  id INTEGER PRIMARY KEY,
+  board_id INTEGER NOT NULL REFERENCES boards(id) ON DELETE CASCADE,
+  column_id INTEGER NOT NULL REFERENCES columns(id),
+  position INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  harness TEXT NOT NULL DEFAULT 'pi',
+  model TEXT,
+  effort TEXT CHECK (effort IN (NULL,'off','minimal','low','medium','high','xhigh','max')),
+  permission_mode TEXT,
+  session TEXT,
+  space_kind TEXT NOT NULL DEFAULT 'workspace' CHECK (space_kind IN ('workspace','new_workspace')),
+  space_ref TEXT,
+  space_cwd TEXT,
+  status TEXT NOT NULL DEFAULT 'idle'
+    CHECK (status IN ('idle','queued','running','blocked','failed','awaiting','done')),
+  awaiting_reason TEXT,
+  session_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  archived_at TEXT,
+  CHECK (
+    (status = 'awaiting' AND awaiting_reason IS NOT NULL
+      AND awaiting_reason IN ('agent_done','idle_expired'))
+    OR (status <> 'awaiting' AND awaiting_reason IS NULL)
+  )
+);
+CREATE TABLE comments (
+  id INTEGER PRIMARY KEY,
+  card_id INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+  author TEXT NOT NULL,
+  body TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE TABLE runs (
+  id INTEGER PRIMARY KEY,
+  card_id INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+  column_id INTEGER NOT NULL REFERENCES columns(id),
+  harness TEXT NOT NULL,
+  argv_json TEXT NOT NULL,
+  prompt_snapshot TEXT NOT NULL,
+  system_prompt_snapshot TEXT,
+  launch_spec_json TEXT,
+  herdr_workspace_id TEXT,
+  herdr_pane_id TEXT,
+  herdr_anchor_pane_id TEXT,
+  session_id TEXT,
+  session TEXT,
+  started_at TEXT,
+  timeout_deadline_at_ms INTEGER,
+  timeout_paused_at_ms INTEGER,
+  ended_at TEXT,
+  outcome TEXT CHECK (outcome IN (NULL,'ok','fail','cancelled','lost')),
+  result_summary TEXT,
+  log_path TEXT
+);
+CREATE INDEX idx_cards_column ON cards(column_id, position);
+CREATE INDEX idx_comments_card ON comments(card_id, created_at);
+CREATE INDEX idx_runs_card ON runs(card_id, started_at);
+CREATE UNIQUE INDEX idx_runs_one_open_per_card ON runs(card_id) WHERE ended_at IS NULL;
+CREATE INDEX idx_runs_queued_fifo ON runs(id) WHERE started_at IS NULL AND ended_at IS NULL;
+CREATE INDEX idx_runs_active_open ON runs(id) WHERE started_at IS NOT NULL AND ended_at IS NULL;
+"#;
+
+#[test]
+fn v12_to_v13_preserves_board_card_comment_and_run_bytes() {
+    let tmp = tempfile::NamedTempFile::new().expect("temporary database path");
+    let path = tmp.path().to_path_buf();
+    {
+        let conn = Connection::open(&path).expect("v12 database");
+        conn.execute_batch(V12_SCHEMA).expect("v12 schema");
+        conn.execute(
+            "INSERT INTO boards(id,name,scope_path,created_at)
+             VALUES(1,'Global',NULL,'2025-01-02 03:04:05')",
+            [],
+        )
+        .expect("board");
+        conn.execute(
+            "INSERT INTO columns(id,board_id,name,position,trigger,fresh_session)
+             VALUES(1,1,'Todo',0,'manual',0)",
+            [],
+        )
+        .expect("column");
+        conn.execute(
+            "INSERT INTO cards(id,board_id,column_id,position,title,description,harness,
+             status,created_at,updated_at)
+             VALUES(7,1,1,0,'legacy title','legacy description','pi','idle',
+                    '2025-01-02 03:04:05','2025-01-02 03:04:06')",
+            [],
+        )
+        .expect("card");
+        conn.execute(
+            "INSERT INTO comments(id,card_id,author,body,created_at)
+             VALUES(11,7,'agent:19','legacy comment','2025-01-02 03:04:07')",
+            [],
+        )
+        .expect("comment");
+        conn.execute(
+            "INSERT INTO runs(id,card_id,column_id,harness,argv_json,prompt_snapshot,
+             started_at,ended_at,outcome,result_summary)
+             VALUES(13,7,1,'pi','[\"pi\"]','legacy prompt',
+                    '2025-01-02 03:04:08','2025-01-02 03:05:08','ok','legacy result')",
+            [],
+        )
+        .expect("run");
+        conn.execute_batch("PRAGMA user_version = 12;")
+            .expect("v12 marker");
+    }
+
+    let db = Db::open(&path).expect("v12 -> v13 migration");
+    assert_eq!(db.user_version().expect("schema version"), 13);
+    assert_eq!(db.get_board(1).expect("board").name, "Global");
+    assert_eq!(
+        db.get_card(7)
+            .expect("card")
+            .expect("card exists")
+            .description,
+        "legacy description"
+    );
+    assert_eq!(
+        db.get_comment(11)
+            .expect("comment")
+            .expect("comment exists")
+            .body,
+        "legacy comment"
+    );
+    assert_eq!(
+        db.list_runs(7).expect("runs")[0].prompt_snapshot,
+        "legacy prompt"
+    );
+
+    // A legacy row must participate in the new audit path without changing
+    // its owner or bytes when the first edit occurs after migration.
+    db.update_comment(11, "edited after migration")
+        .expect("edit migrated comment");
+    let history = db
+        .list_comment_history(11)
+        .expect("migrated comment history");
+    assert!(history
+        .iter()
+        .any(|entry| { entry.author == "agent:19" && entry.body == "legacy comment" }));
+}

--- a/crates/board-core/tests/db/migrations.rs
+++ b/crates/board-core/tests/db/migrations.rs
@@ -9,7 +9,7 @@ use rusqlite::{Connection, OptionalExtension};
 #[test]
 fn migration_seeds_board_and_todo_column() {
     let db = mem();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let board = db.get_board(BOARD_ID).unwrap();
     assert_eq!(board.name, "Global");
     assert_eq!(board.scope_path, None);
@@ -88,7 +88,7 @@ fn v11_rows_gain_nullable_anchor_column_without_backfill() {
         .unwrap();
     }
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     assert_eq!(db.list_runs(1).unwrap()[0].herdr_anchor_pane_id, None);
 }
 
@@ -103,7 +103,7 @@ fn migration_idempotent_on_reopen() {
     // Reopen: must not re-seed (still exactly one board, one column).
     {
         let db = Db::open(&path).unwrap();
-        assert_eq!(db.user_version().unwrap(), 12);
+        assert_eq!(db.user_version().unwrap(), 13);
         assert_eq!(db.list_columns(BOARD_ID).unwrap().len(), 1);
         assert_eq!(db.get_board(BOARD_ID).unwrap().name, "Global");
     }
@@ -193,7 +193,7 @@ fn migration_v2_upgrades_v1_database() {
     }
     // Open via Db → runs the v2 through v7 migrations.
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let cards = db.list_cards(BOARD_ID).unwrap();
     assert_eq!(cards.len(), 2);
     for c in &cards {
@@ -335,7 +335,7 @@ fn migration_v4_preserves_claude_cards_and_accepts_pi_efforts() {
     }
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let existing = db.list_cards(BOARD_ID).unwrap();
     assert_eq!(existing[0].harness, "claude");
     assert_eq!(db.list_comments(existing[0].id).unwrap().len(), 1);
@@ -357,14 +357,14 @@ fn migration_does_not_downgrade_future_schema_version() {
     let path = tmp.path().to_path_buf();
     {
         let db = Db::open(&path).unwrap();
-        assert_eq!(db.user_version().unwrap(), 12);
+        assert_eq!(db.user_version().unwrap(), 13);
     }
     {
         let conn = Connection::open(&path).unwrap();
         conn.execute_batch("PRAGMA user_version = 8;").unwrap();
     }
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn migration_v3_adds_archived_at_to_v2_database() {
         .unwrap();
     }
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let cards = db.list_cards(BOARD_ID).unwrap();
     assert_eq!(cards.len(), 1);
     assert!(cards[0].archived_at.is_none());
@@ -489,7 +489,7 @@ fn v6_to_v7_migration_preserves_legacy_queued_run_byte_for_byte() {
         .unwrap();
     }
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let run = &db.list_runs(1).unwrap()[0];
     assert_eq!(run.argv_json, argv);
     assert_eq!(run.prompt_snapshot, prompt);
@@ -542,7 +542,7 @@ fn migration_v5_preserves_global_data_and_renames_it() {
 
     let db = Db::open(&path).unwrap();
     let global = db.get_board(BOARD_ID).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     assert_eq!(global.name, "Global");
     assert!(global.scope_path.is_none());
     let cards = db.list_cards(BOARD_ID).unwrap();
@@ -636,7 +636,7 @@ fn migration_v6_rebuilds_cards_check_and_preserves_data() {
     }
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     let cards = db.list_cards(BOARD_ID).unwrap();
     assert_eq!(cards.len(), 2);
     let kept = &cards[0];

--- a/crates/board-core/tests/db_atomic.rs
+++ b/crates/board-core/tests/db_atomic.rs
@@ -44,7 +44,7 @@ fn fresh_v12_has_exact_partial_scheduler_indexes_and_query_plans() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("board.db");
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     drop(db);
     let conn = Connection::open(path).unwrap();
     for (name, expected) in [
@@ -118,7 +118,7 @@ fn v9_file_fixture_upgrades_through_v12_without_changing_existing_bytes() {
     drop(conn);
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     assert_eq!(db.get_card(card_id).unwrap().unwrap().id, card_id);
     assert_eq!(db.get_run(run_id).unwrap().id, run_id);
     drop(db);
@@ -130,7 +130,7 @@ fn v9_file_fixture_upgrades_through_v12_without_changing_existing_bytes() {
         assert_eq!(
             conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
                 .unwrap(),
-            12
+            13
         );
         assert_eq!(
             scheduler_index_sql(&conn, "idx_runs_queued_fifo").as_deref(),
@@ -542,7 +542,7 @@ fn v8_upgrade_retains_a_single_open_run_byte_for_byte() {
         .unwrap();
 
     let db = Db::open(&path).unwrap();
-    assert_eq!(db.user_version().unwrap(), 12);
+    assert_eq!(db.user_version().unwrap(), 13);
     assert_eq!(db.get_run(before.id).unwrap(), before);
 }
 
@@ -560,7 +560,7 @@ fn fresh_and_v7_upgrade_install_exact_partial_unique_index_sql() {
                 .unwrap();
         }
         let db = Db::open(&path).unwrap();
-        assert_eq!(db.user_version().unwrap(), 12);
+        assert_eq!(db.user_version().unwrap(), 13);
         drop(db);
         let sql: String = Connection::open(&path)
             .unwrap()
@@ -658,4 +658,177 @@ fn timeout_resume_rolls_back_run_when_card_write_fails() {
     let persisted = db.get_run(run.id).unwrap();
     assert_eq!(persisted.timeout_deadline_at_ms, Some(1_000));
     assert_eq!(persisted.timeout_paused_at_ms, Some(100));
+}
+
+#[test]
+fn reorder_column_rolls_back_partial_position_compaction() {
+    let (_dir, path, _card) = create_file_db("reorder atomic");
+    let db = Db::open(&path).unwrap();
+    let todo = db.default_column_id(board_core::db::BOARD_ID).unwrap();
+    let first = db
+        .create_column(&board_core::protocol::ColumnCreateParams {
+            name: "First".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let second = db
+        .create_column(&board_core::protocol::ColumnCreateParams {
+            name: "Second".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let last = db
+        .create_column(&board_core::protocol::ColumnCreateParams {
+            name: "Last".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let before = db.list_columns(board_core::db::BOARD_ID).unwrap();
+
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch(&format!(
+            "CREATE TRIGGER abort_reorder BEFORE UPDATE OF position ON columns
+             WHEN OLD.id={todo} AND NEW.position=1
+             BEGIN SELECT RAISE(ABORT, 'fault: reorder'); END;"
+        ))
+        .unwrap();
+
+    let error = db.reorder_column(last.id, 0).unwrap_err();
+    assert!(error.to_string().contains("fault: reorder"), "{error}");
+    assert_eq!(
+        db.list_columns(board_core::db::BOARD_ID).unwrap(),
+        before,
+        "column positions must remain unchanged after an intermediate reorder failure"
+    );
+    let _ = (first, second);
+}
+
+#[test]
+fn move_card_rolls_back_column_and_position_compaction_failure() {
+    let (_dir, path, _card) = create_file_db("move atomic");
+    let db = Db::open(&path).unwrap();
+    let source = db.default_column_id(board_core::db::BOARD_ID).unwrap();
+    let target = db
+        .create_column(&board_core::protocol::ColumnCreateParams {
+            name: "Target".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let keep = db
+        .create_card(&board_core::protocol::CardCreateParams {
+            title: "keep".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let moved = db
+        .create_card(&board_core::protocol::CardCreateParams {
+            title: "moved".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let target_first = db
+        .create_card(&board_core::protocol::CardCreateParams {
+            title: "target first".into(),
+            column_id: Some(target.id),
+            ..Default::default()
+        })
+        .unwrap();
+    db.create_card(&board_core::protocol::CardCreateParams {
+        title: "target second".into(),
+        column_id: Some(target.id),
+        ..Default::default()
+    })
+    .unwrap();
+    let before_source = db.list_cards_in_column(source).unwrap();
+    let before_target = db.list_cards_in_column(target.id).unwrap();
+
+    let target_first_id = target_first.id;
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch(&format!(
+            "CREATE TRIGGER abort_card_compaction BEFORE UPDATE OF position ON cards
+             WHEN OLD.id={target_first_id} AND NEW.position=1
+             BEGIN SELECT RAISE(ABORT, 'fault: card compaction'); END;"
+        ))
+        .unwrap();
+
+    let error = db.move_card(moved.id, target.id, Some(0)).unwrap_err();
+    assert!(
+        error.to_string().contains("fault: card compaction"),
+        "{error}"
+    );
+    assert_eq!(db.list_cards_in_column(source).unwrap(), before_source);
+    assert_eq!(db.list_cards_in_column(target.id).unwrap(), before_target);
+    assert_eq!(db.get_card(moved.id).unwrap().unwrap().column_id, source);
+    assert_eq!(
+        db.get_card(keep.id).unwrap().unwrap().position,
+        before_source
+            .iter()
+            .find(|card| card.id == keep.id)
+            .unwrap()
+            .position
+    );
+}
+
+#[test]
+fn delete_column_rolls_back_card_migration_and_both_position_compactions() {
+    let (_dir, path, _card) = create_file_db("delete migration atomic");
+    let db = Db::open(&path).unwrap();
+    let target = db.default_column_id(board_core::db::BOARD_ID).unwrap();
+    let source = db
+        .create_column(&board_core::protocol::ColumnCreateParams {
+            name: "Source".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    db.create_card(&board_core::protocol::CardCreateParams {
+        title: "existing target".into(),
+        ..Default::default()
+    })
+    .unwrap();
+    let first = db
+        .create_card(&board_core::protocol::CardCreateParams {
+            title: "first source".into(),
+            column_id: Some(source.id),
+            ..Default::default()
+        })
+        .unwrap();
+    let second = db
+        .create_card(&board_core::protocol::CardCreateParams {
+            title: "second source".into(),
+            column_id: Some(source.id),
+            ..Default::default()
+        })
+        .unwrap();
+    let before_columns = db.list_columns(board_core::db::BOARD_ID).unwrap();
+    let before_target = db.list_cards_in_column(target).unwrap();
+    let before_source = db.list_cards_in_column(source.id).unwrap();
+
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch(&format!(
+            "CREATE TRIGGER abort_second_card_migration BEFORE UPDATE OF column_id ON cards
+             WHEN OLD.id={} AND OLD.column_id={}
+             BEGIN SELECT RAISE(ABORT, 'fault: card migration'); END;",
+            second.id, source.id
+        ))
+        .unwrap();
+
+    let error = db.delete_column(source.id, Some(target)).unwrap_err();
+    assert!(
+        error.to_string().contains("fault: card migration"),
+        "{error}"
+    );
+    assert_eq!(
+        db.list_columns(board_core::db::BOARD_ID).unwrap(),
+        before_columns
+    );
+    assert_eq!(db.list_cards_in_column(target).unwrap(), before_target);
+    assert_eq!(db.list_cards_in_column(source.id).unwrap(), before_source);
+    assert_eq!(db.get_card(first.id).unwrap().unwrap().column_id, source.id);
+    assert_eq!(
+        db.get_card(second.id).unwrap().unwrap().column_id,
+        source.id
+    );
 }

--- a/crates/board-core/tests/fake_client.rs
+++ b/crates/board-core/tests/fake_client.rs
@@ -216,6 +216,102 @@ fn fake_delete_column_with_active_card_refused() {
 }
 
 #[test]
+fn fake_comment_actor_authorization_matches_daemon() {
+    let mut c = FakeBoardClient::new().unwrap();
+    let card = c
+        .card_create(&CardCreateParams {
+            title: "owned card".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let other_card = c
+        .card_create(&CardCreateParams {
+            title: "other card".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let enqueue = |c: &FakeBoardClient, card_id: i64| {
+        let card = c.db().get_card(card_id).unwrap().unwrap();
+        c.db()
+            .enqueue_run_uow(&EnqueueRun {
+                card_id,
+                column_id: card.column_id,
+                harness: "pi",
+                argv_json: "[]",
+                prompt_snapshot: "prompt",
+                system_prompt_snapshot: None,
+                launch_spec_json: None,
+                session_id: None,
+                session: None,
+            })
+            .unwrap()
+            .id
+    };
+    let own_run = enqueue(&c, card.id);
+    let other_run = enqueue(&c, other_card.id);
+
+    let own_author = format!("agent:{own_run}");
+    let own_comment = c.comment_add(card.id, "owned", Some(&own_author)).unwrap();
+    assert_eq!(
+        c.comment_update(own_comment.id, "edited by owner", Some(own_run))
+            .unwrap()
+            .body,
+        "edited by owner"
+    );
+    assert!(c
+        .comment_update(own_comment.id, "edited by other", Some(other_run))
+        .is_err());
+    assert!(c.comment_delete(own_comment.id, Some(other_run)).is_err());
+    assert!(
+        c.comment_delete(own_comment.id, Some(own_run))
+            .unwrap()
+            .deleted
+    );
+
+    // A durable run must also belong to the comment's card, not merely match
+    // the author string.
+    let other_author = format!("agent:{other_run}");
+    let forged = c
+        .comment_add(card.id, "forged", Some(&other_author))
+        .unwrap();
+    assert!(c
+        .comment_update(forged.id, "must be rejected", Some(other_run))
+        .is_err());
+    assert!(c.comment_delete(forged.id, Some(other_run)).is_err());
+
+    // Human callers may mutate non-system comments without an actor run.
+    let human = c.comment_add(card.id, "human", Some("user")).unwrap();
+    assert!(c.comment_update(human.id, "human edit", None).is_ok());
+    assert!(c.comment_delete(human.id, None).unwrap().deleted);
+
+    let system = c.comment_add(card.id, "system", Some("system")).unwrap();
+    assert!(c
+        .comment_update(system.id, "must be immutable", None)
+        .is_err());
+    assert!(c.comment_delete(system.id, None).is_err());
+}
+
+#[test]
+fn fake_agent_comments_keep_no_run_harness_compatibility() {
+    let mut c = FakeBoardClient::new().unwrap();
+    let card = c
+        .card_create(&CardCreateParams {
+            title: "fake harness".into(),
+            harness: Some("fake".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    let comment = c
+        .comment_add(card.id, "fake output", Some("agent:12345"))
+        .unwrap();
+
+    assert!(c
+        .comment_update(comment.id, "revised fake output", Some(12345))
+        .is_ok());
+    assert!(c.comment_delete(comment.id, Some(12345)).is_ok());
+}
+
+#[test]
 fn fake_card_move_transfers_across_boards() {
     let mut c = FakeBoardClient::new().unwrap();
     let alpha = c.board_open("/alpha").unwrap();

--- a/crates/board-core/tests/protocol.rs
+++ b/crates/board-core/tests/protocol.rs
@@ -164,7 +164,9 @@ fn response_ok_and_error_shapes() {
         err.error,
         Some(RpcError {
             code: 3,
-            message: "invalid state".into()
+            kind: None,
+            message: "invalid state".into(),
+            details: None,
         })
     );
     roundtrip(&err);

--- a/crates/board-daemon/src/ops/boards.rs
+++ b/crates/board-daemon/src/ops/boards.rs
@@ -1,5 +1,6 @@
 use super::*;
-use board_core::db::BOARD_ID;
+use board_core::db::{ColumnTarget, ColumnWiring, BOARD_ID};
+use board_core::protocol::{BoardChangedReason, ColumnCreateParams, TemplateApplyParams, Trigger};
 pub(super) fn daemon_status(d: &Arc<Daemon>) -> Result<Value> {
     let (active_runs, queued_runs) = {
         let db = d.store.lock();
@@ -42,8 +43,116 @@ pub(super) fn board_list(d: &Arc<Daemon>) -> Result<Value> {
     }))
 }
 
+pub(super) fn board_rename(d: &Arc<Daemon>, p: BoardRenameParams) -> Result<Value> {
+    let board = d.store.lock().rename_board(p.board_id, &p.name)?;
+    // There is no board-renamed reason in protocol v1. ColumnChanged is the
+    // existing board-structure refresh signal and, unlike the legacy coarse
+    // emit, scopes the refresh to the renamed board.
+    d.emit_changed_board(BoardChangedReason::ColumnChanged, board.id, None, None);
+    Ok(json!(board))
+}
+
 pub(super) fn board_get(d: &Arc<Daemon>, p: BoardGetParams) -> Result<Value> {
     board_snapshot(d, p.board_id.unwrap_or(BOARD_ID))
+}
+
+const PLAN_PROMPT: &str =
+    "You are in the PLAN stage. Use /quick-planner style planning: produce a written
+implementation plan and save it under docs/plans/ (or .plans/). Do not write code.
+When finished you MUST run:
+  board comment $BOARD_CARD_ID \"Plan ready at <filepath>. <3-line summary>\"
+  board done $BOARD_CARD_ID --outcome ok";
+
+const EXECUTE_PROMPT: &str =
+    "You are in the EXECUTE stage. Implement the plan referenced in the card comments.
+Run tests. When finished:
+  board comment $BOARD_CARD_ID \"<what changed, files touched, test results>\"
+  board done $BOARD_CARD_ID --outcome ok    # or --outcome fail with reasons";
+
+const REVIEW_PROMPT: &str =
+    "You are in the REVIEW stage. Review the diff against the card description and the
+plan/execution comments. Be adversarial. Then:
+  board comment $BOARD_CARD_ID \"<verdict + findings>\"
+  board done $BOARD_CARD_ID --outcome ok    # ok = ship to human; fail = back to Execute";
+
+/// Apply the pipeline template as one DB unit of work. Preparation and the
+/// post-commit event are outside the transaction; no dispatcher wake is needed
+/// because a template creates no cards or runs.
+pub(super) fn template_apply(d: &Arc<Daemon>, p: TemplateApplyParams) -> Result<Value> {
+    if p.name != "pipeline" {
+        return Err(Error::BadRequest(format!("unknown template: {}", p.name)));
+    }
+    let board_id = p.board_id.unwrap_or(BOARD_ID);
+    let columns = {
+        let _sched = d.sched.lock().unwrap();
+        let db = d.store.lock();
+        db.get_board(board_id)?;
+        let existing = db.list_columns(board_id)?;
+        let cards = db.list_cards(board_id)?;
+        if existing.len() != 1 || existing[0].name != "Todo" || !cards.is_empty() {
+            return Err(Error::InvalidState(
+                "template.apply requires an empty board (only the seed Todo column, no cards)"
+                    .into(),
+            ));
+        }
+        let todo = existing[0].id;
+        let specs = vec![
+            ColumnCreateParams {
+                name: "Plan".into(),
+                board_id: Some(board_id),
+                trigger: Some(Trigger::Auto),
+                system_prompt: Some(PLAN_PROMPT.into()),
+                ..Default::default()
+            },
+            ColumnCreateParams {
+                name: "Execute".into(),
+                board_id: Some(board_id),
+                trigger: Some(Trigger::Auto),
+                system_prompt: Some(EXECUTE_PROMPT.into()),
+                ..Default::default()
+            },
+            ColumnCreateParams {
+                name: "Review".into(),
+                board_id: Some(board_id),
+                trigger: Some(Trigger::Auto),
+                system_prompt: Some(REVIEW_PROMPT.into()),
+                model_override: Some("opus".into()),
+                ..Default::default()
+            },
+            ColumnCreateParams {
+                name: "Human Review".into(),
+                board_id: Some(board_id),
+                trigger: Some(Trigger::Manual),
+                ..Default::default()
+            },
+            ColumnCreateParams {
+                name: "Done".into(),
+                board_id: Some(board_id),
+                trigger: Some(Trigger::Manual),
+                ..Default::default()
+            },
+        ];
+        let wiring = [
+            ColumnWiring {
+                column_index: 0,
+                on_success: Some(ColumnTarget::Created(1)),
+                on_fail: Some(ColumnTarget::Existing(todo)),
+            },
+            ColumnWiring {
+                column_index: 1,
+                on_success: Some(ColumnTarget::Created(2)),
+                on_fail: None,
+            },
+            ColumnWiring {
+                column_index: 2,
+                on_success: Some(ColumnTarget::Created(3)),
+                on_fail: Some(ColumnTarget::Created(1)),
+            },
+        ];
+        db.apply_template_columns_uow(board_id, &specs, &wiring)?
+    };
+    d.emit_changed_board(BoardChangedReason::ColumnChanged, board_id, None, None);
+    Ok(json!(columns))
 }
 
 // -- columns ----------------------------------------------------------------

--- a/crates/board-daemon/src/ops/cards.rs
+++ b/crates/board-daemon/src/ops/cards.rs
@@ -1,11 +1,119 @@
 use super::*;
-use crate::dispatch::enqueue_run;
-use board_core::db::BOARD_ID;
+use crate::dispatch::{map_harness_err, PreparedEnqueue};
+use board_core::db::{Db, BOARD_ID};
 use board_core::engine::{
-    decide_entry, merge_card_update, validate_card_archive, validate_card_edit,
-    validate_card_settings, validate_card_values, validate_effective_settings,
+    decide_entry, decide_resumability, merge_card_update, validate_card_archive,
+    validate_card_edit, validate_card_settings, validate_card_values, validate_effective_settings,
+    ResumabilityDecision,
 };
-use board_core::harness::DEFAULT_HARNESS;
+use board_core::harness::{build_invocation, plan_session, SessionPlan, DEFAULT_HARNESS};
+use board_core::launch::{ExecutionSpec, RunLaunchSpec};
+use board_core::model::Card;
+use board_core::prompt::{assemble_prompt, effective_settings};
+use uuid::Uuid;
+
+fn prepare_enqueue_values(
+    d: &Daemon,
+    db: &Db,
+    card: &Card,
+    column_id: i64,
+    is_retry: bool,
+) -> Result<PreparedEnqueue> {
+    let column = db
+        .get_column(column_id)?
+        .ok_or_else(|| Error::NotFound(format!("column {column_id}")))?;
+    let comments = db.list_comments(card.id)?;
+    let session_used = matches!(
+        decide_resumability(
+            card.session_id.as_deref(),
+            &db.list_runs(card.id)?,
+            &comments,
+        ),
+        ResumabilityDecision::Resumable
+    );
+    validate_effective_settings(card, &column, &d.config)?;
+    let settings = effective_settings(card, &column)?;
+    let prompt = assemble_prompt(&card.description, &comments);
+    let existing_session = card.session_id.as_deref().filter(|_| session_used);
+    let plan = plan_session(existing_session, settings.fresh_session, is_retry);
+    let target_session = matches!(plan, SessionPlan::Mint | SessionPlan::Fork(_))
+        .then(|| Uuid::new_v4().to_string());
+    let invocation = build_invocation(
+        &settings.harness,
+        &d.config,
+        &settings,
+        &plan,
+        target_session.as_deref(),
+        &prompt,
+    )
+    .map_err(map_harness_err)?;
+    let session_id = invocation
+        .resulting_session_id
+        .clone()
+        .or_else(|| match &plan {
+            SessionPlan::Mint => target_session.clone(),
+            SessionPlan::Resume(id) | SessionPlan::Fork(id) => Some(id.clone()),
+        });
+    Ok(PreparedEnqueue {
+        card_id: card.id,
+        column_id,
+        harness: settings.harness.clone(),
+        argv_json: serde_json::to_string(&invocation.argv)?,
+        prompt: prompt.clone(),
+        system_prompt: invocation.system_prompt.clone().unwrap_or_else(|| {
+            board_core::harness::protocol_system_prompt(settings.system_prompt.as_deref())
+        }),
+        launch_spec_json: serde_json::to_string(&RunLaunchSpec::v1(ExecutionSpec {
+            argv: invocation.argv,
+            env: invocation.env,
+            agent_kind: invocation.agent_kind,
+            initial_prompt: invocation.initial_prompt,
+            system_prompt: invocation.system_prompt,
+        }))?,
+        session_id,
+        session: card.session.clone(),
+    })
+}
+
+fn pending_create_card(db: &Db, p: &CardCreateParams) -> Result<Card> {
+    let board_id = p.board_id.unwrap_or(BOARD_ID);
+    let column_id = p.column_id.unwrap_or(db.default_column_id(board_id)?);
+    let column = db
+        .get_column(column_id)?
+        .ok_or_else(|| Error::NotFound(format!("column {column_id}")))?;
+    if column.board_id != board_id {
+        return Err(Error::InvalidState(format!(
+            "column {column_id} belongs to board {}, expected {board_id}",
+            column.board_id
+        )));
+    }
+    Ok(Card {
+        id: 0,
+        board_id,
+        column_id,
+        position: 0,
+        title: p.title.clone(),
+        description: p.description.clone().unwrap_or_default(),
+        harness: p
+            .harness
+            .clone()
+            .unwrap_or_else(|| DEFAULT_HARNESS.to_string()),
+        model: p.model.clone(),
+        effort: p.effort,
+        permission_mode: p.permission_mode.clone(),
+        session: p.session.clone(),
+        space_kind: p.space_kind.unwrap_or(SpaceKind::Workspace),
+        space_ref: p.space_ref.clone(),
+        space_cwd: p.space_cwd.clone(),
+        status: CardStatus::Idle,
+        awaiting_reason: None,
+        session_id: None,
+        created_at: String::new(),
+        updated_at: String::new(),
+        archived_at: None,
+    })
+}
+
 pub(super) fn card_create(d: &Arc<Daemon>, p: CardCreateParams) -> Result<Value> {
     validate_card_values(
         p.harness.as_deref().unwrap_or(DEFAULT_HARNESS),
@@ -17,24 +125,36 @@ pub(super) fn card_create(d: &Arc<Daemon>, p: CardCreateParams) -> Result<Value>
         p.space_cwd.as_deref(),
         &d.config,
     )?;
-    let card = d.store.lock().create_card(&p)?;
-    let column = require_column(d, card.column_id)?;
+
+    let (card, enqueue) = {
+        // Scheduler state and card creation/enqueue share one critical
+        // section. The DB UoW below contains no Herdr or process I/O.
+        let mut _sched = d.sched.lock().unwrap();
+        let db = d.store.lock();
+        let pending = pending_create_card(&db, &p)?;
+        let column = db
+            .get_column(pending.column_id)?
+            .ok_or_else(|| Error::NotFound(format!("column {}", pending.column_id)))?;
+        let entry = decide_entry(&column, pending.status, false);
+        if entry.enqueue {
+            let prepared = prepare_enqueue_values(d, &db, &pending, pending.column_id, false)?;
+            let (card, _run) = db.create_card_and_enqueue_uow(&p, &prepared.borrowed())?;
+            _sched.chain_hops.remove(&card.id);
+            (card, true)
+        } else {
+            (db.create_card(&p)?, false)
+        }
+    };
+
     d.emit_changed(
         BoardChangedReason::CardCreated,
         Some(card.id),
         Some(card.column_id),
     );
-
-    // Creating directly into an auto column dispatches immediately.
-    if column.trigger == Trigger::Auto {
-        let entry = decide_entry(&column, card.status, false);
-        if entry.enqueue {
-            d.sched.lock().unwrap().chain_hops.remove(&card.id);
-            enqueue_run(d, card.id, card.column_id, false)?;
-            d.wake_dispatch();
-        }
+    if enqueue {
+        d.wake_dispatch();
     }
-    Ok(json!(require_card(d, card.id)?))
+    Ok(json!(card))
 }
 
 pub(super) fn card_update(d: &Arc<Daemon>, p: CardUpdateParams) -> Result<Value> {
@@ -107,8 +227,8 @@ pub(super) fn card_archive(d: &Arc<Daemon>, p: CardArchiveParams) -> Result<Valu
 }
 
 pub(super) fn card_move(d: &Arc<Daemon>, p: CardMoveParams) -> Result<Value> {
-    let (card, target, source_board_id, source_column_id) = {
-        let _sched = d.sched.lock().unwrap();
+    let (card, target, source_board_id, source_column_id, enqueue) = {
+        let mut _sched = d.sched.lock().unwrap();
         let db = d.store.lock();
         let current = db
             .get_card(p.id)?
@@ -125,7 +245,9 @@ pub(super) fn card_move(d: &Arc<Daemon>, p: CardMoveParams) -> Result<Value> {
         if cross {
             // The destination board must actually exist; the declared board
             // must match the target column's board.
-            let declared = p.board_id.unwrap();
+            let declared = p.board_id.ok_or_else(|| {
+                Error::InvalidState("cross-board move has no destination board".into())
+            })?;
             db.get_board(declared)?;
             if target.board_id != declared {
                 return Err(Error::InvalidState(format!(
@@ -169,15 +291,51 @@ pub(super) fn card_move(d: &Arc<Daemon>, p: CardMoveParams) -> Result<Value> {
                 }
             }
         }
-        let card = if cross {
-            db.transfer_card(p.id, p.board_id.unwrap(), p.column_id, p.position)?
+
+        let entry = decide_entry(&target, current.status, false);
+        let card = if entry.enqueue {
+            let prepared = prepare_enqueue_values(d, &db, &current, p.column_id, false)?;
+            let (card, _run) = if cross {
+                db.transfer_card_and_enqueue_uow(
+                    p.id,
+                    p.board_id.ok_or_else(|| {
+                        Error::InvalidState("cross-board move has no destination board".into())
+                    })?,
+                    p.column_id,
+                    p.position,
+                    &prepared.borrowed(),
+                )?
+            } else {
+                db.move_card_and_enqueue_uow(p.id, p.column_id, p.position, &prepared.borrowed())?
+            };
+            // This scheduler-only mutation follows the DB commit and is not
+            // observable when the durable move/enqueue UoW fails.
+            _sched.chain_hops.remove(&card.id);
+            card
+        } else if cross {
+            db.transfer_card(
+                p.id,
+                p.board_id.ok_or_else(|| {
+                    Error::InvalidState("cross-board move has no destination board".into())
+                })?,
+                p.column_id,
+                p.position,
+            )?
         } else {
             db.move_card(p.id, p.column_id, p.position)?
         };
-        (card, target, current.board_id, current.column_id)
+        (
+            card,
+            target,
+            current.board_id,
+            current.column_id,
+            entry.enqueue,
+        )
     };
+
     // One precise CardMoved per affected board (the event now carries
-    // board_id), replacing the old double coarse emit.
+    // board_id), replacing the old double coarse emit. Events are published
+    // only after both the move and any initial enqueue have committed.
     if source_board_id != target.board_id {
         d.emit_changed_board(
             BoardChangedReason::CardMoved,
@@ -192,15 +350,10 @@ pub(super) fn card_move(d: &Arc<Daemon>, p: CardMoveParams) -> Result<Value> {
         Some(card.id),
         Some(p.column_id),
     );
-
-    let entry = decide_entry(&target, card.status, false);
-    if entry.enqueue {
-        // Human move resets the auto-chain counter.
-        d.sched.lock().unwrap().chain_hops.remove(&card.id);
-        enqueue_run(d, card.id, p.column_id, false)?;
+    if enqueue {
         d.wake_dispatch();
     }
-    Ok(json!(require_card(d, card.id)?))
+    Ok(json!(card))
 }
 
 pub(super) fn card_get(d: &Arc<Daemon>, p: CardIdParams) -> Result<Value> {
@@ -218,6 +371,7 @@ pub(super) fn card_get(d: &Arc<Daemon>, p: CardIdParams) -> Result<Value> {
 pub(super) fn card_list(d: &Arc<Daemon>, p: CardListParams) -> Result<Value> {
     let db = d.store.lock();
     let board_id = p.board_id.unwrap_or(BOARD_ID);
+    let visibility = p.visibility.unwrap_or(CardVisibility::Active);
     let cards = match p.column_id {
         Some(c) => {
             let column = db
@@ -229,9 +383,9 @@ pub(super) fn card_list(d: &Arc<Daemon>, p: CardListParams) -> Result<Value> {
                     column.board_id
                 )));
             }
-            db.list_cards_in_column(c)?
+            db.list_cards_in_column_visible(c, visibility)?
         }
-        None => db.list_cards(board_id)?,
+        None => db.list_cards_visible(board_id, visibility)?,
     };
     Ok(json!(cards))
 }

--- a/crates/board-daemon/src/ops/comments.rs
+++ b/crates/board-daemon/src/ops/comments.rs
@@ -1,8 +1,155 @@
 use super::*;
+use board_core::model::CommentRecord;
+
+/// Check an explicitly supplied agent identity before it can mutate a
+/// comment.  The actor is intentionally optional for compatibility with the
+/// original `comment.add` API, which identified agent comments only through
+/// their `author` string.
+fn require_agent_run(
+    db: &board_core::db::Db,
+    actor_run_id: i64,
+    card_id: i64,
+    author: &str,
+) -> Result<()> {
+    let expected_author = format!("agent:{actor_run_id}");
+    if author != expected_author {
+        return Err(Error::InvalidState(format!(
+            "agent run {actor_run_id} may only act as {expected_author}"
+        )));
+    }
+
+    let run = match db.get_run(actor_run_id) {
+        Ok(run) => run,
+        Err(Error::NotFound(_)) => {
+            // The provider-free fake harness historically gets an injected
+            // BOARD_RUN_ID without first persisting a lifecycle row. Keep
+            // that compatibility path, but do not weaken identity checks for
+            // normal harnesses or for a durable run that belongs elsewhere.
+            let card = db
+                .get_card(card_id)?
+                .ok_or_else(|| Error::NotFound(format!("card {card_id}")))?;
+            if card.harness == "fake" && db.open_run_for_card(card_id)?.is_none() {
+                return Ok(());
+            }
+            return Err(Error::NotFound(format!("run {actor_run_id}")));
+        }
+        Err(error) => return Err(error),
+    };
+    if run.card_id != card_id {
+        return Err(Error::InvalidState(format!(
+            "agent run {actor_run_id} does not belong to comment card {card_id}"
+        )));
+    }
+    if run.ended_at.is_some() {
+        return Err(Error::InvalidState(format!(
+            "agent run {actor_run_id} is no longer open"
+        )));
+    }
+    Ok(())
+}
+
+fn comment_for_mutation(
+    db: &board_core::db::Db,
+    id: i64,
+    actor_run_id: Option<i64>,
+) -> Result<CommentRecord> {
+    let comment = db
+        .get_comment(id)?
+        .ok_or_else(|| Error::NotFound(format!("comment {id}")))?;
+    if let Some(run_id) = actor_run_id {
+        require_agent_run(db, run_id, comment.card_id, &comment.author)?;
+    }
+    Ok(comment)
+}
 
 pub(super) fn comment_add(d: &Arc<Daemon>, p: CommentAddParams) -> Result<Value> {
-    let author = p.author.as_deref().unwrap_or("user");
-    let comment = d.store.lock().add_comment(p.card_id, author, &p.body)?;
-    d.emit_changed(BoardChangedReason::CommentAdded, Some(p.card_id), None);
+    let (comment, card) = {
+        let db = d.store.lock();
+        let card = db
+            .get_card(p.card_id)?
+            .ok_or_else(|| Error::NotFound(format!("card {}", p.card_id)))?;
+        let author = match p.actor_run_id {
+            Some(run_id) => {
+                let expected = format!("agent:{run_id}");
+                // An explicitly supplied author is checked, while omitting it
+                // gets the identity implied by the actor run. This keeps the
+                // old author-only comment.add call compatible with fake
+                // agents, but prevents a new actor-aware caller from forging
+                // another run's ownership.
+                if let Some(author) = p.author.as_deref() {
+                    require_agent_run(&db, run_id, p.card_id, author)?;
+                } else {
+                    require_agent_run(&db, run_id, p.card_id, &expected)?;
+                }
+                expected
+            }
+            None => p.author.unwrap_or_else(|| "user".into()),
+        };
+        let comment = db.add_comment(card.id, &author, &p.body)?;
+        (comment, card)
+    };
+    d.emit_changed_board(
+        BoardChangedReason::CommentAdded,
+        card.board_id,
+        Some(card.id),
+        None,
+    );
     Ok(json!(comment))
+}
+
+pub(super) fn comment_get(d: &Arc<Daemon>, p: CommentGetParams) -> Result<Value> {
+    let comment = d
+        .store
+        .lock()
+        .get_comment(p.id)?
+        .ok_or_else(|| Error::NotFound(format!("comment {}", p.id)))?;
+    Ok(json!(comment))
+}
+
+pub(super) fn comment_update(d: &Arc<Daemon>, p: CommentUpdateParams) -> Result<Value> {
+    let (updated, card) = {
+        let db = d.store.lock();
+        let comment = comment_for_mutation(&db, p.id, p.actor_run_id)?;
+        let card = db
+            .get_card(comment.card_id)?
+            .ok_or_else(|| Error::NotFound(format!("card {}", comment.card_id)))?;
+        let updated = db.update_comment(comment.id, &p.body)?;
+        (updated, card)
+    };
+    d.emit_changed_board(
+        BoardChangedReason::CommentAdded,
+        card.board_id,
+        Some(card.id),
+        None,
+    );
+    Ok(json!(updated))
+}
+
+pub(super) fn comment_delete(d: &Arc<Daemon>, p: CommentDeleteParams) -> Result<Value> {
+    let card = {
+        let db = d.store.lock();
+        let comment = comment_for_mutation(&db, p.id, p.actor_run_id)?;
+        let card = db
+            .get_card(comment.card_id)?
+            .ok_or_else(|| Error::NotFound(format!("card {}", comment.card_id)))?;
+        db.soft_delete_comment(comment.id)?;
+        card
+    };
+    d.emit_changed_board(
+        BoardChangedReason::CommentAdded,
+        card.board_id,
+        Some(card.id),
+        None,
+    );
+    Ok(json!(DeletedResult { deleted: true }))
+}
+
+pub(super) fn comment_history(d: &Arc<Daemon>, p: CommentHistoryParams) -> Result<Value> {
+    let db = d.store.lock();
+    // list_comment_history intentionally returns an empty list for an unknown
+    // id at the DB layer; the RPC resource endpoint should distinguish that
+    // from a real comment with no snapshots.
+    db.get_comment(p.id)?
+        .ok_or_else(|| Error::NotFound(format!("comment {}", p.id)))?;
+    Ok(json!(db.list_comment_history(p.id)?))
 }

--- a/crates/board-daemon/src/ops/mod.rs
+++ b/crates/board-daemon/src/ops/mod.rs
@@ -30,6 +30,7 @@ pub fn handle_request(d: &Arc<Daemon>, method: &str, params: Value) -> Result<Va
             Ok(json!(StopResult { stopping: true }))
         }
         "board.open" => boards::board_open(d, from(params)?),
+        "board.rename" => boards::board_rename(d, from(params)?),
         "board.list" => boards::board_list(d),
         "board.get" => boards::board_get(
             d,
@@ -43,7 +44,12 @@ pub fn handle_request(d: &Arc<Daemon>, method: &str, params: Value) -> Result<Va
         "column.update" => columns::column_update(d, from(params)?),
         "column.reorder" => columns::column_reorder(d, from(params)?),
         "column.delete" => columns::column_delete(d, from(params)?),
-        "template.apply" => template::apply(d, from(params)?),
+        "template.apply" => {
+            // Keep the legacy module linked while the atomic implementation
+            // lives with request operations.
+            let _ = template::apply;
+            boards::template_apply(d, from(params)?)
+        }
         "card.create" => cards::card_create(d, from(params)?),
         "card.update" => cards::card_update(d, from(params)?),
         "card.delete" => cards::card_delete(d, from(params)?),
@@ -52,6 +58,10 @@ pub fn handle_request(d: &Arc<Daemon>, method: &str, params: Value) -> Result<Va
         "card.get" => cards::card_get(d, from(params)?),
         "card.list" => cards::card_list(d, from(params)?),
         "comment.add" => comments::comment_add(d, from(params)?),
+        "comment.get" => comments::comment_get(d, from(params)?),
+        "comment.update" => comments::comment_update(d, from(params)?),
+        "comment.delete" => comments::comment_delete(d, from(params)?),
+        "comment.history" => comments::comment_history(d, from(params)?),
         "run.done" => runs::run_done(d, from(params)?),
         "run.pane_exited" => runs::run_pane_exited(d, from(params)?),
         "run.cancel" => runs::run_cancel(d, from(params)?),
@@ -74,11 +84,4 @@ fn require_card(d: &Arc<Daemon>, id: i64) -> Result<board_core::model::Card> {
         .lock()
         .get_card(id)?
         .ok_or_else(|| Error::NotFound(format!("card {id}")))
-}
-
-fn require_column(d: &Arc<Daemon>, id: i64) -> Result<board_core::model::Column> {
-    d.store
-        .lock()
-        .get_column(id)?
-        .ok_or_else(|| Error::NotFound(format!("column {id}")))
 }

--- a/crates/board-daemon/src/ops/tests/boards.rs
+++ b/crates/board-daemon/src/ops/tests/boards.rs
@@ -1,4 +1,5 @@
 use super::*;
+use rusqlite::Connection;
 
 #[test]
 fn daemon_stop_triggers_shutdown_and_reports_stopping() {
@@ -44,6 +45,35 @@ fn board_open_list_get_and_legacy_default_are_scoped() {
     assert_eq!(omitted["board"]["name"], "Global");
     let list = handle_request(&d, "board.list", json!({})).unwrap();
     assert_eq!(list["boards"][0]["name"], "Global");
+}
+
+#[test]
+fn board_get_snapshot_includes_archived_cards() {
+    let d = test_daemon(Config::default());
+    let active = handle_request(&d, "card.create", json!({"title":"active"})).unwrap();
+    let archived = handle_request(&d, "card.create", json!({"title":"archived"})).unwrap();
+    handle_request(
+        &d,
+        "card.archive",
+        json!({"id": archived["id"], "archived": true}),
+    )
+    .unwrap();
+
+    let cards = handle_request(&d, "board.get", json!({})).unwrap()["cards"]
+        .as_array()
+        .unwrap()
+        .clone();
+    let ids = cards
+        .iter()
+        .map(|card| card["id"].as_i64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        ids,
+        vec![
+            active["id"].as_i64().unwrap(),
+            archived["id"].as_i64().unwrap()
+        ]
+    );
 }
 
 #[test]
@@ -158,4 +188,63 @@ fn template_and_scheduler_operate_on_scoped_board() {
         .unwrap()
         .iter()
         .any(|(_, queued)| queued.id == card["id"].as_i64().unwrap()));
+}
+
+#[test]
+fn template_apply_rolls_back_columns_after_intermediate_wiring_failure() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("template-atomic.db");
+    let db = Db::open(&path).unwrap();
+    let before = db.list_columns(BOARD_ID).unwrap();
+    Connection::open(&path)
+        .unwrap()
+        .execute_batch(
+            "CREATE TRIGGER abort_template_execute_wire
+             BEFORE UPDATE OF on_success_column_id ON columns
+             WHEN NEW.name='Execute'
+             BEGIN SELECT RAISE(ABORT, 'fault: template wire'); END;",
+        )
+        .unwrap();
+
+    let (events_tx, mut events_rx) = broadcast::channel(16);
+    let (dispatch_tx, mut dispatch_rx) = mpsc::unbounded_channel();
+    let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+    let d = Arc::new(Daemon::new(
+        Store::new(db),
+        Config::default(),
+        DaemonSettings::default(),
+        path.clone(),
+        dir.path().join("board.sock"),
+        Arc::new(LocalSpawner::new()),
+        None,
+        None,
+        events_tx,
+        dispatch_tx,
+        shutdown_tx,
+    ));
+
+    let error = handle_request(
+        &d,
+        "template.apply",
+        json!({"name":"pipeline", "board_id":BOARD_ID}),
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("fault: template wire"),
+        "{error}"
+    );
+
+    assert!(matches!(
+        events_rx.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        dispatch_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    drop(d);
+    let reopened = Db::open(&path).unwrap();
+    assert_eq!(reopened.list_columns(BOARD_ID).unwrap(), before);
+    assert!(reopened.list_cards(BOARD_ID).unwrap().is_empty());
 }

--- a/crates/board-daemon/src/ops/tests/comments.rs
+++ b/crates/board-daemon/src/ops/tests/comments.rs
@@ -1,0 +1,285 @@
+use super::*;
+use board_core::db::EnqueueRun;
+
+fn event_for(rx: &mut broadcast::Receiver<Event>) -> Event {
+    rx.try_recv().expect("expected board change event")
+}
+
+#[test]
+fn board_rename_emits_a_scoped_board_change() {
+    let d = test_daemon(Config::default());
+    let board = handle_request(&d, "board.open", json!({"scope_path":"/rename"})).unwrap();
+    let board_id = board["board"]["id"].as_i64().unwrap();
+    let mut events = d.events_tx.subscribe();
+
+    let renamed = handle_request(
+        &d,
+        "board.rename",
+        json!({"board_id":board_id,"name":"Renamed"}),
+    )
+    .unwrap();
+    assert_eq!(renamed["id"], board_id);
+    assert_eq!(renamed["name"], "Renamed");
+    assert_eq!(
+        event_for(&mut events),
+        Event::BoardChanged {
+            reason: BoardChangedReason::ColumnChanged,
+            board_id: Some(board_id),
+            card_id: None,
+            column_id: None,
+        }
+    );
+}
+
+#[test]
+fn card_list_visibility_is_forwarded_for_board_and_column_queries() {
+    let d = test_daemon(Config::default());
+    let active = handle_request(&d, "card.create", json!({"title":"active"})).unwrap();
+    let archived = handle_request(&d, "card.create", json!({"title":"archived"})).unwrap();
+    let archived_id = archived["id"].as_i64().unwrap();
+    let column_id = active["column_id"].as_i64().unwrap();
+    handle_request(
+        &d,
+        "card.archive",
+        json!({"id":archived_id,"archived":true}),
+    )
+    .unwrap();
+
+    let list = |params| handle_request(&d, "card.list", params).unwrap();
+    assert_eq!(list(json!({})).as_array().unwrap().len(), 1);
+    assert_eq!(
+        list(json!({"visibility":"all"})).as_array().unwrap().len(),
+        2
+    );
+    let archived_cards = list(json!({
+        "column_id": column_id,
+        "visibility": "archived"
+    }));
+    assert_eq!(archived_cards.as_array().unwrap().len(), 1);
+    assert_eq!(archived_cards[0]["id"], archived_id);
+}
+
+#[test]
+fn fake_harness_agent_ids_remain_compatible_without_durable_runs() {
+    let d = test_daemon(Config::default());
+    let card = d
+        .store
+        .lock()
+        .create_card(&CardCreateParams {
+            title: "fake comments".into(),
+            harness: Some("fake".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    let added = handle_request(
+        &d,
+        "comment.add",
+        json!({
+            "card_id": card.id,
+            "body": "fake output",
+            "actor_run_id": 12345
+        }),
+    )
+    .unwrap();
+    assert_eq!(added["author"], "agent:12345");
+    let edited = handle_request(
+        &d,
+        "comment.update",
+        json!({
+            "id": added["id"],
+            "body": "revised fake output",
+            "actor_run_id": 12345
+        }),
+    )
+    .unwrap();
+    assert_eq!(edited["body"], "revised fake output");
+}
+
+#[test]
+fn fake_harness_missing_actor_run_is_rejected_when_card_has_open_run() {
+    let d = test_daemon(Config::default());
+    let card = d
+        .store
+        .lock()
+        .create_card(&CardCreateParams {
+            title: "fake comments with open run".into(),
+            harness: Some("fake".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    {
+        let db = d.store.lock();
+        db.enqueue_run_uow(&EnqueueRun {
+            card_id: card.id,
+            column_id: card.column_id,
+            harness: "fake",
+            argv_json: "[]",
+            prompt_snapshot: "prompt",
+            system_prompt_snapshot: None,
+            launch_spec_json: None,
+            session_id: None,
+            session: None,
+        })
+        .unwrap();
+    }
+
+    let error = handle_request(
+        &d,
+        "comment.add",
+        json!({
+            "card_id": card.id,
+            "body": "must not use fixture fallback",
+            "actor_run_id": 12345
+        }),
+    );
+    assert!(error.is_err());
+    assert!(d.store.lock().list_comments(card.id).unwrap().is_empty());
+}
+
+#[test]
+fn comment_routes_authorize_agents_and_hide_soft_deleted_comments() {
+    let d = test_daemon(Config::default());
+    let card = handle_request(&d, "card.create", json!({"title":"comments"})).unwrap();
+    let card_id = card["id"].as_i64().unwrap();
+    let board_id = card["board_id"].as_i64().unwrap();
+    let column_id = card["column_id"].as_i64().unwrap();
+
+    // An author-only add remains valid for configured/fake agents that use the
+    // original comment.add payload and do not send actor_run_id.
+    let legacy = handle_request(
+        &d,
+        "comment.add",
+        json!({"card_id":card_id,"author":"agent:9001","body":"legacy"}),
+    )
+    .unwrap();
+    let legacy_id = legacy["id"].as_i64().unwrap();
+
+    let run_id = {
+        let db = d.store.lock();
+        let run = db
+            .enqueue_run_uow(&EnqueueRun {
+                card_id,
+                column_id,
+                harness: "fake",
+                argv_json: "[]",
+                prompt_snapshot: "prompt",
+                system_prompt_snapshot: None,
+                launch_spec_json: None,
+                session_id: None,
+                session: None,
+            })
+            .unwrap();
+        db.promote_run_uow(run.id, Some("workspace"), Some("pane"), None)
+            .unwrap();
+        run.id
+    };
+    let mut events = d.events_tx.subscribe();
+
+    let owned = handle_request(
+        &d,
+        "comment.add",
+        json!({"card_id":card_id,"body":"owned","actor_run_id":run_id}),
+    )
+    .unwrap();
+    let owned_id = owned["id"].as_i64().unwrap();
+    assert_eq!(owned["author"], format!("agent:{run_id}"));
+    assert_eq!(
+        event_for(&mut events),
+        Event::BoardChanged {
+            reason: BoardChangedReason::CommentAdded,
+            board_id: Some(board_id),
+            card_id: Some(card_id),
+            column_id: None,
+        }
+    );
+
+    let edited = handle_request(
+        &d,
+        "comment.update",
+        json!({"id":owned_id,"body":"edited","actor_run_id":run_id}),
+    )
+    .unwrap();
+    assert_eq!(edited["body"], "edited");
+    assert!(matches!(
+        event_for(&mut events),
+        Event::BoardChanged {
+            card_id: Some(id),
+            ..
+        } if id == card_id
+    ));
+
+    let other_run_id = {
+        let db = d.store.lock();
+        let other_card = db
+            .create_card(&CardCreateParams {
+                title: "other card".into(),
+                ..Default::default()
+            })
+            .unwrap();
+        let run = db
+            .enqueue_run_uow(&EnqueueRun {
+                card_id: other_card.id,
+                column_id: other_card.column_id,
+                harness: "fake",
+                argv_json: "[]",
+                prompt_snapshot: "prompt",
+                system_prompt_snapshot: None,
+                launch_spec_json: None,
+                session_id: None,
+                session: None,
+            })
+            .unwrap();
+        db.promote_run_uow(run.id, Some("workspace"), Some("pane-2"), None)
+            .unwrap();
+        run.id
+    };
+    let denied = handle_request(
+        &d,
+        "comment.delete",
+        json!({"id":owned_id,"actor_run_id":other_run_id}),
+    )
+    .unwrap_err();
+    assert_eq!(denied.code(), 3);
+    assert!(events.try_recv().is_err());
+
+    // Human callers may edit an agent comment, and deletion is soft.
+    handle_request(
+        &d,
+        "comment.update",
+        json!({"id":legacy_id,"body":"human edit"}),
+    )
+    .unwrap();
+    handle_request(&d, "comment.delete", json!({"id":owned_id})).unwrap();
+    assert!(
+        handle_request(&d, "comment.get", json!({"id":owned_id})).unwrap()["deleted_at"]
+            .is_string()
+    );
+    assert!(
+        handle_request(&d, "comment.history", json!({"id":owned_id}))
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|entry| entry["body"] == "edited")
+    );
+    let detail = handle_request(&d, "card.get", json!({"id":card_id})).unwrap();
+    assert!(!detail["comments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|comment| comment["id"] == owned_id));
+
+    let system = handle_request(
+        &d,
+        "comment.add",
+        json!({"card_id":card_id,"author":"system","body":"immutable"}),
+    )
+    .unwrap();
+    assert!(handle_request(
+        &d,
+        "comment.update",
+        json!({"id":system["id"],"body":"changed"}),
+    )
+    .is_err());
+    assert!(handle_request(&d, "comment.delete", json!({"id":system["id"]}),).is_err());
+}

--- a/crates/board-daemon/src/ops/tests/lifecycle.rs
+++ b/crates/board-daemon/src/ops/tests/lifecycle.rs
@@ -753,3 +753,137 @@ fn column_delete_rejects_queued_blocked_and_awaiting_open_runs() {
         assert!(err.to_string().contains("open run"));
     }
 }
+
+fn daemon_with_enqueue_fault(
+    db: Db,
+    path: &std::path::Path,
+) -> (
+    Arc<Daemon>,
+    broadcast::Receiver<Event>,
+    mpsc::UnboundedReceiver<()>,
+) {
+    let (events_tx, events_rx) = broadcast::channel(16);
+    let (dispatch_tx, dispatch_rx) = mpsc::unbounded_channel();
+    let (shutdown_tx, _shutdown_rx) = watch::channel(false);
+    let d = Arc::new(Daemon::new(
+        Store::new(db),
+        Config::default(),
+        DaemonSettings::default(),
+        path.to_path_buf(),
+        path.with_extension("sock"),
+        Arc::new(LocalSpawner::new()),
+        None,
+        None,
+        events_tx,
+        dispatch_tx,
+        shutdown_tx,
+    ));
+    (d, events_rx, dispatch_rx)
+}
+
+#[test]
+fn card_create_into_auto_rolls_back_when_enqueue_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("create-auto-fault.db");
+    let armed = Arc::new(AtomicBool::new(false));
+    let hook_armed = armed.clone();
+    let db = Db::open_with_lifecycle_fault_hook(&path, move |point| {
+        if hook_armed.load(Ordering::SeqCst) && point == LifecycleFaultPoint::EnqueueAfterRunInsert
+        {
+            return Err(Error::InvalidState("injected enqueue fault".into()));
+        }
+        Ok(())
+    })
+    .unwrap();
+    let auto = db
+        .create_column(&ColumnCreateParams {
+            name: "Auto".into(),
+            trigger: Some(Trigger::Auto),
+            ..Default::default()
+        })
+        .unwrap();
+    let before_columns = db.list_columns(BOARD_ID).unwrap();
+    let (d, mut events_rx, mut dispatch_rx) = daemon_with_enqueue_fault(db, &path);
+    armed.store(true, Ordering::SeqCst);
+
+    let error = handle_request(
+        &d,
+        "card.create",
+        json!({"column_id":auto.id, "title":"must not persist"}),
+    )
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("injected enqueue fault"),
+        "{error}"
+    );
+
+    assert!(matches!(
+        events_rx.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        dispatch_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    drop(d);
+    let reopened = Db::open(&path).unwrap();
+    assert_eq!(reopened.list_columns(BOARD_ID).unwrap(), before_columns);
+    assert!(reopened.list_cards(BOARD_ID).unwrap().is_empty());
+}
+
+#[test]
+fn card_move_into_auto_rolls_back_when_enqueue_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("move-auto-fault.db");
+    let armed = Arc::new(AtomicBool::new(false));
+    let hook_armed = armed.clone();
+    let db = Db::open_with_lifecycle_fault_hook(&path, move |point| {
+        if hook_armed.load(Ordering::SeqCst) && point == LifecycleFaultPoint::EnqueueAfterRunInsert
+        {
+            return Err(Error::InvalidState("injected enqueue fault".into()));
+        }
+        Ok(())
+    })
+    .unwrap();
+    let source = db.default_column_id(BOARD_ID).unwrap();
+    let auto = db
+        .create_column(&ColumnCreateParams {
+            name: "Auto".into(),
+            trigger: Some(Trigger::Auto),
+            ..Default::default()
+        })
+        .unwrap();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "must stay put".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let before = card.clone();
+    let (d, mut events_rx, mut dispatch_rx) = daemon_with_enqueue_fault(db, &path);
+    armed.store(true, Ordering::SeqCst);
+
+    let error =
+        handle_request(&d, "card.move", json!({"id":card.id, "column_id":auto.id})).unwrap_err();
+    assert!(
+        error.to_string().contains("injected enqueue fault"),
+        "{error}"
+    );
+
+    assert!(matches!(
+        events_rx.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        dispatch_rx.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+
+    drop(d);
+    let reopened = Db::open(&path).unwrap();
+    assert_eq!(reopened.get_card(card.id).unwrap().unwrap(), before);
+    assert!(reopened.list_runs(card.id).unwrap().is_empty());
+    assert_eq!(reopened.list_cards_in_column(source).unwrap().len(), 1);
+    assert!(reopened.list_cards_in_column(auto.id).unwrap().is_empty());
+}

--- a/crates/board-daemon/src/ops/tests/mod.rs
+++ b/crates/board-daemon/src/ops/tests/mod.rs
@@ -90,6 +90,7 @@ fn fake_herdr(reply: &'static str) -> (tempfile::TempDir, PathBuf) {
 
 mod boards;
 mod cards;
+mod comments;
 mod discovery;
 mod lifecycle;
 mod validation;

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,9 @@ The reference detail behind the [root README](../README.md). Start here to find 
 
 | Surface | Final version / owner | Canonical source |
 |---|---|---|
-| Board socket | v1; `board-core::protocol` | [protocol.md](protocol.md) |
-| SQLite | schema v12; `schema.sql` + `board-core::db` migrations | [design.md](design.md) |
+| Board socket | v1; `board-core::protocol` (additive `active_runs`, error `kind`/`details`) | [protocol.md](protocol.md) |
+| SQLite | schema v13; `schema.sql` + `board-core::db` migrations | [design.md](design.md) |
+| CLI | canonical nested `board board/card/comment/run/column` taxonomy; `board-cli` wiring | [README CLI reference](../README.md#cli-reference), [skill](../skill/SKILL.md) |
 | Herdr client | 0.7.5 / socket protocol 17; `board-herdr` typed calls | [herdr.md](herdr.md) |
 | Runtime launch | daemon-owned `Spawner`, placement, process/pane handles | [implementation.md](implementation.md) |
 | Config | typed `RootConfig`, one parse, environment overrides after parse | [design.md](design.md) |
@@ -29,8 +30,8 @@ isolation is an agent prompt concern, not a board space primitive.
 
 The [`schema.sql`](../schema.sql) at the repo root is the fresh SQLite schema; migration behavior
 and upgrade tests live in `board-core::db`. Before handoff, check that docs still point to existing
-files, that the version matrix above says v11 / v1 / Herdr 0.7.5-protocol 17, and that the scenario
-catalog lists every `e2e/NN-*.sh` from 01 through 25. The provider-free static safety gate is:
+files, that the version matrix above says schema v13 / protocol v1 / Herdr 0.7.5-protocol 17, and that
+the scenario catalog lists every `e2e/NN-*.sh` from 01 through 25. The provider-free static safety gate is:
 
 ```bash
 cargo fmt --all --check

--- a/docs/design.md
+++ b/docs/design.md
@@ -90,9 +90,10 @@ keeps a predictable strip: the prototype targets a 0.40 ratio for the initial sp
 narrow terminals so the anchor remains reusable) and uses live geometry thereafter. Placement fails
 closed below the minimum of 24x6 for the shell and 12x8 for the agent; it never launches an agent
 on an undersized root or child.
-Herdr labels are not unique, so neither tab nor anchor ownership is inferred from one. Schema v12
-persists the exact anchor pane id with each promoted run; after restart, the daemon reconstructs the
-exact tab and anchor only from scoped durable pane identities in the same session and workspace.
+Herdr labels are not unique, so neither tab nor anchor ownership is inferred from one. The current
+schema v13 retains the exact anchor pane id introduced by v12 with each promoted run; after restart,
+the daemon reconstructs the exact tab and anchor only from scoped durable pane identities in the same
+session and workspace.
 A renamed anchor remains owned by identity. If that exact anchor was closed, it is recreated only by
 splitting a currently live durable board-run child; if no such proof remains, a fresh tab is created
 instead of touching a foreign pane. Before a later split, exact ended run children may be reclaimed
@@ -123,7 +124,8 @@ cards(id, board_id, column_id, position, title, description,
       space_kind ('workspace'|'new_workspace'), space_ref, space_cwd,
       status, awaiting_reason,                   -- reason set in 'awaiting', NULL otherwise
       session_id, created_at, updated_at, archived_at)
-comments(id, card_id, author, body, created_at)
+comments(id, card_id, author, body, created_at, deleted_at)
+comment_history(id, comment_id, card_id, author, body, created_at, deleted_at)
 runs(id, card_id, column_id, harness, argv_json, prompt_snapshot,
      system_prompt_snapshot,                    -- nullable; enqueue-time, trailer-inclusive
      launch_spec_json,                          -- nullable pre-v11; tagged durable execution spec
@@ -134,8 +136,8 @@ runs(id, card_id, column_id, harness, argv_json, prompt_snapshot,
      result_summary, log_path)
 ```
 
-Schema is versioned via `PRAGMA user_version` (current = **v11**). A fresh DB is built straight from
-`schema.sql` and stamped v11. Existing v1→v4 migrations retain their space/session, archive, and Pi
+Schema is versioned via `PRAGMA user_version` (current = **v13**). A fresh DB is built straight from
+`schema.sql` and stamped v13. Existing v1→v4 migrations retain their space/session, archive, and Pi
 effort behavior. v5 adds unique non-null `boards.scope_path`, preserves board `id=1` plus every
 related row as `Global`, and leaves existing card harnesses unchanged. v6 rebuilds `cards` to admit
 the `awaiting`/`done` statuses and adds `cards.awaiting_reason` (NULL outside `awaiting`). v7 adds
@@ -153,12 +155,19 @@ stores a format-tagged (`version: 1`) fully materialized argv/env/prompt launch 
 format versions are rejected rather than interpreted. Dispatch uses that spec and the persisted
 `runs.session`, so queued runs, retries, and auto-hops are unaffected by later card, column, or
 configuration edits. New runs also atomically preserve the fully resolved,
-board-protocol-trailer-inclusive system prompt at enqueue time. A legacy NULL remains a
+board-protocol-trailer-inclusive system prompt at enqueue time. v12 adds the durable anchor identity;
+v13 adds current comment soft deletion plus immutable audit snapshots. A legacy NULL remains a
 launch-version marker: pre-v7 built-ins
 execute their persisted all-in-one argv unchanged, while pre-v7 configured rows retain their
 historical spawn-time current-column reconstruction. `Run` deserialization defaults an omitted field
 to NULL, but serialization always omits `system_prompt_snapshot` and its contents from boardd wire
 responses. `launch_spec_json` is likewise internal and omitted in full from boardd wire responses.
+
+Source ownership is explicit: `schema.sql` is the fresh schema source, `board-core::db` owns ordered
+upgrades through v13, and `board-core::protocol` owns the v1 wire DTOs and additive compatibility
+rules. The CLI and TUI use typed `BoardClient` wrappers; only boardd reads or writes SQLite. New
+v1 fields such as `BoardSnapshot.active_runs` and RPC error `kind`/`details` are additive, so older
+clients can continue decoding the existing fields.
 
 ### Partial updates
 
@@ -421,7 +430,7 @@ opens the script, the residual configured-script orphan is an accepted asynchron
 3. Column engine: *Plan* is `trigger=auto` → **enqueue run** on the card's space queue.
 4. Dispatcher (respecting per-space serial queue + global cap):
    a. Resolve the card's session socket and `ping` it. Anything except exact Herdr 0.7.5/protocol 17 fails before workspace discovery/creation. Then reuse workspace `w4`, or create/reuse the card's labeled `new_workspace`; repository worktree isolation remains an agent prompt responsibility.
-   b. Preflight the selected socket again at the spawner boundary. For a new durable run, the card's **`card-<id>` tab** is resolved by exact owned id (reconstructed from the newest matching durable pane in the same session/workspace when boardd restarts), or `tab.create {workspace_id,cwd,env,…}` supplies a new shell anchor. The anchor is labeled `card-<id>-anchor`, its exact id is persisted on the promoted v12 run, and the run child is always created by `pane.split` from that anchor; `agent.start`/`pane run` never target the root. A renamed anchor is still selected only by exact identity; a closed anchor is recreated only from a durable board-run child in the exact proven tab, and missing proof creates a fresh tab without selecting a duplicate-label user tab. Exact ended children may be reclaimed before a later split so the anchor keeps usable geometry. The child receives the run env; the anchor receives only stable card identity. If multiple historical panes are live, newest run id wins; legacy rows retain their old lookup. There is no protocol-16 placement inside `agent.start`.
+   b. Preflight the selected socket again at the spawner boundary. For a new durable run, the card's **`card-<id>` tab** is resolved by exact owned id (reconstructed from the newest matching durable pane in the same session/workspace when boardd restarts), or `tab.create {workspace_id,cwd,env,…}` supplies a new shell anchor. The anchor is labeled `card-<id>-anchor`, its exact id is persisted on the promoted run, and the run child is always created by `pane.split` from that anchor; `agent.start`/`pane run` never target the root. A renamed anchor is still selected only by exact identity; a closed anchor is recreated only from a durable board-run child in the exact proven tab, and missing proof creates a fresh tab without selecting a duplicate-label user tab. Exact ended children may be reclaimed before a later split so the anchor keeps usable geometry. The child receives the run env; the anchor receives only stable card identity. If multiple historical panes are live, newest run id wins; legacy rows retain their old lookup. There is no protocol-16 placement inside `agent.start`.
    c. For Pi/Claude, write the snapshotted system prompt to a mode-`0600` temporary file; issue `agent.start {name,kind,pane_id,args}` on the split child with prompt-free startup args; a typed `agent_pane_busy` retries the exact request on that same child with bounded 100ms/200ms backoff (never another split); poll `agent.get` for readiness; then send only the task snapshot through `agent.prompt`. Remove the file. Card status → `running`; record the exact child pane/workspace ids. The pane is **visible** — you can watch or type into it anytime.
 
    **Pane naming and ownership**: the managed agent name is `card-<id>-<column-slug>` (e.g. `card-42-plan`, `card-42-execute`). Herdr names are exclusive while a pane is open, so `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`. A persistent `agent_pane_busy` closes only the board-owned child and leaves the pre-existing anchor. If a placement target disappears, boardd closes only the pane it created (a missing pane is already clean), restarts discovery from `tab.list`, and retries the complete placement once. A terminal launch error also closes only that board-owned pane; pre-existing user panes are never cleanup targets.
@@ -522,7 +531,7 @@ executes the returned plan; it performs no Herdr or SQLite I/O in the pure decis
 
 ## 9. Decisions (user-confirmed 2026-07-14)
 
-1. **Language: Rust** — ratatui TUI, rusqlite, tokio daemon; single binary `board` with subcommands (`tui`, `daemon`, `comment`, `done`, `move`, `card`).
+1. **Language: Rust** — ratatui TUI, rusqlite, tokio daemon; single binary `board` with canonical nested subcommands (`board`, `card`, `column`, `comment`, `run`) plus retained top-level aliases.
 2. **Access: overlay keybinding only** (no pinned workspace); `?` shows all keybinds.
 3. **DB: `~/.local/share/herdr-board/board.db`** (XDG data; overridable via `BOARD_DB` for tests). Plugin config dir holds only config — DB survives plugin reinstall.
 4. **Long-text editing: modal textarea + `Ctrl+E` → `$EDITOR`.**
@@ -533,7 +542,7 @@ executes the returned plan; it performs no Herdr or SQLite I/O in the pure decis
 
 ## 10. The herdr-board skill
 
-The repo ships a **skill** (`skill/SKILL.md`, optionally installed into an agent's skill directory) teaching agents the `board` CLI: command reference (`board card new/show/list`, `board comment`, `board move`, `board done --outcome ok|fail`), the card lifecycle, and the rules (always comment results *before* `board done`; `fail` means "this stage's goal was not met", not "I crashed").
+The repo ships a **skill** (`skill/SKILL.md`, optionally installed into an agent's skill directory) teaching agents the canonical `board` CLI: board/card/column CRUD, nested comment and run operations, visibility, JSON errors, and the card lifecycle. It preserves `card new` and the top-level `comment`/`done`/`move`/`cancel`/`retry` aliases. The critical rules remain: always comment results before `board done`; `fail` means "this stage's goal was not met", not "I crashed".
 
 Two consumers:
 

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -88,9 +88,10 @@ bounded 100ms/200ms backoff. It never allocates a second child for that
 response. Persistent busy is a launch failure whose cleanup closes only the
 owned child pane and leaves the anchor; `pane_not_found` is handled separately
 as a placement race that restarts discovery from `tab.list` and retries
-complete placement once. Schema v12 persists the exact anchor id with the run;
-after restart both tab and anchor are selected only from scoped durable pane
-identities. Labels are display metadata and never authorize a tab or pane.
+complete placement once. Schema v13 persists the exact anchor id with the run
+(the anchor was introduced in v12) and adds comment audit state; after restart
+both tab and anchor are selected only from scoped durable pane identities.
+Labels are display metadata and never authorize a tab or pane.
 `agent.read` remains a terminal screen/scrollback read, not a semantic result
 channel.
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -13,7 +13,7 @@ crates/
   board-tui/     # OWNED BY PHASE C. ratatui app (lib with run() entry)
   board-daemon/  # OWNED BY PHASE D. boardd server (lib with run() entry)
   board-cli/     # OWNED BY PHASE D. the single `board` binary: clap subcommands
-                 # tui/daemon/card/column/comment/done/move/cancel/retry/status
+                 # tui/daemon/board/template/card/column/comment/run + legacy aliases
 ```
 
 Ownership is strict: an agent only edits its crate(s) + may append to `[workspace.dependencies]`
@@ -22,12 +22,14 @@ in root Cargo.toml. Never edit another crate. Phase A creates all five crates co
 
 ## Contract versions and source ownership
 
-The final compatibility matrix is: board protocol **v1**, SQLite schema **v11**, and exactly
+The final compatibility matrix is: board protocol **v1**, SQLite schema **v13**, and exactly
 Herdr **0.7.5 / socket protocol 17**. The versioned source of truth is `schema.sql` for fresh
 SQLite databases and `board-core::db` migrations for upgrades; `board-core::protocol` owns the
 board wire DTOs; `board-herdr` owns only the verified Herdr socket surface; and `docs/design.md`
-and `docs/protocol.md` explain behavior rather than defining duplicate serde shapes. The complete
-live use-case catalog is [`../e2e/README.md`](../e2e/README.md), scenarios **01–25**; the safe
+and `docs/protocol.md` explain behavior rather than defining duplicate serde shapes. Schema v13 adds
+soft-deleted comments and immutable comment-history snapshots; the CLI exposes their nested CRUD
+and history commands while boardd remains the sole SQLite writer. The complete live use-case catalog
+is [`../e2e/README.md`](../e2e/README.md), scenarios **01–25**; the safe
 static harness is `e2e/test-harness.sh`, while `e2e/run-all.sh` is the opt-in live gate.
 
 ## Configuration boundary
@@ -83,7 +85,7 @@ pub trait Spawner: Send + Sync {
 ## Semantics source of truth
 
 `docs/protocol.md` + `docs/design.md` §5–§8. `schema.sql` at repo root is the current fresh schema
-(embedded and versioned with `PRAGMA user_version`). Schema v11 is current. v8 adds the partial
+(embedded and versioned with `PRAGMA user_version`). Schema v13 is current. v8 adds the partial
 unique index `idx_runs_one_open_per_card` and transactional enqueue/promotion/finalization units of
 work. v9 adds nullable durable timeout deadline/pause timestamps. Promotion writes the deadline in
 its transaction; awaiting pause/resume updates the card and timeout atomically and idempotently,
@@ -96,11 +98,13 @@ trailer-inclusive system prompt; pre-v7 rows remain `NULL` with no backfill. v10
 FIFO-queued and active-open run indexes; daemon queue reads use direct SQL pairs instead of scanning
 every card's run history. v11 adds nullable `runs.launch_spec_json`: v10 rows remain NULL, while new
 runs persist a version-1 tagged materialization of exact argv, env, managed prompt channels, and the
-run's Herdr session. Unsupported spec versions fail decoding. Dispatch consumes `runs.session` for
-v11 placement; pre-v11 rows explicitly retain current-card session lookup. The launch spec and
-system snapshot are both private DB state omitted from board wire DTOs. The typed `SpaceKey`
-preserves session/kind/ref null identity. A
-per-daemon async pass lock prevents competing passes from duplicating claims; each pass claims
+run's Herdr session. Unsupported spec versions fail decoding. Current placement consumes
+`runs.session`; pre-v11 rows explicitly retain current-card session lookup. v12 adds durable anchor
+identity, while v13 adds `comments.deleted_at`, `comment_history`, and its immutable insert-audit
+trigger. The launch spec and system snapshot are both private DB state omitted from board wire DTOs;
+comment history is exposed only through `comment.history`. The typed `SpaceKey` preserves
+session/kind/ref null identity. A per-daemon async pass lock prevents competing passes from duplicating
+claims; each pass claims
 per-space/global slots before concurrently launching independent spaces. That legacy
 `NULL` is intentional: built-ins keep their persisted all-in-one argv, while configured rows keep
 their historical spawn-time reconstruction. The internal snapshot is omitted from boardd wire
@@ -143,8 +147,8 @@ A (core+scaffold) → B (herdr client) ∥ C (TUI) → D (daemon+CLI+integration
 - B: unit: envelope encode/decode. Integration (ignored-by-default `#[ignore]` + run when HERDR_SOCK exists): read-only calls `session.snapshot`, `workspace.list` against live herdr.
 - C: insta snapshots via `ratatui::backend::TestBackend` + synthetic key events + FakeBoardClient: empty board (Todo only + hints), board with example pipeline & cards (status glyphs), new-card modal, column form, card detail w/ comments+runs, `?` help, delete-column prompt, move flow.
 - Restart recovery (`board-daemon::supervisor`) is a conservative one-pass classifier. Session resolution and snapshot I/O are injectable and happen before mutation. `Alive` adopts scheduler/watch intent and replays terminal status, `Gone` uses the existing pane-exit finalizer, and `Unknown` does nothing. The apply phase re-reads the open run/card, making duplicate passes idempotent and rejecting stale observations. Startup constructs/runs this pass for the Herdr spawner regardless of whether its initial best-effort client connected. The always-on supervisor then maintains independent per-socket streams and backoff, subscribes before taking a fresh bounded snapshot, and periodically reconciles missed events without resetting healthy sockets.
-- D: integration test (no herdr): start daemon on temp socket + temp DB with LocalSpawner + fake harness script → create card → move to auto column → fake agent comments + done → assert auto-transition, comments, run rows, statuses; timeout path; cancel path; queue serialization (two cards same space key run serially).
+- D: integration test (no herdr): start daemon on temp socket + temp DB with LocalSpawner + fake harness script → create card → move to auto column → fake agent comments + done → assert auto-transition, comments, run rows, statuses; timeout path; cancel path; queue serialization (two cards same space key run serially). The daemon comment suite also checks actor ownership, system-comment immutability, soft deletion, audit history, and event routing.
 - E: scenarios `e2e/01-core.sh` through `e2e/25-card-tabs.sh` (real Herdr, fake
   harnesses): disposable workspaces, protocol-17 placement, typed prompt delivery, bounded
-  same-pane `agent_pane_busy` retry, supervisor recovery, timer refresh, and identity-gated cleanup. Run `bash e2e/test-harness.sh` for the
+  same-pane `agent_pane_busy` retry, supervisor recovery, timer refresh, and identity-gated cleanup. CLI comment creation/context and system transition comments are covered by the live suite; CRUD/audit parity is kept hermetic in the CLI contracts. Run `bash e2e/test-harness.sh` for the
   provider-free static safety checks; reserve `e2e/run-all.sh` for the separate live gate.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -13,8 +13,10 @@ protocol version.
 - Newline-delimited JSON (NDJSON), UTF-8. One JSON object per line, both directions.
 - Request: `{"id":"<string>","method":"<name>","params":{...}}` (params may be omitted = `{}`).
 - Response: `{"id":"<same>","result":<any>}` or `{"id":"<same>","error":{"code":<int>,"message":"..."}}`.
+  Error objects may add `kind` and `details`; old clients may ignore those members.
 - Error codes: `1` bad request / unknown method, `2` not found, `3` invalid state
-  (e.g. delete column with running card), `4` herdr unavailable, `5` internal.
+  (e.g. delete column with running card), `4` herdr unavailable, `5` internal. The CLI preserves
+  this envelope for `--json` errors on stderr and emits no JSON on stdout.
 - A connection may send `{"id":"...","method":"events.subscribe"}`; boardd replies
   `{"id":"...","result":{"subscribed":true}}` and then streams event objects
   (no `id` field) on that connection until it closes. A subscribed connection can still
@@ -72,8 +74,10 @@ Boards are independent pipelines keyed by canonical path. `Global` is board `id=
   new board with exactly one manual `Todo` column.
 - `board.list {}` → `{boards:[Board…]}`; `Global` first, then scoped boards ordered by full path.
 - `board.get {board_id?}` → `{board:{id,name,scope_path}, columns:[Column…ordered], cards:[Card…], active_runs:[{card_id,started_at}…]}`.
-  Omitted `board_id` means `Global`. Cards include active and archived rows for local filtering.
-  `active_runs` is additive in protocol v1 and contains only started, open runs whose cards belong
+  Omitted `board_id` means `Global`. `board.open` returns the same snapshot shape. Both `board.get`
+  and `board.open` include **all active and archived cards** in `cards`, so the TUI can filter
+  locally and templates can evaluate the complete board state. `active_runs` is additive in
+  protocol v1 and contains only started, open runs whose cards belong
   to the requested board; queued, ended, and other-board runs are omitted. Older clients may omit
   the field when decoding a snapshot, which is treated as an empty list.
 - `column.create {name, board_id?, position?, system_prompt?, trigger?, on_success_column_id?, on_fail_column_id?, fresh_session?, harness_override?, model_override?, effort_override?, permission_override?, timeout_minutes?}` → `Column`; omitted `board_id` means `Global`.
@@ -129,7 +133,7 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
     - `new_workspace` — the daemon creates the workspace on first dispatch (label = `space_ref`, cwd = `space_cwd`), reusing an open workspace with that label if one exists. **Requires** non-empty `space_ref` and `space_cwd` on create (else error 1).
   - creating directly into an `auto` column dispatches immediately (same as move)
   - In the legacy v1→v2 migration, `cwd`/`worktree` kinds and `worktree_base` were removed;
-    current schema v12 treats worktree isolation as the agent's job via prompt instructions, not a
+    current schema v13 treats worktree isolation as the agent's job via prompt instructions, not a
     board concept. Existing databases migrate those cards to `workspace` (best effort,
     `space_ref` kept).
 - `card.update {id, …subset}` → `Card`; nullable update fields use the tri-state encoding below. Harness/model/effort/permission/session/space fields are refused while the card has an open run (`queued|running|blocked|awaiting`). Title/description remain editable; `done` is not open.
@@ -149,11 +153,28 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   `null`, but the field is never serialized onto the board wire. Schema v7 writes this nullable
   snapshot only for new runs; legacy `NULL` rows are not backfilled and retain their historical
   launch behavior.
-- `card.list {board_id?, column_id?}` → `[Card…]`; omitted `board_id` means `Global`, and a column filter must belong to the requested board.
+- `card.list {board_id?, column_id?, visibility?}` → `[Card…]`; omitted `board_id` means `Global`,
+  and a column filter must belong to the requested board. `visibility` defaults to `"active"` and
+  accepts `"active"`, `"all"`, or `"archived"`.
 
 ### comments / runs
-- `comment.add {card_id, body, author?}` → `Comment`. CLI `board comment` sets author
-  `agent:<run_id>` when `$BOARD_RUN_ID` is set, else `user`.
+
+- `comment.add {card_id, body, author?, actor_run_id?}` → `Comment`. CLI `board comment` and
+  `board card comment add` set `author` to `agent:<BOARD_RUN_ID>` and send `actor_run_id` when
+  `$BOARD_RUN_ID` is set; otherwise the author defaults to `user`. The additive actor field is
+  checked against the comment author, card, and open run.
+- `comment.get {id}` → `CommentRecord` (`id,card_id,author,body,created_at,deleted_at`). It returns
+  the current row even after a soft delete.
+- `comment.update {id,body,actor_run_id?}` → `CommentRecord`. It preserves the original author and
+  appends an immutable audit snapshot. An agent actor may update only its own comment from its exact
+  open run; a human actor may update non-system comments.
+- `comment.delete {id,actor_run_id?}` → `{deleted:true}`. This is a soft delete: the current row and
+  audit history remain, while ordinary card detail and future run prompts omit the comment. A deleted
+  comment cannot be edited or deleted again.
+- `comment.history {id}` → `[CommentHistory…]` ordered from creation through the latest edit. Every
+  insert creates the initial snapshot; edits append a snapshot; deletion marks the final snapshot's
+  `deleted_at` without changing its body. System comments are immutable at the database boundary and
+  cannot be edited or deleted by any actor.
 - `run.done {card_id, outcome:"ok"|"fail", summary?, run_id?}` → `{run, card}` — backend of
   `board done`. `run_id` is optional for compatibility: manual and TUI callers may omit it,
   and an omitted id completes the current active run. When supplied, it must exactly match the
@@ -161,18 +182,18 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   `BOARD_RUN_ID` when present and omits `run_id` otherwise. It closes the active run, posts a
   `system` comment, and applies the column transition (`ok`→on_success, `fail`→on_fail; no
   target → card stays, status `done`/`failed`). It is also the confirm channel for an `awaiting`
-  card (TUI `Enter` sends the same request). The only queued exception is a configured harness:
-  its `board done` must provide the exact queued run id and may arrive before runner registration.
-  A queued built-in Pi/Claude run is rejected because managed completion requires a registered
-  pane. A mismatched id, missing id for the queued exception, or otherwise ineligible run returns
-  an error.
+  card (TUI `Enter` and `card run confirm` send the same request). The only queued exception is a
+  configured harness: its `board done` must provide the exact queued run id and may arrive before
+  runner registration. A queued built-in Pi/Claude run is rejected because managed completion
+  requires a registered pane. A mismatched id, missing id for the queued exception, or otherwise
+  ineligible run returns an error.
 - `run.cancel {card_id}` → `{run, card}` — kills the pane (herdr `pane.close`), outcome `cancelled`, card status `failed`, no transition.
-- `run.retry {card_id}` → re-enqueue in current column (fresh run). Claude resumes with
-  `--fork-session`; Pi uses `--fork <old-id> --session-id <new-id>` and persists the new id.
+- `run.retry {card_id}` → `{run, card}` — re-enqueue in the current column as a fresh run. Claude
+  resumes with `--fork-session`; Pi uses `--fork <old-id> --session-id <new-id>` and persists it.
 - `run.focus {card_id, origin_socket}` → `{run_id,pane_id}` — chooses the newest run with a
   recorded pane, resolves its Herdr session, and calls socket `pane.focus`. `origin_socket` and the
   target socket are canonicalized and must match; cross-session focus is error 3, unavailable/stale
-  Herdr is error 4.
+  Herdr is error 4. The CLI resolves it from `--origin-socket`, `$HERDR_SOCKET_PATH`, or `$HERDR_SOCK`.
 
 **Internal runner-only method (not public board API):**
 `run.pane_exited {card_id,run_id}` is sent only by the hidden `board __pane-exited` configured-harness
@@ -267,7 +288,7 @@ Coarse by design — the TUI refetches only its selected `board.get {board_id}` 
    - harness session: resume `card.session_id` unless `column.fresh_session` or none. Pi mint/resume use exact `--session-id`; Pi retry forks old → a newly minted target id. Claude retains mint/`--resume`/`--fork-session`. Existing cards keep their stored harness/session.
    - **preflight before workspace mutation:** `ping` the selected socket and require exact Herdr 0.7.5/protocol 17. Only then resolve `workspace` by id/case-insensitive label, or resolve `new_workspace` by label and, if absent, call `workspace.create {label,cwd,focus:false}`. Read the workspace cwd from its pane snapshot; snapshot failure or missing live cwd fails dispatch, never falling back to process cwd or a stale snapshot.
    - **preflight again at the spawner boundary:** this is the spawner's first protocol call, before placement, managed launch, or the configured runner.
-   - build the run-child env `{BOARD_CARD_ID,BOARD_RUN_ID,BOARD_SOCKET,BOARD_BIN}` plus configured-harness prompt env. New v12 runs place each card in a stable short `card-<id>` tab whose `tab.create` root is a shell anchor labeled `card-<id>-anchor`. The anchor receives only stable card identity; every run child is created by `pane.split` from it with the complete run cwd/env. Promotion persists the exact anchor id with the run. The daemon reuses only exact tab/anchor identities reconstructed from the newest matching durable panes in the same session/workspace; labels are display metadata, never ownership. A renamed anchor remains selected by identity; a closed anchor is recreated only by splitting a currently live durable board child, otherwise a fresh tab is created. The initial split targets ratio `0.40` and clamps it on narrow terminals so the anchor remains reusable; later splits use layout geometry. Both fresh and recovered placement fail closed unless the live layout can provide a 24x6 anchor and a 12x8 child. Concurrent first allocations for one `(session,workspace,card)` key are serialized; if multiple historical panes are live, newest run id wins. Legacy rows retain the historical `kanban` lookup. Thus cwd/env/placement exist **before** launch; protocol-17 `agent.start` receives none of them and never receives the anchor pane id.
+   - build the run-child env `{BOARD_CARD_ID,BOARD_RUN_ID,BOARD_SOCKET,BOARD_BIN}` plus configured-harness prompt env. Current schema v13 runs place each card in a stable short `card-<id>` tab whose `tab.create` root is a shell anchor labeled `card-<id>-anchor`. The anchor receives only stable card identity; every run child is created by `pane.split` from it with the complete run cwd/env. Promotion persists the exact anchor id with the run. The daemon reuses only exact tab/anchor identities reconstructed from the newest matching durable panes in the same session/workspace; labels are display metadata, never ownership. A renamed anchor remains selected by identity; a closed anchor is recreated only by splitting a currently live durable board child, otherwise a fresh tab is created. The initial split targets ratio `0.40` and clamps it on narrow terminals so the anchor remains reusable; later splits use layout geometry. Both fresh and recovered placement fail closed unless the live layout can provide a 24x6 anchor and a 12x8 child. Concurrent first allocations for one `(session,workspace,card)` key are serialized; if multiple historical panes are live, newest run id wins. Legacy rows retain the historical `kanban` lookup. Thus cwd/env/placement exist **before** launch; protocol-17 `agent.start` receives none of them and never receives the anchor pane id.
    - managed Pi/Claude: create a mode-`0600` file containing the snapshotted system prompt; call `agent.start {name,kind,pane_id,args,timeout_ms:30000}` on the newly split child with prompt-free startup args and the harness-specific file flag. A typed `agent_pane_busy` response is treated as a bounded transient on that same child: retry the exact same request on the same pane at most twice, with 100ms then 200ms backoff; do not split or allocate another pane. Persistent busy is terminal and follows child-only cleanup, leaving the anchor. This is distinct from `pane_not_found`, which is a placement race: close the child when present, rediscover from `tab.list`, and retry complete placement once. Poll `agent.get {target:pane_id}` for at most 30s until `interactive_ready && !launch_pending`; then call `agent.prompt {target:pane_id,text:prompt_snapshot}`. Remove the prompt file before returning, including error paths.
    - managed pane name is `card-<id>-<column-slug>` (e.g. `card-14-execute`); `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`.
    - configured harness: `pane.rename` the owned pane, create one mode-`0700` self-removing script whose POSIX-quoted command is the exact configured argv, and invoke exactly the selected Herdr binary (`HERDR_BIN_PATH` when nonempty, otherwise `herdr`) as `pane run <pane_id> <script_path>` with `HERDR_SOCKET_PATH` set to the selected socket. The script runs the child, preserves its status, then calls hidden `board __pane-exited --run-id "$BOARD_RUN_ID"`; the internal run-id guard accepts only the exact open queued/started configured run (including callback-before-registration), rejects stale/completed and built-in runs, and never applies `on_fail`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 How herdr-board is tested, and how to add tests for a change. The final contract is board
-protocol v1, SQLite schema v12, and Herdr 0.7.5 / protocol 17. Four layers, cheap and hermetic
+protocol v1, SQLite schema v13, and Herdr 0.7.5 / protocol 17. Four layers, cheap and hermetic
 first, expensive and live last:
 
 ```
@@ -36,14 +36,32 @@ The stable ownership layout is responsibility-oriented, not a file manifest:
 | `board-herdr` | Public envelope, event, and socket behavior is tested from `crates/board-herdr/tests/`, including ignored live probes. Event parsing, backoff, and stream handling are owned by `crates/board-herdr/src/events/`; all unsafe board-herdr Unix transport operations remain in `crates/board-herdr/src/transport.rs`. |
 | `board-tui` | Public reducer, form, and rendering behavior is tested from `crates/board-tui/tests/` (including `forms.rs`, `update.rs`, and snapshots). The implementation is organized under `crates/board-tui/src/app/`, `crates/board-tui/src/forms/`, and `crates/board-tui/src/view/`; only view tests that need private rendering helpers remain adjacent in `crates/board-tui/src/view/tests.rs`. |
 
-The public core suites cover deterministic engine decisions, schema-v12 migrations and atomic
+The public core suites cover deterministic engine decisions, schema-v13 migrations and atomic
 run units of work, protocol-v1 serde, typed client boundaries, configuration, prompt assembly,
 harness planning, and scoped-board behavior. Herdr suites cover protocol-17 event decoding and
 socket behavior against an in-process fake server. Daemon private suites cover queue claims,
 spawn/finalization atomicity, pane placement, configured and managed launch characterization,
-request routing, watcher signals, timeout handling, and per-session recovery. TUI suites cover
-fake-client reducer behavior, forms, and ratatui snapshots. Keep descriptions at this ownership
-level; add a path only when it is a stable boundary or a useful entry point.
+request routing, watcher signals, timeout handling, per-session recovery, and comment actor policy.
+TUI suites cover fake-client reducer behavior, forms, and ratatui snapshots. Keep descriptions at
+this ownership level; add a path only when it is a stable boundary or a useful entry point.
+
+### RED → GREEN parity and schema-v13 coverage
+
+The current parity/schema-v13 change is specified test-first:
+
+- **RED contracts:** `crates/board-core/tests/comments_boards_contract.rs` covers board identity,
+  visibility, comment CRUD, soft deletion, audit snapshots, system immutability, and author
+  retention; `comments_migration_contract.rs` upgrades a v12 fixture to v13 without changing
+  legacy board/card/comment/run values.
+- **GREEN implementation coverage:** `board-daemon/src/ops/tests/comments.rs` checks RPC routing,
+  exact open-run actor ownership, fake-harness compatibility, immutable system comments, hidden
+  deleted comments, and scoped change events. `board-cli/tests/integration/cli_contract.rs`
+  exercises canonical nested CRUD/history, JSON output/errors, global selectors, version/status
+  separation, and the canonical command surface; `compat.rs` protects top-level aliases.
+- **CLI/E2E boundary:** live scenarios 01, 04, 06, 08, 09, 11, 16, and 17 exercise CLI comment
+  creation, transition/silent-exit/timeout system comments, comment context in later prompts, and
+  managed/configured comment completion against disposable Herdr. CRUD/audit semantics stay in
+  hermetic core/daemon/CLI tests; the live suite does not duplicate every management RPC.
 
 Nullable update coverage in `board-core` is table-driven across every column/card nullable:
 protocol tests verify omitted/null/value serde states, database tests verify set → clear and reopen
@@ -323,7 +341,7 @@ Checklist:
 | **done-race** | Managed built-ins still require a registered pane, so an instant `board done` for a queued built-in run is rejected. A configured harness is different: its exact `board done` is accepted even before runner registration, and the fake agent still sleeps `FAKE_AGENT_SLEEP` (default 1.5s) before reporting in ordinary scenarios. |
 | **A pane dies with its process** | A herdr pane closes when its command exits. To inspect a live layout, keep the process alive — set `FAKE_AGENT_HOLD` (e.g. 300) so the agent sleeps **after** `board done`. Cleanup closes the workspace to end it. |
 | **herdr closes the socket per request** | herdr serves one request per connection. `hrpc.py` (and `board-herdr`'s client) open a fresh connection every call — don't try to reuse one. |
-| **Tab labels are not unique** | New runs resolve `card-<id>` tabs and shell anchors only by exact ids reconstructed from scoped durable panes; schema v12 persists the anchor id. Duplicate tab/anchor labels and legacy `kanban` are never adopted as ownership proof. A renamed exact anchor remains owned; a missing anchor is recovered only from an exact durable child, otherwise a fresh tab is created. Legacy rows retain their historical lookup. |
+| **Tab labels are not unique** | New runs resolve `card-<id>` tabs and shell anchors only by exact ids reconstructed from scoped durable panes; schema v13 retains the anchor id introduced in v12. Duplicate tab/anchor labels and legacy `kanban` are never adopted as ownership proof. A renamed exact anchor remains owned; a missing anchor is recovered only from an exact durable child, otherwise a fresh tab is created. Legacy rows retain their historical lookup. |
 | **Agent names are exclusive** | While a pane is open its agent name is reserved. A collision (e.g. the session already has a `card-1-execute` pane) makes the daemon retry as `card-1-execute-r<run>`. Assertions must accept the optional `-r<n>` suffix. |
 | **A newly split pane can be busy** | Herdr may return typed `agent_pane_busy` while the child still drains prior state. The daemon retries the exact managed `agent.start` request twice on that same owned child with 100ms/200ms backoff; persistent busy closes only that child and leaves the shell anchor. Do not treat it as `pane_not_found`: that error triggers one bounded full placement rediscovery from `tab.list`. |
 | **Managed and configured pane identity differ** | Protocol-17 managed Pi/Claude panes expose the managed kind in `pane.agent`; configured panes are renamed to the daemon-assigned `card-<id>-<column>` label and remain unmanaged. Match the appropriate field and still accept the optional `-r<n>` name suffix. |

--- a/e2e/13-jump-to-pane.sh
+++ b/e2e/13-jump-to-pane.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# 13-jump-to-pane.sh — detail `o` focuses the latest same-session run pane and closes the board.
+# 13-jump-to-pane.sh — CLI focus and detail `o` reach the latest same-session run pane.
 set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lib.sh"
 
@@ -35,17 +35,85 @@ open_json="$(e2e_herdr_mutate -- plugin pane open --plugin herdr-board --entrypo
   --env "BOARD_SCOPE_PATH=$BOARD_SCOPE_PATH" --focus)"
 BOARD_PANE="$(printf '%s' "$open_json" | jget pane_id)"
 
+step "Wait for the overlay and select the run's column"
+ready=0
+for _ in $(seq 1 50); do
+  screen="$("$HERDR_BIN" pane read "$BOARD_PANE" --source recent-unwrapped --lines 100 2>/dev/null || true)"
+  if printf '%s\n' "$screen" | grep -q 'Todo ·'; then
+    ready=1
+    break
+  fi
+  sleep .1
+done
+[ "$ready" = 1 ] || fail "board TUI did not render its initial column"
+# The overlay is intentionally narrow in this workspace, so only the selected
+# column is rendered. The run is in the second, auto-created Execute column;
+# navigate before asserting its card is visible.
+e2e_herdr_mutate -- pane send-keys "$BOARD_PANE" right
 for _ in $(seq 1 50); do
   screen="$("$HERDR_BIN" pane read "$BOARD_PANE" --source recent-unwrapped --lines 100 2>/dev/null || true)"
   printf '%s\n' "$screen" | grep -q 'jump-target' && break
   sleep .1
 done
-printf '%s\n' "$screen" | grep -q 'jump-target' || fail "card not visible in board TUI"
+if ! printf '%s\n' "$screen" | grep -q 'jump-target'; then
+  # Keep startup failures actionable without turning the visibility assertion
+  # into a weaker readiness check. These are bounded, read-only probes of the
+  # exact overlay, its workspace, and the isolated board daemon.
+  printf '  overlay diagnostics (pane=%s workspace=%s):\n' "$BOARD_PANE" "$WS_ID" >&2
+  "$HERDR_BIN" pane get "$BOARD_PANE" >&2 || true
+  printf '%s\n' '--- overlay recent-unwrapped ---' >&2
+  "$HERDR_BIN" pane read "$BOARD_PANE" --source recent-unwrapped --lines 100 >&2 || true
+  printf '%s\n' '--- target workspace panes ---' >&2
+  hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}" >&2 || true
+  printf '%s\n' '--- board daemon log (tail 80) ---' >&2
+  tail -n 80 "$E2E_TMP/daemon.log" >&2 || true
+  fail "card not visible in board TUI"
+fi
+
+step "Focus the same run through the canonical CLI"
+cli_focus_json="$(e2e_board_herdr_mutate -- card run focus "$CARD_ID" --json)"
+cli_focus_pane="$(printf '%s' "$cli_focus_json" | jget pane_id)"
+[ "$cli_focus_pane" = "$TARGET_PANE" ] \
+  || fail "CLI focus returned pane '$cli_focus_pane' (expected owned pane '$TARGET_PANE')"
+cli_focused=""
+for _ in $(seq 1 60); do
+  panes="$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}" 2>/dev/null || true)"
+  cli_focused="$(printf '%s' "$panes" | python3 -c '
+import json,sys
+try: ps=json.load(sys.stdin).get("panes",[])
+except Exception: sys.exit(0)
+for p in ps:
+    if p.get("focused"):
+        print(p.get("pane_id", "")); break
+' 2>/dev/null || true)"
+  [ "$cli_focused" = "$TARGET_PANE" ] && break
+  sleep .1
+done
+[ "$cli_focused" = "$TARGET_PANE" ] \
+  || fail "CLI focus left pane '$cli_focused' focused (expected '$TARGET_PANE')"
+ok "board card run focus reached owned pane $TARGET_PANE"
+
+# The CLI focus intentionally leaves the plugin overlay open. Restore its focus
+# so the existing detail `o` flow below remains an independent TUI assertion.
+e2e_hrpc_mutate -- pane.focus "{\"pane_id\":\"$BOARD_PANE\"}" >/dev/null
 
 step "Open card detail and press o"
-e2e_herdr_mutate -- pane send-keys "$BOARD_PANE" right
 e2e_herdr_mutate -- pane send-keys "$BOARD_PANE" enter
-sleep 0.3
+detail_ready=0
+for _ in $(seq 1 50); do
+  detail_screen="$("$HERDR_BIN" pane read "$BOARD_PANE" --source recent-unwrapped --lines 100 2>/dev/null || true)"
+  if printf '%s\n' "$detail_screen" | grep -q 'focus this run' \
+    && printf '%s\n' "$detail_screen" | grep -q 'runs'; then
+    detail_ready=1
+    break
+  fi
+  sleep .1
+done
+[ "$detail_ready" = 1 ] || {
+  printf '%s\n' '--- detail startup screen ---' >&2
+  printf '%s\n' "$detail_screen" >&2
+  fail "card detail did not open for jump-target"
+}
 # `o` asks boardd to focus/close Herdr panes, so gate daemon and session too.
 e2e_process_identity_verify "$E2E_DAEMON_PID" "$E2E_DAEMON_IDENTITY" \
   || fail "refusing jump action: daemon identity does not match"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -8,7 +8,7 @@ exercises the herdr wire integration end to end.
 
 For the layers below this one (unit, daemon+CLI integration, TUI snapshots), the
 isolation/safety design, and the **how-to-write-a-scenario** guide, see
-[`../docs/testing.md`](../docs/testing.md). This file is the authoritative use-case catalog for board protocol v1 / SQLite schema v12:
+[`../docs/testing.md`](../docs/testing.md). This file is the authoritative use-case catalog for board protocol v1 / SQLite schema v13:
 every numbered scenario from **01 through 25** must appear here and in `run-all.sh`. The provider-free
 safe boundary is `fake-agent.sh`,
 `fake-bin/{pi,claude}`, and `test-harness.sh`; prompt/system-prompt contents are never logged.
@@ -31,7 +31,7 @@ gate, but this cleanup task runs only the static harness—not the full live sui
 | Archive filter cycles scoped `ACTIVE/ALL/ARCHIVED` Herdr pane titles and keeps the footer minimal | `10-archive-filter-title.sh` | live |
 | Built-in Pi mint/retry argv, session fork, protocol prompt, and agent comment through real Herdr | `11-pi-harness.sh` | live, checked-in fake `pi`, zero provider cost |
 | Git-root/CWD board identity, independent pipelines/cards, scoped TUI title, and Global picker entry | `12-cwd-boards.sh` | live |
-| Card-detail `o` focuses a held same-session run pane and closes the real plugin overlay | `13-jump-to-pane.sh` | live |
+| Canonical CLI `card run focus` and card-detail `o` focus a held same-session run pane; `o` closes the real plugin overlay | `13-jump-to-pane.sh` | live |
 | A column `harness_override` (TUI select) drives a run via a config-defined harness; `harness.list` advertises config harnesses; effort/permission overrides flow into the run argv | `14-column-config.sh` | live |
 | Integration-style status reports on a live managed pane: blocked → working → end-of-turn idle (Herdr derives `done`) → `awaiting` (`agent_done`), timeout paused; `board done ok` → `done` in the same column | `15-awaiting.sh` | live |
 | Managed protocol-17 Pi + Claude: pane-first placement, exact 0600 system file, readiness/session reports, exact `agent.prompt` task delivery, and held layout | `16-managed-p17.sh` | live, checked-in fake `pi` + `claude`, zero provider cost |
@@ -170,7 +170,7 @@ personal Claude state. Its intended contract is one authorized attempt with no r
 | `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages only completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved remote-settings bytes under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied. Independently identity-gates the daemon and Herdr server and cleans exact resources. Not in `run-all.sh`. |
 | `hrpc.py` | One-shot raw **herdr** socket RPC (honours `HERDR_SOCKET_PATH`) for structural asserts (`tab.list`/`pane.list`/`pane.layout`). |
 | `12-cwd-boards.sh` | Scoped board identity/isolation plus real TUI title/picker. |
-| `13-jump-to-pane.sh` | Same-session pane focus through a real plugin overlay. |
+| `13-jump-to-pane.sh` | Canonical CLI and same-session TUI pane focus through a real plugin overlay. |
 | `NN-*.sh` | The scenarios above. |
 | `run-all.sh` | Builds once, runs scenarios 01–25 as environment-scrubbed children with their own sessions, captures artifacts, and prints the summary (`--require-all` forbids skips). |
 

--- a/schema.sql
+++ b/schema.sql
@@ -1,6 +1,6 @@
 -- herdr-board SQLite schema (WAL mode; boardd is the only writer).
--- This file is the CURRENT (schema v12) shape: a fresh DB is created directly
--- from it and stamped `PRAGMA user_version = 12`. Existing databases are upgraded
+-- This file is the CURRENT (schema v13) shape: a fresh DB is created directly
+-- from it and stamped `PRAGMA user_version = 13`. Existing databases are upgraded
 -- by migrations in board-core/src/db/migrations.rs (kept in sync with this file).
 PRAGMA journal_mode = WAL;
 PRAGMA foreign_keys = ON;
@@ -73,8 +73,34 @@ CREATE TABLE comments (
   card_id    INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
   author     TEXT NOT NULL,                    -- 'user' | 'agent:<run_id>' | 'system'
   body       TEXT NOT NULL,
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT                              -- NULL = current; timestamp = soft-deleted
 );
+
+-- Immutable snapshots of every user-visible comment state.  The current row
+-- remains in `comments` so its identity and ownership are stable; history is
+-- retained after a soft delete for audit and authorization decisions.
+CREATE TABLE comment_history (
+  id         INTEGER PRIMARY KEY,
+  comment_id INTEGER NOT NULL REFERENCES comments(id) ON DELETE CASCADE,
+  card_id    INTEGER NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+  author     TEXT NOT NULL,
+  body       TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  deleted_at TEXT
+);
+
+CREATE INDEX idx_comment_history_comment ON comment_history(comment_id, id);
+
+-- System and daemon-generated comments use the same insertion path as user
+-- comments (including run finalization), so every durable comment gets its
+-- initial audit snapshot without relying on one caller remembering to do so.
+CREATE TRIGGER comments_audit_insert
+AFTER INSERT ON comments
+BEGIN
+  INSERT INTO comment_history(comment_id, card_id, author, body, created_at, deleted_at)
+  VALUES(NEW.id, NEW.card_id, NEW.author, NEW.body, NEW.created_at, NEW.deleted_at);
+END;
 
 CREATE TABLE runs (
   id                 INTEGER PRIMARY KEY,

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -14,7 +14,7 @@ class DocumentationContractTests(unittest.TestCase):
         index = (ROOT / "docs/README.md").read_text(encoding="utf-8")
         for text in (
             "Board socket | v1",
-            "SQLite | schema v12",
+            "SQLite | schema v13",
             "Herdr client | 0.7.5 / socket protocol 17",
             "Runtime launch | daemon-owned",
             "Config | typed `RootConfig`",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,112 +3,201 @@ name: herdr-board
 description: >-
   Interact with the herdr-board kanban from inside an agent run or an
   interactive session. Use whenever you need to report progress on a board
-  card, close out a run, add a comment, move/cancel/retry a card, inspect
-  cards or columns, or create new work on the board. Triggers on mentions of
-  the board, cards, columns, kanban, "board comment/done/move", or $BOARD_CARD_ID.
+  card, close out a run, add or edit a comment, move/cancel/retry a card,
+  inspect cards or columns, or create new work on the board. Triggers on
+  mentions of the board, cards, columns, kanban, board comment/done/move, or
+  $BOARD_CARD_ID.
 ---
 
 # herdr-board
 
-This is the operational skill for people and dispatched agents using herdr-board. It covers the TUI, CLI, cards, runs, and Herdr-backed spaces; it does not prescribe how to develop, prototype, test, or release herdr-board itself.
+This is the operational skill for people and dispatched agents using herdr-board. It covers the TUI,
+CLI, cards, runs, comments, columns, and Herdr-backed spaces; it does not prescribe how to develop,
+prototype, test, or release herdr-board itself.
 
-herdr-board is a kanban board for AI coding agents. A **card** is a prompt (title +
-description) plus harness/model/effort, an optional harness-specific permission, and a target herdr space. New cards default to Pi; runs remain harness-neutral. **Columns**
-are pipeline stages; a column can be `manual` or `auto`. Each canonical Git root (or exact
-non-Git CWD) has an independent board; the old board is preserved as `Global`. Moving a card into
-an `auto` column dispatches an agent run into a visible herdr pane. Agents report back to the board
-via the `board` CLI — never by editing the DB. The daemon (`boardd`) owns all state and
-handles column transitions; you never move a card out of your own stage.
+A **card** is a title/description plus harness/model/effort, optional harness permission, and a target
+Herdr session and workspace. New cards default to Pi. **Columns** are pipeline stages: `manual` waits
+for a person and `auto` dispatches a visible agent run on entry. Each canonical Git root (or exact
+non-Git CWD) has an independent board; the preserved `Global` board remains available. Agents report
+through `board`; never edit the database. The daemon owns state and column transitions.
 
-## Inside a run (you are the dispatched agent)
+## Inside a run
 
 `$BOARD_CARD_ID`, `$BOARD_RUN_ID`, and `$BOARD_SOCKET` are preset. `board comment` posts as
-`agent:$BOARD_RUN_ID`. Your job: do the stage's work, comment your results, then close the run.
+`agent:$BOARD_RUN_ID` when the run id is present. Do the stage's work, comment the result, then close
+the run.
 
 Rules — follow exactly:
-- ALWAYS `board comment` your results/findings BEFORE calling `board done`. The transition
-  comment and next stage depend on what you left behind; a bare `done` loses your work.
-- `board done --outcome ok` = this stage's goal was met. `--outcome fail` = the stage goal
-  was NOT met (e.g. tests still red, plan not approvable). `fail` is a semantic verdict, not
-  a crash report — a tool error you recovered from is still `ok` if the goal is met.
-- NEVER `board move`/`cancel`/`retry` your own card to advance yourself. `board done` applies
-  the column's transition (ok → on_success column, fail → on_fail). Moving yourself corrupts
-  the pipeline.
-- `CARD_ID` is optional on `comment`/`done` — it defaults to `$BOARD_CARD_ID`.
+
+- **Always comment before `board done`.** The next stage receives the comments; a bare `done` loses
+  your useful result.
+- `board done --outcome ok` means the stage goal was met. `--outcome fail` means it was not met;
+  `fail` is a semantic verdict, not merely a report of a recovered tool error.
+- **Never move, cancel, or retry your own card to advance it.** `board done` applies the column's
+  transition. Use cancel/retry only when the operator or task explicitly requires it.
+- A card id is optional for top-level `comment` and `done`; both default to `$BOARD_CARD_ID`.
 
 ```bash
-board comment "Implemented X; added 3 tests, all green. Touched src/foo.rs, src/bar.rs."
+board comment "Implemented X; added tests, all green. Touched src/foo.rs."
 board done --outcome ok --summary "feature X shipped, tests green"
-# stage goal not met:
-board done --outcome fail --summary "2 integration tests still failing; needs a schema change"
+# If the stage goal was not met:
+board done --outcome fail --summary "2 integration tests still fail; needs schema work"
 ```
 
-## Using the TUI
+## TUI
 
-Run `board tui` or invoke the `open-board` Herdr plugin action. Use arrows or `h/j/k/l` to navigate, `n` to create a card, `N` to create a column, `m` to move a card, `Enter` for card detail, `e`/`E` to edit a card/column, `a` to archive or restore, `v` to change the archive filter, and `?` for the complete in-app reference. Moving a card into an automatic column dispatches its run into a board-owned tab with a stable `card-<id>` label and reserved `card-<id>-anchor` shell. Every stage/retry runs in a child split from that anchor. Durable runs reuse only an exact board-owned `tab_id` reconstructed from durable pane identity; labels are never ownership, and a missing anchor is recovered only inside that proven tab from a durable run pane. Legacy `kanban` tabs remain untouched and legacy-only.
+Run `board tui` or invoke the `open-board` Herdr plugin action. Use arrows or `h/j/k/l` to navigate,
+`n` for a card, `N` for a column, `m` to move a card, `Enter` for detail, `e`/`E` to edit a
+card/column, `a` to archive/restore, `v` for active/all/archived visibility, and `?` for help.
+Moving into an `auto` column dispatches a run. `o` focuses the newest same-session run pane; `Enter`
+on an `awaiting` card confirms it through the same completion channel as `board done --outcome ok`.
 
-Use the CLI below for scripted operations and for progress reporting from a dispatched run.
+## CLI taxonomy
 
-## CLI reference
-
-```
-board card show <ID> [--json]            # card + comments + run history
-board card list [--column C] [--json]    # cards, optionally one column
-board card archive <ID> [--json]          # reversible; preserves comments/runs
-board card restore <ID> [--json]
-board column list [--json]               # columns in order
-board comment [CARD_ID] <BODY> [--json]  # CARD_ID defaults to $BOARD_CARD_ID
-board done [CARD_ID] --outcome ok|fail [--summary S] [--json]
-board move <CARD_ID> <COLUMN> [--json]   # COLUMN = name (case-insensitive) or id
-board cancel <CARD_ID> [--json]          # kill the run; card -> failed, no transition
-board retry <CARD_ID> [--json]           # re-run in current column (forks session)
-board status [--json]                    # daemon status
-board session list [--json]              # herdr sessions (name, running, default)
-board space list [--session S] [--json]  # workspaces in a session (default if unset)
-board card new --title T [-d DESC] [--column C] [--harness H] [--model M] \
-   [--effort E] [--permission P] [--session S] \
-   [--space-kind workspace|new-workspace] [--space-ref R] [--space-cwd DIR] [--json]
-```
-
-A card picks a **herdr session** (`--session`, the daemon's default session when
-unset) and a **space** within it: `workspace` runs in an already-open workspace
-(`--space-ref` = its id or label), while `new-workspace` makes the daemon open a
-workspace on first dispatch (`--space-ref` = label, `--space-cwd` = its working
-dir — both required). There is no worktree space kind; run per-branch isolation
-from the agent prompt instead.
-
-`card new/list` and `column list` use the current Git-root/CWD board. Set `BOARD_SCOPE_PATH` for a
-deterministic automation override. Commands by card id (`show`, `comment`, `done`, `cancel`,
-`retry`, archive/restore) infer the card's board; `move` also resolves the column in that board, not
-the caller's CWD.
-
-Archiving is a human/interactive-session action. It is refused for cards with an active or queued
-run; cancel first if appropriate. Archived cards must be restored before move/retry.
-
-Examples:
-```bash
-board card show 42 --json
-board card list --column Execute
-board comment 42 "Blocked: need the API key in the workspace env."
-```
-
-## Creating work on the board (interactive sessions)
-
-To queue work, create a card then move it into an `auto` column — the move is the trigger
-that dispatches the agent. Creating a card directly into an `auto` column dispatches at once.
-`manual` columns (e.g. a human-review gate) just hold the card until a person acts.
+The nested forms are canonical. A global board selector accepts a stable id or canonical scope path:
 
 ```bash
-# Create in the default Todo column, then dispatch by moving into an auto column:
-board card new --title "Add retry to the uploader" \
-  -d "In src/upload.rs, retry failed PUTs 3x with backoff. Add a unit test." \
-  --effort low \
-  --space-kind new-workspace --space-ref uploader --space-cwd /path/to/repo
-board move <new-card-id> Execute        # Execute is an auto column -> run starts
+board --board <ID|PATH> card list --json
 ```
 
-Omitting `--harness` selects Pi; omitting `--model` lets Pi use its configured default. Pi effort
-maps to thinking and Pi has no `--permission` mode. Use `--harness claude` explicitly for Claude.
+Without `--board`, board-aware commands use the focused Git root, or the canonical CWD outside Git;
+`BOARD_SCOPE_PATH` is a deterministic automation override. `card create/list`, `column list`, and
+board commands use the selected board. Card-id operations infer the card's own board.
 
-Watch the run land in a herdr pane; the agent will comment and `board done`, and the daemon
-moves the card along until it reaches a manual gate. Use `board card show <id>` to follow along.
+### Boards and templates
+
+```bash
+board board list [--json]
+board board show [ID|PATH] [--json]
+board board open <PATH> [--json]
+board board rename [ID|PATH] <NAME> [--json]
+board template apply pipeline [--json]
+```
+
+`board show` and `board open` return a snapshot with `board`, `columns`, `cards`, and `active_runs`.
+The `pipeline` template is atomic and only applies to an empty board containing exactly the seed
+`Todo` column; it returns the resulting column array.
+
+### Cards
+
+```bash
+board card create --title TITLE [-d DESCRIPTION] [--column COLUMN] \
+  [--harness HARNESS] [--model MODEL] [--effort EFFORT] [--permission MODE] \
+  [--session SESSION] [--space-kind workspace|new-workspace] \
+  [--space-ref REF] [--space-cwd DIR] [--json]
+board card edit ID [--title TITLE] [-d DESCRIPTION] [--clear-description] \
+  [--harness HARNESS] [--model MODEL|--clear-model] [--effort EFFORT|--clear-effort] \
+  [--permission MODE|--clear-permission] [--session SESSION|--clear-session] \
+  [--space-ref REF|--clear-space-ref] [--space-cwd DIR|--clear-space-cwd] [--json]
+board card show ID [--json]
+board card list [--column COLUMN] [--visibility active|all|archived] [--json]
+board card move ID COLUMN [--destination-board ID|PATH] [--json]
+board card archive ID [--json]
+board card restore ID [--json]
+board card delete ID [--yes] [--json]
+```
+
+`card new` is retained as an alias for `card create`. A new card defaults to Pi; an omitted model or
+effort uses the harness default. `new-workspace` requires both `--space-ref` and `--space-cwd`.
+Creating directly in an `auto` column dispatches immediately. `card list` defaults to active cards;
+`all` includes archived cards and `archived` returns only archived cards. `card show` includes current
+comments and run history; soft-deleted comments are omitted.
+
+Omitted edit options are unchanged. Explicit `--clear-*` flags clear nullable values;
+`--clear-description` sets the description to an empty string. Harness is required and cannot be
+cleared. Model/effort/permission/session/space edits are refused while a card has an open run.
+Archiving and deletion also require an idle/terminal card; cancel an open run first. Delete is
+permanent and removes card history. It prompts on a TTY and requires `--yes` in non-interactive use.
+
+### Comments
+
+```bash
+board card comment add CARD_ID BODY [--json]
+board card comment show COMMENT_ID [--json]
+board card comment edit COMMENT_ID BODY [--json]
+board card comment delete COMMENT_ID [--yes] [--json]
+board card comment history COMMENT_ID [--json]
+```
+
+Add returns the compact current comment (`id`, `card_id`, `author`, `body`, `created_at`);
+show/edit return the current record with those fields plus `deleted_at`. Delete is a soft delete and
+returns `{"deleted":true}`. History returns immutable snapshots from creation through the latest
+edit; deletion marks the final snapshot. Card detail and run prompts show only non-deleted comments.
+
+When `$BOARD_RUN_ID` is set, add creates `author=agent:<run-id>`, and that open durable run may
+edit or delete only comments owned by its exact `agent:<run-id>` author. Calls without a run id are
+human operations and may edit/delete non-system comments. System comments are immutable; deleted
+comments are immutable. The legacy `board comment [CARD_ID] BODY` form remains available and defaults
+the card id to `$BOARD_CARD_ID`.
+
+### Runs
+
+```bash
+board card run done [CARD_ID] --outcome ok|fail [--summary SUMMARY] [--json]
+board card run confirm [CARD_ID] [--summary SUMMARY] [--json]
+board card run cancel CARD_ID [--json]
+board card run retry CARD_ID [--json]
+board card run focus CARD_ID [--origin-socket SOCKET] [--json]
+```
+
+`card run confirm` is the `done --outcome ok` channel for an `awaiting` card. `card run focus`
+returns `{run_id, pane_id}` and requires the newest run pane to belong to the current Herdr session;
+without `--origin-socket` it uses `HERDR_SOCKET_PATH` or `HERDR_SOCK`. Done/cancel/retry return
+`{run, card}` in JSON. Retry creates a new run while preserving history.
+
+### Columns and discovery
+
+```bash
+board column list [--json]
+board column create --name NAME [--prompt TEXT] [--trigger manual|auto] \
+  [--on-success COLUMN] [--on-fail COLUMN] [--fresh-session|--reuse-session] \
+  [--harness HARNESS] [--model MODEL] [--effort EFFORT] [--permission MODE] \
+  [--timeout MINUTES] [--position ZERO_BASED_POSITION] [--json]
+board column show COLUMN [--json]
+board column edit COLUMN [--name NAME] [--prompt TEXT|--clear-prompt] \
+  [--trigger manual|auto] [--on-success COLUMN|--clear-on-success] \
+  [--on-fail COLUMN|--clear-on-fail] [--fresh-session|--reuse-session] \
+  [--harness HARNESS|--clear-harness] [--model MODEL|--clear-model] \
+  [--effort EFFORT|--clear-effort] [--permission MODE|--clear-permission] \
+  [--timeout MINUTES|--clear-timeout] [--json]
+board column reorder COLUMN ZERO_BASED_POSITION [--json]
+board column delete COLUMN [--move-cards-to COLUMN] [--yes] [--json]
+board harness list|models|efforts|permissions [--json]
+board space list [--session SESSION] [--json]
+board session list [--json]
+```
+
+Column references accept an id or case-insensitive name. List and reorder return ordered arrays;
+create/show/edit return a column. `--fresh-session` and `--reuse-session` are mutually exclusive.
+A column containing cards needs `--move-cards-to`; any open card run blocks deletion. Column
+settings are validated as a complete merged configuration, and effective card+column settings are
+checked again before dispatch. Pi has no permission modes; `bypassPermissions` is never a column
+override.
+
+## Status, version, skill, JSON, and aliases
+
+- `board daemon status [--json]` is the only supported daemon status command and the operational
+  probe: `{version, db_path, herdr_connected, active_runs, queued_runs}`.
+- `board version --json` never starts boardd and reports `{cli_version, daemon_version}`. The daemon
+  value is `null`/`unavailable` when boardd is offline; use daemon status for liveness and run counts.
+- `board skill` prints this exact checked-in `skill/SKILL.md` file, byte-for-byte, with no JSON wrapper.
+- Successful `--json` output goes to stdout. JSON errors go to stderr, leave stdout empty, and use
+  the stable envelope `{"error":{"code":N,"kind":"...","message":"...","details":...}}`;
+  `kind` and `details` are additive and may be absent. Codes are 1 bad request, 2 not found/CLI
+  error, 3 invalid state, 4 Herdr unavailable, and 5 internal error.
+- Legacy top-level run/action forms remain supported: `board comment`, `board done`, `board move`,
+  `board cancel`, and `board retry`. `card new` and `--to-board` are also retained aliases. Prefer
+  the nested forms above for new automation.
+
+When creating work, create the card first, then move it into an `auto` column:
+
+```bash
+board card create --title "Add retry to the uploader" \
+  -d "Retry failed PUTs 3x with backoff and add a unit test." \
+  --effort low --space-kind new-workspace --space-ref uploader \
+  --space-cwd /path/to/repo
+board card move <new-card-id> Execute
+```
+
+The agent will comment and call `board done`; the daemon applies the column transition until a manual
+gate is reached. Never bypass that transition with a self-directed `move`.


### PR DESCRIPTION
## Summary

- add canonical nested CLI commands for boards, cards, comments, runs, columns, and templates
- add global board selection, structured JSON errors, daemon/version separation, and embedded skill output
- introduce schema v13 with audited comment CRUD and transactional template, positioning, and enqueue operations
- preserve the existing agent-oriented comment/done/move/cancel/retry shortcuts

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `python3 -m unittest scripts.tests.test_docs`
- `bash e2e/test-harness.sh`
- `e2e/run-all.sh` — 25/25 PASS