### PR TITLE
fix(ci): stage every file prepare-release.py writes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -82,6 +82,12 @@ jobs:
             --repo-url "$REPO_URL"
           python3 scripts/prepare-release.py --repo . verify --repo-url "$REPO_URL"
 
+      # Re-run the documentation contracts against the BUMPED tree. The pre-bump
+      # run above cannot see a stale pin, and `verify` runs before `git add`, so
+      # this is the only step positioned to fail on what actually gets committed.
+      - name: Documentation contracts (bumped tree)
+        run: python3 -m unittest discover -s scripts/tests -p 'test_docs.py'
+
       - name: fmt
         run: cargo fmt --all --check
 
@@ -103,7 +109,12 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           if [ -n "$(git status --porcelain)" ]; then
-            git add Cargo.toml herdr-plugin.toml Cargo.lock CHANGELOG.md
+            # Stage exactly what the tool writes. This list used to be repeated
+            # here, and when `apply` grew the install-ref repin the extra files
+            # were rewritten on the runner and then dropped at `git add`, so
+            # v0.9.1 was cut with stale `--ref v0.9.0` pins.
+            python3 scripts/prepare-release.py --repo . files \
+              | tr '\n' '\0' | xargs -0 --no-run-if-empty git add --
             git commit -m "chore(release): v$TARGET"
           else
             echo "prepare-release.py made no file changes"

--- a/scripts/prepare-release.py
+++ b/scripts/prepare-release.py
@@ -38,6 +38,11 @@ LOCAL_PACKAGES = ("board-cli", "board-core", "board-daemon", "board-herdr", "boa
 # the copy-pasteable install/update command, so they are part of the release
 # contract rather than free prose: a stale pin installs the previous release.
 INSTALL_REF_DOCS = ("README.md", "docs/install.md", "docs/operations.md")
+# The version-bearing files `apply` always rewrites, alongside INSTALL_REF_DOCS.
+# `managed_documents` is the single list the Prepare Release workflow stages;
+# hardcoding it a second time in the workflow is what silently dropped the
+# install-ref repin from the v0.9.1 release branch.
+RELEASE_FILES = ("Cargo.toml", "herdr-plugin.toml", "Cargo.lock", "CHANGELOG.md")
 INSTALL_REF_RE = re.compile(r"(--ref\s+v)(\d+\.\d+\.\d+)")
 
 
@@ -229,6 +234,20 @@ def install_ref_documents(repo_root: Path) -> list[Path]:
         for relative in INSTALL_REF_DOCS
         if (repo_root / relative).is_file()
     ]
+
+
+def managed_documents(repo_root: Path) -> list[Path]:
+    """Every file `apply` may rewrite, in a stable order.
+
+    Exposed as the `files` subcommand so the release workflow stages exactly
+    what the tool writes. A caller that repeats this list instead will keep
+    working right up until the list grows, then silently discard the new file.
+    """
+    return [
+        repo_root / relative
+        for relative in RELEASE_FILES
+        if (repo_root / relative).is_file()
+    ] + install_ref_documents(repo_root)
 
 
 def parse_lock_versions(lock_text: str) -> Dict[str, str]:
@@ -579,6 +598,8 @@ def build_parser() -> argparse.ArgumentParser:
     verify = sub.add_parser("verify", help="verify synchronized, prepared release files")
     verify.add_argument("--repo-url", help="GitHub repo URL for changelog links")
 
+    sub.add_parser("files", help="list the repo-relative files `apply` may rewrite")
+
     return parser
 
 
@@ -607,6 +628,13 @@ def cmd_verify(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_files(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo)
+    for path in managed_documents(repo_root):
+        print(path.relative_to(repo_root).as_posix())
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -617,6 +645,8 @@ def main(argv: list[str] | None = None) -> int:
             return cmd_apply(args)
         if args.cmd == "verify":
             return cmd_verify(args)
+        if args.cmd == "files":
+            return cmd_files(args)
         raise AssertionError(f"unknown command: {args.cmd!r}")
     except ReleaseError as exc:
         print(f"prepare-release.py: {exc}", file=sys.stderr)

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -315,6 +315,34 @@ class DocumentationContractTests(unittest.TestCase):
                     f"{module} matches no CI pattern {patterns}; it would never run",
                 )
 
+    def test_release_workflow_stages_what_the_tool_writes(self) -> None:
+        """The Prepare Release workflow must not repeat the managed-file list.
+
+        It used to `git add` four filenames literally. When `apply` grew the
+        install-ref repin, those three extra files were rewritten on the runner
+        and dropped at staging, so v0.9.1 was cut with stale pins — and
+        `verify`, which runs before `git add`, could not see it.
+        """
+        workflow = (ROOT / ".github/workflows/prepare-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            "prepare-release.py --repo . files",
+            workflow,
+            "stage the tool's own file list instead of repeating it",
+        )
+        for literal in ("git add Cargo.toml", "git add README.md"):
+            self.assertNotIn(
+                literal,
+                workflow,
+                f"{literal!r} hardcodes the managed-file list again",
+            )
+        self.assertIn(
+            "-p 'test_docs.py'",
+            workflow,
+            "re-run the documentation contracts against the bumped tree",
+        )
+
     def test_maintained_markdown_links_resolve(self) -> None:
         for document in maintained_markdown():
             for link in re.findall(r"\[[^]]+\]\(([^)]+)\)", document.read_text()):

--- a/scripts/tests/test_prepare_release.py
+++ b/scripts/tests/test_prepare_release.py
@@ -504,3 +504,69 @@ class PrepareReleaseTests(unittest.TestCase):
 
 if __name__ == "__main__":  # pragma: no cover - convenience.
     unittest.main()
+
+
+class ManagedFileListTests(unittest.TestCase):
+    """`files` must equal what `apply` actually writes.
+
+    The Prepare Release workflow stages the output of `files`. If the two ever
+    disagree, a release is cut with some managed file silently left behind —
+    which is exactly how v0.9.1 shipped with stale `--ref v0.9.0` pins while
+    `verify` still reported success.
+    """
+
+    def test_files_lists_every_document_apply_rewrites(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            PrepareReleaseTests.write_fixture(self, repo_root)
+            for relative in prepare_release.INSTALL_REF_DOCS:
+                path = repo_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    "install:\n\n    herdr plugin install owner/repo --ref v0.1.0\n",
+                    encoding="utf-8",
+                )
+
+            before = {
+                path: path.read_bytes()
+                for path in repo_root.rglob("*")
+                if path.is_file()
+            }
+            prepare_release.apply_release(
+                repo_root,
+                "0.2.0",
+                release_date="2026-01-01",
+                repo_url="https://github.com/owner/repo",
+            )
+            rewritten = {
+                path.relative_to(repo_root).as_posix()
+                for path, blob in before.items()
+                if path.read_bytes() != blob
+            }
+            advertised = {
+                path.relative_to(repo_root).as_posix()
+                for path in prepare_release.managed_documents(repo_root)
+            }
+
+            self.assertTrue(rewritten, "apply rewrote nothing; fixture is wrong")
+            self.assertTrue(
+                rewritten <= advertised,
+                f"apply rewrote {sorted(rewritten - advertised)}, which `files` "
+                "does not list, so the release workflow would not stage it",
+            )
+
+    def test_files_output_is_repo_relative_and_ordered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            PrepareReleaseTests.write_fixture(self, repo_root)
+            listed = [
+                path.relative_to(repo_root).as_posix()
+                for path in prepare_release.managed_documents(repo_root)
+            ]
+            self.assertIn("Cargo.toml", listed)
+            self.assertIn("CHANGELOG.md", listed)
+            for entry in listed:
+                self.assertFalse(entry.startswith("/"), f"{entry} is absolute")
+            # A missing optional document is skipped, never emitted as a path
+            # that `git add` would then fail on.
+            self.assertNotIn("docs/install.md", listed)


### PR DESCRIPTION
## What / why

Follow-up to #47, and the cause of #48's red `docs` check.

The Prepare Release workflow staged four filenames literally:

```
git add Cargo.toml herdr-plugin.toml Cargo.lock CHANGELOG.md
```

#47 taught `prepare-release.py` to also repin the documented `--ref vX.Y.Z` install commands in `README.md`, `docs/install.md` and `docs/operations.md` — and updated the script, its `verify`, and its tests. It did not update the workflow that *stages* the result. So on the v0.9.1 run those three files were rewritten on the runner and then thrown away, and the release branch was cut with bumped versions and stale `v0.9.0` pins.

**Why nothing upstream caught it:** the Python tier runs *before* the bump, and `verify` runs after `apply` but *before* `git add` — so it inspected a tree that was still correct at that moment. The loss happened afterwards. Only CI on the resulting PR failed, which is late.

## The fix

Remove the duplicated list rather than extend it:

- `prepare-release.py` gains a `files` subcommand over a new `managed_documents()`, so the managed set has exactly one definition.
- The workflow stages that output instead of repeating it.
- The workflow re-runs the documentation contracts **against the bumped tree** — the only point positioned to see what actually gets committed.

## Guards (both negative-tested)

| Guard | Fails with |
|---|---|
| `files()` covers everything `apply()` rewrites | `apply rewrote ['README.md', 'docs/install.md', 'docs/operations.md'], which \`files\` does not list, so the release workflow would not stage it` |
| workflow uses the subcommand, never a hardcoded `git add` | `'prepare-release.py --repo . files' not found … : stage the tool's own file list instead of repeating it` |

## Verification

End-to-end simulation of the workflow's own sequence on a real bump:

```
staged:            7 files (Cargo.toml, herdr-plugin.toml, Cargo.lock,
                   CHANGELOG.md, README.md, docs/install.md, docs/operations.md)
unstaged leftovers: (none)
```

The old list staged 4 of those 7.

Python tier: 67 → 70 tests, green.

## Crates touched

- none (workflow + release tooling only)

## Gates

- [x] `python3 -m unittest discover -s scripts/tests` — 70 passing
- [x] Rust gates unaffected (no crate changes); CI will confirm

## Docs

- [x] N/A for user-facing behavior — the release contract in `docs/releasing.md` already describes the docs as synchronized by the tool; this makes that true in the workflow as well.

## Related

Fixes the failure seen on #48. Caused by #47.