### PR TITLE
feat(herdr,daemon): adopt Herdr 0.8.0 and protocol 19

### DIFF
--- a/.agents/skills/herdr-board-visual-validation/references/playbook.md
+++ b/.agents/skills/herdr-board-visual-validation/references/playbook.md
@@ -13,7 +13,7 @@
 8. Cleanup and recovery
 9. Common failures
 
-Commands below were exercised with Herdr 0.7.5 / protocol 17. This repository
+Commands below were exercised with Herdr 0.8.0 / protocol 19. This repository
 requires that exact pair; re-verify the installed CLI and session socket before use.
 
 ## 1. Preflight
@@ -22,9 +22,9 @@ requires that exact pair; re-verify the installed CLI and session socket before 
 REPO="$(git rev-parse --show-toplevel)"
 cd "$REPO"
 git status --short
-test "$(herdr --version)" = "herdr 0.7.5"
+test "$(herdr --version)" = "herdr 0.8.0"
 herdr status
-herdr api schema --json | jq -e 'select(.protocol == 17) | {protocol,schema_version}'
+herdr api schema --json | jq -e 'select(.protocol == 19) | {protocol,schema_version}'
 herdr plugin list --plugin herdr-board --json | jq '.result.plugins[0] | {version,plugin_root,source}'
 ~/.cargo/bin/cargo test -p board-tui --features fake-client --test snapshots
 ```
@@ -146,7 +146,7 @@ WS_JSON="$(herdr --session "$SESSION" workspace create \
 WS="$(printf '%s' "$WS_JSON" | jq -r '.result.workspace.workspace_id')"
 printf 'WS=%s\n' "$WS" >>"$STATE"
 
-printf 'HERDR MUTATION: invoke real plugin action (opens protocol-17 plugin pane)\n'
+printf 'HERDR MUTATION: invoke real plugin action (opens protocol-19 plugin pane)\n'
 herdr --session "$SESSION" plugin action invoke open-board --plugin herdr-board
 
 BOARD_PID="$(lsof -t "$TMP/board.sock" 2>/dev/null | head -1 || true)"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
     attributes:
       label: herdr version
       description: Output of `herdr -v`.
-      placeholder: "0.7.5"
+      placeholder: "0.8.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,15 +157,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Cache Herdr 0.7.5
+      - name: Cache Herdr 0.8.0
         uses: actions/cache@v4
         with:
-          path: ${{ runner.tool_cache }}/herdr-board-0.7.5-linux-x86_64
-          key: herdr-${{ runner.os }}-x86_64-0.7.5-3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253
+          path: ${{ runner.tool_cache }}/herdr-board-0.8.0-linux-x86_64
+          key: herdr-${{ runner.os }}-x86_64-0.8.0-b872ea7e40fa2cb17e857ac9b62b1bf26db7b403c622f5d2f3f5b35f6e9acd28
 
       - name: Provider-free live E2E
         env:
-          HERDR_CACHE_DIR: ${{ runner.tool_cache }}/herdr-board-0.7.5-linux-x86_64
+          HERDR_CACHE_DIR: ${{ runner.tool_cache }}/herdr-board-0.8.0-linux-x86_64
         run: bash e2e/ci.sh
 
       - name: Upload live E2E evidence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ TUI + daemon + CLI. Rust, cargo workspace, edition 2021, all crates share the wo
 Ownership is strict: edit your crate(s) + append to root `[workspace.dependencies]`. Semantics
 source of truth: `docs/protocol.md` + `docs/design.md`. Docs live in `docs/` (index: `docs/README.md`);
 `schema.sql` is the fresh-schema source of truth and `board-core::db` owns upgrades. Final compatibility
-is board protocol v1, SQLite schema v13, and exactly Herdr 0.7.5 / socket protocol 17. The complete
+is board protocol v1, SQLite schema v13, and exactly Herdr 0.8.0 / socket protocol 19. The complete
 live catalog is `e2e/README.md` (scenarios 01–29); `e2e/test-harness.sh` is the provider-free static
 safety gate.
 
@@ -27,7 +27,7 @@ The gate list has one maintained copy: **[`docs/README.md` → Test gates](docs/
 (mirrored by `.github/workflows/ci.yml`; `scripts/tests/test_docs.py` fails if the two drift).
 
 - The Python tier is a CI gate too (`ci.yml`'s `Python tests` step) and is easy to forget:
-  `scripts/tests/test_docs.py` pins the version matrix (schema v13, protocol 17, Herdr 0.7.5)
+  `scripts/tests/test_docs.py` pins the version matrix (schema v13, protocol 19, Herdr 0.8.0)
   and the exact `e2e/NN-*.sh` catalog, so adding a scenario or bumping the schema fails here
   until the docs and that test are updated together.
 
@@ -60,7 +60,7 @@ Full layering, test placement, harness details, and how to add tests live in
   | | `dispatch/` | queue lifecycle; `launch_plan.rs` builds the launch spec, `ownership.rs` decides what this daemon may claim |
   | | `spawner/` | launch and placement; `placement/` (alloc/geometry/race), `herdr/` (managed + configured), `error.rs` |
   | | `watchers/` | timeout/liveness/Herdr observation |
-  | | `herdr_conn.rs` | the gated connect: normalize the socket path, connect, run the 0.7.5/protocol-17 check, in one place. New Herdr work goes through it. The two space-resolution sites that still connect directly (`ops/cards.rs`, `dispatch/launch_plan.rs`) run the same gate inside `dispatch/space.rs` — nothing reaches Herdr ungated |
+  | | `herdr_conn.rs` | the gated connect: normalize the socket path, connect, run the 0.8.0/protocol-19 check, in one place. New placement, discovery, and mutation paths go through it. The two space-resolution sites that still connect directly (`ops/cards.rs`, `dispatch/launch_plan.rs`) run the same gate inside `dispatch/space.rs`; cleanup/observation retain an ungated client only for panes this daemon already owns |
   | | `rescue.rs`, `recovery.rs`, `logging.rs`, `testkit.rs` | run rescue, per-session recovery, tracing setup, and the `cfg(test)` daemon/fake-Herdr builders |
   | `board-tui` | `app/` | the pure reducer — `state`/`effect`/`nav`/`drag` plus one module per screen |
   | | `driver/` | the effect loop (`dispatch`, `load`); `runtime.rs` owns terminal setup/teardown, `origin.rs` the Herdr-plugin origin context |
@@ -119,7 +119,7 @@ Full layering, test placement, harness details, and how to add tests live in
 sources are the installed binary itself — `herdr api schema --json` (methods/types/events +
 protocol number), `herdr <cmd> --help`, `herdr api snapshot`. Never assume a herdr command,
 flag, or JSON shape from memory, and pin the argv you verified in a test comment. Repo herdr
-facts are pinned to exactly **Herdr 0.7.5 / protocol 17**. herdr-board intentionally rejects every
+facts are pinned to exactly **Herdr 0.8.0 / protocol 19**. herdr-board intentionally rejects every
 other Herdr version and protocol; re-verify against `api schema` before changing that gate or any
 wire behavior. **See [`docs/herdr.md`](docs/herdr.md).**
 
@@ -127,12 +127,12 @@ wire behavior. **See [`docs/herdr.md`](docs/herdr.md).**
   against disposable workspaces you created (see `e2e/`). Read-only probes otherwise.
 - **Agent names are exclusive** while a pane is open. Names are `card-<id>-<column-slug>`; on an
   `agent_name_taken` collision the daemon retries with the `-r<run>` fallback.
-- **Panes don't inherit the workspace's env/cwd.** Protocol-17 launch is pane-first:
+- **Panes don't inherit the workspace's env/cwd.** Managed-agent launch is pane-first:
   `tab.create`/`pane.split` establishes cwd + env, then `agent.start` targets that pane with
   `{name, kind, pane_id, args}`. Workspace cwd is read from the workspace's pane snapshot.
 - Current durable runs use stable `card-<id>` tab labels, but reuse only an exact board-owned `tab_id` reconstructed from durable pane identity; labels are never ownership. Legacy `kanban` tabs remain untouched and legacy-only.
 - **Herdr events are a raw-socket stream** (`events.subscribe`, persistent connection); the CLI only
-  has a blocking one-shot `events.wait`. Protocol-17 `pane_agent_status_changed` carries pane,
+  has a blocking one-shot `events.wait`. Protocol-19 `pane_agent_status_changed` carries pane,
   workspace, agent, and status fields; `idle ≠ finished`, and a trailing `idle` may follow `done`
   (completion still needs the explicit `board done` channel). Watcher identity is `(session socket,
   pane id)`, not pane id alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-- Upgrade Herdr compatibility to 0.8.0/socket protocol 19 and centralize the gated client/daemon integration with matching E2E preflight.
+- [#54](https://github.com/nelsonPires5/herdr-board/pull/54) Upgrade Herdr compatibility to 0.8.0/socket protocol 19 and centralize the gated client/daemon integration with matching E2E preflight.
 
 ## [0.10.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- Upgrade Herdr compatibility to 0.8.0/socket protocol 19 and centralize the gated client/daemon integration with matching E2E preflight.
+
 ## [0.10.0] - 2026-07-30
 
 - [#50](https://github.com/nelsonPires5/herdr-board/pull/50) fix(core,tui): honor Pi `thinkingLevelMap` missing/string/null semantics in model effort menus.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ welcome. For the full cross-agent contributor guide (crate ownership, herdr gotc
 
 ## Development setup
 
-Requirements: a **Rust toolchain** (stable, edition 2021) and exactly **Herdr 0.7.5 with
-socket protocol 17** on `PATH` for the end-to-end path (unit and integration tests need neither
+Requirements: a **Rust toolchain** (stable, edition 2021) and exactly **Herdr 0.8.0 with
+socket protocol 19** on `PATH` for the end-to-end path (unit and integration tests need neither
 herdr nor an agent harness).
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # herdr-board
 
 ![Rust](https://img.shields.io/badge/rust-edition%202021-orange.svg)
-![herdr 0.7.5](https://img.shields.io/badge/herdr-0.7.5-8a2be2)
+![herdr 0.8.0](https://img.shields.io/badge/herdr-0.8.0-8a2be2)
 ![platforms: linux, macOS](https://img.shields.io/badge/platforms-linux%2C%20macOS-informational)
 ![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
@@ -39,13 +39,14 @@ only `Todo`.
 
 ## Install
 
-Requires exactly **Herdr 0.7.5 (protocol 17)**, Git, and a Rust toolchain with `cargo`. Linux
+Requires exactly **Herdr 0.8.0 (protocol 19)**, Git, and a Rust toolchain with `cargo`. Linux
 and macOS are supported. Ensure `~/.local/bin` is on your `PATH`. The board protocol is v1 and the
 current SQLite schema is v13; `schema.sql` defines fresh databases and the daemon applies tested
 upgrades through `board-core::db`.
 
 The daemon checks the selected Herdr socket before workspace discovery and pane launch. It rejects
-any Herdr version other than 0.7.5 and any protocol other than 17; protocol 16 is not supported.
+any Herdr version other than 0.8.0 and any protocol other than 19; older, unknown, and future
+protocols are not supported.
 
 ```bash
 herdr plugin install nelsonPires5/herdr-board --ref v0.10.0
@@ -270,7 +271,7 @@ typed `board_core::client::BoardClient`; only boardd touches SQLite.
 
 ## Status
 
-**v1 board protocol / schema v13 / Herdr 0.7.5 (protocol 17).** Rust with Ratatui, Rusqlite, and
+**v1 board protocol / schema v13 / Herdr 0.8.0 (protocol 19).** Rust with Ratatui, Rusqlite, and
 Tokio. See [`docs/README.md`](docs/README.md) for the full version and source-ownership matrix.
 
 ## License

--- a/crates/board-cli/src/daemon/tests.rs
+++ b/crates/board-cli/src/daemon/tests.rs
@@ -68,13 +68,19 @@ fn daemon_child_owns_a_distinct_process_group() {
     command.env("BOARD_TEST_PROCESS_GROUP", &evidence);
     let mut child = command.spawn().expect("spawn probe");
 
-    for _ in 0..100 {
-        if evidence.exists() {
-            break;
+    let values = {
+        let mut complete = None;
+        for _ in 0..100 {
+            if let Ok(values) = fs::read_to_string(&evidence) {
+                if values.split_whitespace().count() == 3 {
+                    complete = Some(values);
+                    break;
+                }
+            }
+            thread::sleep(Duration::from_millis(10));
         }
-        thread::sleep(Duration::from_millis(10));
-    }
-    let values = fs::read_to_string(&evidence).expect("read process-group evidence");
+        complete.expect("process-group evidence did not contain exactly three fields within 1s")
+    };
     let mut fields = values.split_whitespace();
     let pid: i32 = fields.next().expect("pid").parse().expect("numeric pid");
     let pgid: i32 = fields.next().expect("pgid").parse().expect("numeric pgid");

--- a/crates/board-core/src/harness.rs
+++ b/crates/board-core/src/harness.rs
@@ -226,7 +226,7 @@ pub const BOARD_RESCUE: &str = "BOARD_RESCUE";
 ///
 /// Re-threading works by [`strip_session_flags`] + append, which is only sound
 /// while the persisted argv is *startup-only*. That holds for every spec
-/// [`build_invocation`] produces (protocol-17 managed launches keep both prompt
+/// [`build_invocation`] produces (pane-first managed launches keep both prompt
 /// channels out of argv). The legacy all-in-one helpers [`claude_argv`] /
 /// [`pi_argv`] do **not** hold it: they end in `-- "<prompt>"` (claude) or a
 /// bare positional (pi). If such an argv were ever persisted, appending resume
@@ -310,7 +310,7 @@ pub fn protocol_system_prompt(column_prompt: Option<&str>) -> String {
 
 /// Build the legacy all-in-one argv for the builtin `claude` harness.
 ///
-/// This public helper is retained for existing callers; protocol-17 dispatch
+/// This public helper is retained for existing callers; managed Herdr dispatch
 /// uses [`build_invocation`] so prompts are not included in startup argv.
 ///
 /// `claude [--model M] [--effort E] [--permission-mode P] --append-system-prompt SP
@@ -352,7 +352,7 @@ pub fn claude_argv(
 
 /// Build the legacy all-in-one argv/session result for the built-in Pi harness.
 ///
-/// This public helper is retained for existing callers; protocol-17 dispatch
+/// This public helper is retained for existing callers; managed Herdr dispatch
 /// uses [`build_invocation`] so prompts are not included in startup argv.
 /// Pi takes a normal positional prompt (no Claude `--` delimiter). Prefixing it
 /// with non-flag text ensures a card description beginning with `-` cannot be
@@ -438,7 +438,7 @@ pub fn build_invocation(
     })
 }
 
-/// Build a protocol-17 managed Pi launch. Unlike the legacy argv helper above,
+/// Build a managed Herdr Pi launch. Unlike the legacy argv helper above,
 /// this keeps both prompt channels out of startup argv so Herdr can start the
 /// agent first and submit the card task only after it is interactive.
 fn managed_pi_invocation(
@@ -473,7 +473,7 @@ fn managed_pi_invocation(
     })
 }
 
-/// Build a protocol-17 managed Claude launch while preserving the established
+/// Build a managed Herdr Claude launch while preserving the established
 /// model/effort/permission/session flag ordering exactly.
 fn managed_claude_invocation(
     settings: &EffectiveSettings,

--- a/crates/board-core/tests/harness.rs
+++ b/crates/board-core/tests/harness.rs
@@ -518,7 +518,7 @@ fn resume_invocation_refuses_a_legacy_all_in_one_command_line() {
             .unwrap_err(),
         HarnessError::ResumeLegacyArgv("claude".into())
     );
-    // The protocol-17 form `build_invocation` actually persists is accepted.
+    // The pane-first managed form `build_invocation` actually persists is accepted.
     let managed = build_invocation(
         "claude",
         &Config::default(),

--- a/crates/board-core/tests/managed_spawn.rs
+++ b/crates/board-core/tests/managed_spawn.rs
@@ -1,4 +1,4 @@
-//! Protocol-17 launch metadata contracts.
+//! Managed launch metadata contracts.
 //!
 //! Managed agents expose the authoritative system instructions separately from
 //! the card task. The daemon materializes those instructions as a startup-only

--- a/crates/board-daemon/src/dispatch/launch_plan.rs
+++ b/crates/board-daemon/src/dispatch/launch_plan.rs
@@ -63,7 +63,7 @@ pub(super) async fn spawn_one(d: &Arc<Daemon>, run: &Run, card: &Card) -> Result
         db.require_column(run.column_id)?
     };
 
-    // A non-NULL snapshot is explicit protocol-17 launch metadata. Legacy v6
+    // A non-NULL snapshot is explicit managed-launch metadata. Legacy v6
     // built-ins remain unmanaged so their persisted all-in-one argv executes
     // unchanged, without duplicate prompt delivery.
     let builtin = is_builtin_harness(&run.harness);

--- a/crates/board-daemon/src/dispatch/space.rs
+++ b/crates/board-daemon/src/dispatch/space.rs
@@ -1,8 +1,6 @@
 use board_core::protocol::SpaceKind;
 use board_herdr::{HerdrClient, WorkspaceCreateParams, WorkspaceInfo};
 
-use crate::HERDR_PROTOCOL;
-
 /// Resolve a card's space within its session to `(workspace_id, cwd)`.
 ///
 /// - [`SpaceKind::Workspace`]: `space_ref` is an existing workspace id or a
@@ -18,7 +16,7 @@ pub(crate) fn resolve_space(
 ) -> anyhow::Result<(String, String)> {
     // Dispatch performs workspace discovery before handing off to the spawner,
     // so the selected socket must be gated here as well as in HerdrSpawner.
-    client.require_protocol(HERDR_PROTOCOL).map_err(|error| {
+    client.require_supported_protocol().map_err(|error| {
         let message = error.to_string();
         anyhow::Error::new(error).context(format!(
             "checking Herdr protocol before workspace resolution: {message}"
@@ -42,8 +40,9 @@ pub(crate) fn resolve_space(
                 .ok_or_else(|| anyhow::anyhow!("new_workspace space requires space_cwd"))?;
             match find_workspace_by_label(&workspaces, label) {
                 // A reused workspace must use a cwd from one of its live
-                // panes. Protocol 17 does not inherit workspace cwd, so the
-                // card's original create cwd is not a safe fallback here.
+                // panes. The supported Herdr launch contract does not inherit
+                // workspace cwd, so the card's original create cwd is not a
+                // safe fallback here.
                 Some(id) => {
                     let live = workspace_cwd(client, &id)?;
                     Ok((id, live))
@@ -66,8 +65,9 @@ pub(crate) fn resolve_space(
 
 /// Look up a workspace's cwd via one of its live panes in the session snapshot.
 ///
-/// Protocol 17 placement is pane-first and never inherits a workspace cwd, so
-/// failure to read this value must stop dispatch rather than launch from an
+/// The supported Herdr placement contract is pane-first and never inherits a
+/// workspace cwd, so failure to read this value must stop dispatch rather than
+/// launch from an
 /// implicit daemon/Herdr fallback directory.
 pub(crate) fn workspace_cwd(
     client: &mut HerdrClient,
@@ -147,7 +147,7 @@ pub(crate) fn validate_space_resolvable(
     space_ref: Option<&str>,
     space_cwd: Option<&str>,
 ) -> anyhow::Result<()> {
-    client.require_protocol(HERDR_PROTOCOL).map_err(|error| {
+    client.require_supported_protocol().map_err(|error| {
         let message = error.to_string();
         anyhow::Error::new(error).context(format!(
             "checking Herdr protocol before workspace pre-check: {message}"

--- a/crates/board-daemon/src/dispatch/tests/space.rs
+++ b/crates/board-daemon/src/dispatch/tests/space.rs
@@ -96,11 +96,11 @@ fn newly_created_workspace_requires_live_snapshot_cwd() {
 
 #[test]
 fn new_workspace_selected_socket_preflights_protocol_before_resolution() {
-    // RED: dispatch must gate the selected socket before resolve_space. A
+    // Dispatch must gate the selected socket before resolve_space. A
     // mismatched socket must receive exactly ping; workspace.list/create,
     // session.snapshot, and spawner placement must not be reached.
     let herdr = testkit::herdr_server()
-        .version("0.7.4")
+        .version("0.8.1")
         .take(3)
         .on("workspace.list", |req| {
             testkit::reply(
@@ -126,9 +126,11 @@ fn new_workspace_selected_socket_preflights_protocol_before_resolution() {
 
     assert_eq!(herdr.methods(), vec!["ping"]);
     let err = result.expect_err("protocol mismatch must stop workspace resolution");
-    assert!(err
-        .to_string()
-        .contains("Herdr 0.7.5 with protocol 17 is required"));
+    assert!(err.to_string().contains(&format!(
+        "Herdr {} with protocol {} is required",
+        board_herdr::SUPPORTED_HERDR_VERSION,
+        board_herdr::SUPPORTED_HERDR_PROTOCOL
+    )));
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/board-daemon/src/herdr_conn.rs
+++ b/crates/board-daemon/src/herdr_conn.rs
@@ -1,14 +1,13 @@
 //! The single gated way to open a Herdr request connection.
 //!
-//! `AGENTS.md` pins herdr-board to exactly Herdr 0.7.5 / socket protocol 17 and
-//! rejects every other one. The daemon opens a fresh connection per operation,
+//! The board-herdr client pins herdr-board to one supported Herdr release and
+//! socket protocol and rejects every other one. The daemon opens a fresh
+//! connection per operation,
 //! so the gate has to live at the connect, not at a single startup check.
 
 use std::path::{Path, PathBuf};
 
 use board_herdr::HerdrClient;
-
-use crate::HERDR_PROTOCOL;
 
 /// Connect to `socket` and require the pinned Herdr protocol before any other
 /// request can reach it.
@@ -19,7 +18,7 @@ use crate::HERDR_PROTOCOL;
 /// while the gate itself stays identical everywhere.
 pub(crate) fn connect_checked(socket: &Path) -> board_herdr::Result<HerdrClient> {
     let mut client = HerdrClient::connect(socket)?;
-    client.require_protocol(HERDR_PROTOCOL)?;
+    client.require_supported_protocol()?;
     Ok(client)
 }
 
@@ -32,7 +31,7 @@ pub(crate) fn connect_checked_for(socket: &Path, purpose: &str) -> anyhow::Resul
         let message = error.to_string();
         anyhow::Error::new(error).context(format!("herdr unavailable: {message}"))
     })?;
-    client.require_protocol(HERDR_PROTOCOL).map_err(|error| {
+    client.require_supported_protocol().map_err(|error| {
         let message = error.to_string();
         anyhow::Error::new(error).context(format!(
             "checking Herdr protocol before {purpose}: {message}"

--- a/crates/board-daemon/src/herdr_snapshot/tests.rs
+++ b/crates/board-daemon/src/herdr_snapshot/tests.rs
@@ -20,8 +20,8 @@ fn make_pane(pane_id: &str, agent_status: AgentStatus) -> PaneInfo {
 
 fn empty_snapshot() -> SessionSnapshot {
     SessionSnapshot {
-        version: "1".into(),
-        protocol: 17,
+        version: board_herdr::SUPPORTED_HERDR_VERSION.into(),
+        protocol: board_herdr::SUPPORTED_HERDR_PROTOCOL,
         workspaces: vec![],
         tabs: vec![],
         panes: vec![],

--- a/crates/board-daemon/src/lib.rs
+++ b/crates/board-daemon/src/lib.rs
@@ -23,7 +23,7 @@ mod supervisor;
 mod testkit;
 mod watchers;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,8 +45,13 @@ use crate::store::Store;
 /// table itself so it cannot drift from routing.
 pub use ops::ROUTED_METHODS;
 
-/// The herdr protocol version the daemon requires.
-pub(crate) const HERDR_PROTOCOL: u32 = 17;
+/// Retain a reachable default-session handle without imposing the operation
+/// compatibility gate during startup. Status and notifications perform that
+/// exact gate when they run; all dispatch, event, and mutation paths keep their
+/// checked connection helpers.
+fn initial_herdr_handle(socket: &Path) -> Option<HerdrClient> {
+    HerdrClient::connect(socket).ok()
+}
 
 /// Run the daemon. `foreground` mirrors logs to stderr and is used by
 /// `board daemon --foreground`. Returns `Ok(())` immediately if another daemon
@@ -94,10 +99,14 @@ async fn async_main(db_path: PathBuf, socket_path: PathBuf) -> anyhow::Result<()
     let store = Store::new(db);
 
     // Herdr handle (best effort): used for notifications, liveness, status, and
-    // the default-session event stream. Absence never crashes the daemon.
+    // the default-session event stream. Keep any reachable socket handle even
+    // when its current contract is incompatible; status and notifications
+    // probe the exact supported contract at operation time, so a server that
+    // upgrades in place can recover without restarting boardd. Dispatch,
+    // events, and mutations retain their own checked gates.
     let herdr: Option<HerdrClient> = match settings.spawner {
         SpawnerKind::Local => None,
-        SpawnerKind::Herdr => HerdrClient::connect_default().ok(),
+        SpawnerKind::Herdr => initial_herdr_handle(&board_herdr::default_socket_path()),
     };
 
     // Session registry (herdr spawner only): resolves card sessions to sockets.

--- a/crates/board-daemon/src/ops/boards.rs
+++ b/crates/board-daemon/src/ops/boards.rs
@@ -9,7 +9,7 @@ pub(super) fn daemon_status(d: &Arc<Daemon>) -> Result<Value> {
     let herdr_connected = match &d.herdr {
         Some(h) => {
             let mut c = h.clone();
-            c.is_live()
+            c.require_supported_protocol().is_ok()
         }
         None => false,
     };

--- a/crates/board-daemon/src/ops/panes.rs
+++ b/crates/board-daemon/src/ops/panes.rs
@@ -17,7 +17,7 @@ use board_herdr::PaneRenameParams;
 /// the caller's own Herdr session. That session is named by `origin_socket`
 /// exactly as it is for `run.focus`, because only the caller knows which Herdr
 /// it is running inside; the socket is canonicalized and then opened through
-/// [`crate::herdr_conn`], so the pinned Herdr 0.7.5 / protocol-17 gate applies
+/// [`crate::herdr_conn`], so the pinned Herdr 0.8.0 / protocol-19 gate applies
 /// before the rename reaches it.
 ///
 /// **A failure here is a real error (code 4), not a silent success.** The

--- a/crates/board-daemon/src/ops/tests/boards.rs
+++ b/crates/board-daemon/src/ops/tests/boards.rs
@@ -11,6 +11,70 @@ fn daemon_stop_triggers_shutdown_and_reports_stopping() {
 }
 
 #[test]
+fn daemon_status_reports_supported_pingable_herdr_as_connected() {
+    let herdr = testkit::herdr_server().serve();
+    let client = board_herdr::HerdrClient::connect(&herdr.socket).unwrap();
+    let d = testkit::daemon().herdr(client).build_daemon();
+
+    let status = handle_request(&d, "daemon.status", json!({})).unwrap();
+
+    assert_eq!(status["herdr_connected"], true);
+    assert_eq!(herdr.methods(), vec!["ping"]);
+}
+
+#[test]
+fn daemon_status_does_not_report_incompatible_pingable_herdr_as_connected() {
+    let herdr = testkit::herdr_server().version("0.8.1").serve();
+    let client = board_herdr::HerdrClient::connect(&herdr.socket).unwrap();
+    let d = testkit::daemon().herdr(client).build_daemon();
+
+    let status = handle_request(&d, "daemon.status", json!({})).unwrap();
+
+    assert_eq!(status["herdr_connected"], false);
+    assert_eq!(herdr.methods(), vec!["ping"]);
+}
+
+#[test]
+fn daemon_status_reprobes_a_reachable_handle_after_an_initial_mismatch() {
+    let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let probes_for_server = Arc::clone(&probes);
+    let herdr = testkit::herdr_server()
+        .on("ping", move |req| {
+            let supported = probes_for_server.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0;
+            testkit::reply(
+                req,
+                if supported {
+                    json!({
+                        "type": "pong",
+                        "version": board_herdr::SUPPORTED_HERDR_VERSION,
+                        "protocol": board_herdr::SUPPORTED_HERDR_PROTOCOL,
+                        "capabilities": {}
+                    })
+                } else {
+                    json!({
+                        "type": "pong",
+                        "version": "0.8.1",
+                        "protocol": board_herdr::SUPPORTED_HERDR_PROTOCOL,
+                        "capabilities": {}
+                    })
+                },
+            )
+        })
+        .serve();
+    // Reachability is enough to retain the default-session handle. Compatibility
+    // is deliberately checked by each status operation below.
+    let client = crate::initial_herdr_handle(&herdr.socket).expect("reachable Herdr handle");
+    let d = testkit::daemon().herdr(client).build_daemon();
+
+    let first = handle_request(&d, "daemon.status", json!({})).unwrap();
+    let second = handle_request(&d, "daemon.status", json!({})).unwrap();
+
+    assert_eq!(first["herdr_connected"], false);
+    assert_eq!(second["herdr_connected"], true);
+    assert_eq!(herdr.methods(), vec!["ping", "ping"]);
+}
+
+#[test]
 fn board_open_list_get_and_legacy_default_are_scoped() {
     let d = test_daemon(Config::default());
     let alpha = handle_request(&d, "board.open", json!({"scope_path":"/alpha"})).unwrap();

--- a/crates/board-daemon/src/ops/tests/discovery.rs
+++ b/crates/board-daemon/src/ops/tests/discovery.rs
@@ -230,7 +230,7 @@ fn run_focus_rescues_a_dead_pane_by_resuming_in_a_new_pane_without_touching_the_
 
 #[test]
 fn run_focus_rescue_gives_the_new_pane_the_board_env_but_never_the_run_credential() {
-    // Protocol-17 placement is pane-first: the run environment arrives on
+    // Pane-first placement puts the run environment on
     // `pane.split`, not `agent.start`. Without it a harness that reads the board
     // env (every checked-in fixture does, under `set -u`) exits immediately.
     let fake = fake_rescue_herdr(RescueFakeFaults::default());
@@ -719,7 +719,7 @@ fn space_list_without_herdr_is_herdr_unavailable() {
 
 #[test]
 fn space_list_rejects_a_socket_with_the_wrong_protocol() {
-    let herdr = fake_herdr_with_protocol(16);
+    let herdr = fake_herdr_with_protocol(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1);
     // Seed the listing: resolving the default session otherwise shells out to
     // `herdr session list --json`, which makes this assert on whatever herdr is
     // on PATH rather than on the protocol gate — green locally, red in CI.
@@ -739,7 +739,11 @@ fn space_list_rejects_a_socket_with_the_wrong_protocol() {
     assert_eq!(err.code(), 4);
     let msg = err.to_string();
     assert!(
-        msg.contains("Herdr 0.7.5 with protocol 17 is required"),
+        msg.contains(&format!(
+            "Herdr {} with protocol {} is required",
+            board_herdr::SUPPORTED_HERDR_VERSION,
+            board_herdr::SUPPORTED_HERDR_PROTOCOL
+        )),
         "message: {msg}"
     );
     // The gate is the first and only request: workspace.list never happens.
@@ -748,7 +752,7 @@ fn space_list_rejects_a_socket_with_the_wrong_protocol() {
 
 #[test]
 fn run_focus_rejects_a_socket_with_the_wrong_protocol() {
-    let herdr = fake_herdr_with_protocol(16);
+    let herdr = fake_herdr_with_protocol(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1);
     let origin_dir = tempfile::tempdir().unwrap();
     let origin = origin_dir.path().join("origin.sock");
     std::os::unix::fs::symlink(&herdr.socket, &origin).unwrap();
@@ -766,7 +770,11 @@ fn run_focus_rejects_a_socket_with_the_wrong_protocol() {
     assert_eq!(err.code(), 4);
     let msg = err.to_string();
     assert!(
-        msg.contains("Herdr 0.7.5 with protocol 17 is required"),
+        msg.contains(&format!(
+            "Herdr {} with protocol {} is required",
+            board_herdr::SUPPORTED_HERDR_VERSION,
+            board_herdr::SUPPORTED_HERDR_PROTOCOL
+        )),
         "message: {msg}"
     );
     // The liveness probe for the recorded pane must not reach an incompatible

--- a/crates/board-daemon/src/ops/tests/mod.rs
+++ b/crates/board-daemon/src/ops/tests/mod.rs
@@ -69,7 +69,11 @@ fn fake_herdr(reply: &'static str) -> FakeHerdr {
 /// `pane_exists == false` makes `pane.get` answer `pane_not_found`, i.e. the
 /// run's recorded pane id is stale (its terminal was closed).
 fn fake_herdr_with_pane(focus_reply: &'static str, pane_exists: bool) -> FakeHerdr {
-    fake_herdr_inner(focus_reply, pane_exists, crate::HERDR_PROTOCOL)
+    fake_herdr_inner(
+        focus_reply,
+        pane_exists,
+        board_herdr::SUPPORTED_HERDR_PROTOCOL,
+    )
 }
 
 /// A fake Herdr that answers the protocol gate with `protocol` and records
@@ -114,7 +118,8 @@ fn fake_herdr_inner(focus_reply: &'static str, pane_exists: bool, protocol: u32)
 }
 
 // ---------------------------------------------------------------------------
-// Rescue fixture: a small stateful protocol-17 Herdr for `run.focus` rescues
+// Rescue fixture: a small stateful Herdr 0.8.0 / protocol 19 server for
+// `run.focus` rescues
 // ---------------------------------------------------------------------------
 
 /// Create a card plus one *finished* run that recorded a dead pane, a live
@@ -246,7 +251,7 @@ impl RescueFake {
     }
 
     /// The env of the last `pane.split`, i.e. what the rescued pane received.
-    /// Protocol-17 placement is pane-first, so the run environment arrives on
+    /// Pane-first placement puts the run environment on
     /// `pane.split`, NOT on `agent.start`.
     fn last_split_env(&self) -> BTreeMap<String, String> {
         let splits = self.herdr.requests_for("pane.split");
@@ -255,7 +260,7 @@ impl RescueFake {
     }
 }
 
-/// A stateful protocol-17 Herdr covering the rescue path: the run's recorded
+/// A stateful Herdr 0.8.0 / protocol 19 server covering the rescue path: the run's recorded
 /// pane `w1:p9` is **absent** (its terminal was closed) while the card tab
 /// `w1:t1` and its shell anchor `w1:anchor` are still alive. Panes created by
 /// `pane.split` persist in this fake and are returned by `pane.list`, which is
@@ -341,7 +346,7 @@ fn fake_rescue_herdr(faults: RescueFakeFaults) -> RescueFake {
                     testkit::reply(
                         request,
                         json!({"type":"session_snapshot","snapshot":{
-                            "version":"0.7.5","protocol":17,
+                            "version":board_herdr::SUPPORTED_HERDR_VERSION,"protocol":board_herdr::SUPPORTED_HERDR_PROTOCOL,
                             "workspaces":[{"workspace_id":"w1","label":"ws","focused":true,
                                            "tab_count":1,"pane_count":1,"agent_status":"idle"}],
                             "tabs":tab_list,"panes":list,"agents":[]

--- a/crates/board-daemon/src/ops/tests/panes.rs
+++ b/crates/board-daemon/src/ops/tests/panes.rs
@@ -45,7 +45,9 @@ fn pane_set_title_renames_the_caller_pane_through_herdr() {
 
 #[test]
 fn pane_set_title_rejects_a_socket_with_the_wrong_protocol() {
-    let herdr = testkit::herdr_server().protocol(16).serve();
+    let herdr = testkit::herdr_server()
+        .protocol(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1)
+        .serve();
     let d = test_daemon(Config::default());
 
     let err = handle_request(
@@ -58,7 +60,11 @@ fn pane_set_title_rejects_a_socket_with_the_wrong_protocol() {
     assert_eq!(err.code(), 4);
     let msg = err.to_string();
     assert!(
-        msg.contains("Herdr 0.7.5 with protocol 17 is required"),
+        msg.contains(&format!(
+            "Herdr {} with protocol {} is required",
+            board_herdr::SUPPORTED_HERDR_VERSION,
+            board_herdr::SUPPORTED_HERDR_PROTOCOL
+        )),
         "message: {msg}"
     );
     // The gate is the first and only request: no rename reaches a socket the

--- a/crates/board-daemon/src/rescue.rs
+++ b/crates/board-daemon/src/rescue.rs
@@ -209,7 +209,7 @@ fn rescue_identity(
 ///
 /// Dispatch injects `BOARD_CARD_ID`/`BOARD_RUN_ID`/`BOARD_SOCKET`/`BOARD_BIN` at
 /// spawn time (`dispatch::launch_plan`); none of them live in the persisted launch
-/// spec (a built-in's persisted `env` is empty), and protocol-17 `agent.start` carries
+/// spec (a built-in's persisted `env` is empty), and the supported Herdr `agent.start` carries
 /// no environment of its own. Without this the rescued pane would receive only
 /// the two rescue variables, and any harness that reads the board env — the
 /// checked-in fixtures do, under `set -u` — would exit immediately.

--- a/crates/board-daemon/src/spawner/herdr/managed.rs
+++ b/crates/board-daemon/src/spawner/herdr/managed.rs
@@ -1,4 +1,4 @@
-//! Managed protocol-17 launch: `agent.start` on a board-owned pane, with the
+//! Managed Herdr launch: `agent.start` on a board-owned pane, with the
 //! name/busy retry taxonomy and the wait for the agent to become interactive.
 
 use std::fs;

--- a/crates/board-daemon/src/spawner/herdr/mod.rs
+++ b/crates/board-daemon/src/spawner/herdr/mod.rs
@@ -25,7 +25,7 @@ pub(crate) use configured::{configured_script, posix_quote, remove_file_if_exist
 pub(crate) use configured::{launch_configured, HerdrCliPaneRunner, PaneRunner};
 pub(crate) use managed::{launch_managed, DelayFn, DEFAULT_AGENT_START_DELAY};
 
-/// Launches managed agents through protocol-17 `agent.start`, and configured
+/// Launches managed agents through the supported Herdr `agent.start` contract, and configured
 /// harnesses through a board-owned split child plus `herdr pane run`.
 ///
 /// New durable card tabs retain their root as a shell anchor; the anchor is
@@ -81,7 +81,14 @@ impl HerdrSpawner {
         }
     }
 
-    /// Open a client on `socket` (the run's session), else the default socket.
+    /// Open an ungated client on `socket` (the run's session), else the
+    /// default socket.
+    ///
+    /// This helper is intentionally reserved for [`Spawner::kill`] and
+    /// [`Spawner::is_alive`]. Cleanup and observation may need to inspect or
+    /// close a pane already owned by this daemon even when Herdr has become
+    /// incompatible; every new placement/mutation path starts with
+    /// [`connect_checked_for`] instead.
     fn client_for(&self, socket: Option<&Path>) -> anyhow::Result<HerdrClient> {
         let target = socket.unwrap_or(&self.socket);
         HerdrClient::connect(target).map_err(|error| {

--- a/crates/board-daemon/src/spawner/rescue.rs
+++ b/crates/board-daemon/src/spawner/rescue.rs
@@ -84,7 +84,7 @@ pub(crate) enum RescueOutcome {
 /// - **managed** (`agent_kind: Some`): Herdr tracks a registered agent for the
 ///   pane, so require `PaneInfo::agent` to still be *present*. Deliberately a
 ///   presence test, not an equality test against our `agent.start` name: the
-///   pinned protocol-17 schema gives `AgentInfo` **both** an `agent` and a
+///   supported Herdr 0.8.0 / protocol 19 schema gives `AgentInfo` **both** an `agent` and a
 ///   separate `name` field, and `e2e/16-managed-p17.sh` matches `pane.agent`
 ///   against the agent *kind* (`pi`/`claude`), so `agent` is not the exclusive
 ///   name we chose and must not be compared to it. Presence is the same
@@ -113,7 +113,7 @@ fn rescued_pane_is_live(pane: &PaneInfo, marker_name: &str, managed: bool) -> bo
 ///
 /// The label is used because it is the one field we both **write** (`pane.rename
 /// {pane_id, label}`) and can **read back** (`PaneInfo::label`) under the pinned
-/// protocol-17 schema. The `agent.start` name is deliberately *not* matched
+/// supported Herdr 0.8.0 / protocol 19 schema. The `agent.start` name is deliberately *not* matched
 /// against `PaneInfo::agent`: that field is not the exclusive name we chose (see
 /// [`rescued_pane_is_live`]).
 ///
@@ -207,7 +207,8 @@ pub(crate) fn rescue_run_pane(plan: &RescuePlan<'_>) -> anyhow::Result<RescueOut
         })?;
     }
 
-    // Protocol 17 never inherits a workspace cwd, so the rescue pane's cwd is
+    // The supported Herdr launch contract never inherits a workspace cwd, so
+    // the rescue pane's cwd is
     // read from a live pane of the run's recorded workspace — the same rule
     // dispatch uses. A vanished workspace fails here rather than launching in
     // some implicit directory.
@@ -304,7 +305,7 @@ pub(crate) fn rescue_run_pane(plan: &RescuePlan<'_>) -> anyhow::Result<RescueOut
 /// it. Labelling happens before the launch so the correlator exists even if the
 /// launch is slow; a failed launch removes the pane again.
 ///
-/// Verified against Herdr 0.7.5 / protocol 17 on a live socket: `agent.start`
+/// Verified against Herdr 0.8.0 / protocol 19 on a live socket: `agent.start`
 /// leaves a board-set `label` untouched, so this single pre-launch rename is
 /// enough and the label is still `marker_name` afterwards. That was checked by
 /// running `e2e/27-rescue-dead-pane.sh` with the label re-asserted post-launch

--- a/crates/board-daemon/src/spawner/tests/failures.rs
+++ b/crates/board-daemon/src/spawner/tests/failures.rs
@@ -23,7 +23,7 @@ fn failed_managed_start_removes_prompt_file_and_closes_only_owned_pane() {
             error(req, "unsupported_agent_kind", "unsupported kind")
         }
         "pane.close" => pane_result(req, "w1:p2"),
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
 

--- a/crates/board-daemon/src/spawner/tests/managed.rs
+++ b/crates/board-daemon/src/spawner/tests/managed.rs
@@ -1,4 +1,4 @@
-//! Protocol-17 managed launch: the version/protocol gate, the pane-first
+//! Supported-contract managed launch: the version/protocol gate, the pane-first
 //! `pane.split` → `agent.start` order, the authoritative startup system-prompt
 //! file, readiness polling before the card prompt, and the bounded
 //! `agent_pane_busy` / name-collision retry budget.
@@ -7,7 +7,13 @@ use super::*;
 
 #[test]
 fn herdr_protocol_gate_rejects_mismatches_before_any_spawn_or_placement_call() {
-    for (version, protocol) in [("0.7.4", 17), ("0.7.5", 16)] {
+    for (version, protocol) in [
+        ("0.8.1", board_herdr::SUPPORTED_HERDR_PROTOCOL),
+        (
+            board_herdr::SUPPORTED_HERDR_VERSION,
+            board_herdr::SUPPORTED_HERDR_PROTOCOL - 1,
+        ),
+    ] {
         let fake = serve_recording_herdr_with_ping(
             |req, _| error(req, "unexpected_call", "protocol gate was bypassed"),
             version,
@@ -29,7 +35,11 @@ fn herdr_protocol_gate_rejects_mismatches_before_any_spawn_or_placement_call() {
             .unwrap_err();
         let text = err.to_string();
         assert!(
-            text.contains("Herdr 0.7.5 with protocol 17 is required"),
+            text.contains(&format!(
+                "Herdr {} with protocol {} is required",
+                board_herdr::SUPPORTED_HERDR_VERSION,
+                board_herdr::SUPPORTED_HERDR_PROTOCOL
+            )),
             "mismatch must explain the required Herdr version/protocol: {text}"
         );
         assert_eq!(
@@ -100,7 +110,7 @@ fn managed_pi_uses_startup_only_system_file_then_polls_ready_before_card_prompt(
             );
             agent_prompted(req, "w1:p2", "card-42-execute")
         }
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
     let prompt = "first task line\nsecond task line with spaces";
@@ -173,7 +183,7 @@ fn managed_claude_uses_file_specific_flag_after_unchanged_startup_tail() {
             *prompt_path2.lock().unwrap() = Some(path);
             agent_started(req, "w1:p8", false, true)
         }
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
 
@@ -219,7 +229,7 @@ fn managed_existing_tab_splits_selected_pane_before_exact_agent_start() {
             );
             agent_started(req, "w1:p3", false, true)
         }
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
 

--- a/crates/board-daemon/src/spawner/tests/mod.rs
+++ b/crates/board-daemon/src/spawner/tests/mod.rs
@@ -29,7 +29,7 @@ fn pane(id: &str, width: u64, height: u64) -> LayoutPane {
 }
 
 // -----------------------------------------------------------------------
-// Protocol-17 pane-first launch contracts
+// Pane-first managed launch contracts for the supported Herdr API
 // -----------------------------------------------------------------------
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/board-daemon/src/spawner/tests/races.rs
+++ b/crates/board-daemon/src/spawner/tests/races.rs
@@ -51,7 +51,7 @@ fn pane_split_race_rediscovers_tab_and_splits_a_live_replacement() {
             }
         }
         "agent.start" => agent_started(req, "w1:p5", false, true),
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
 
@@ -157,7 +157,7 @@ fn name_collision_retries_on_the_same_owned_pane_and_same_prompt_file() {
                 agent_started(req, "w1:p2", false, true)
             }
         }
-        method => panic!("unexpected protocol-17 method {method}"),
+        method => panic!("unexpected supported-contract method {method}"),
     });
     let spawner = HerdrSpawner::new(fake.socket.clone());
 

--- a/crates/board-daemon/src/state.rs
+++ b/crates/board-daemon/src/state.rs
@@ -35,6 +35,20 @@ fn trace_notification_error(error: &HerdrError) {
     );
 }
 
+/// Probe the exact supported Herdr contract immediately before the cosmetic
+/// notification mutation. Keeping this synchronous helper separate from the
+/// detached wrapper makes the gate and request ordering deterministic in tests.
+fn send_notification(
+    client: &mut HerdrClient,
+    title: &str,
+    body: Option<&str>,
+    sound: NotificationSound,
+) -> board_herdr::Result<()> {
+    client.require_supported_protocol()?;
+    client.notification_show(title, body, sound)?;
+    Ok(())
+}
+
 fn system_wall_now_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -267,7 +281,11 @@ impl Daemon {
         let _ = self.dispatch_tx.send(());
     }
 
-    /// Fire a herdr notification (best effort, detached; no-op without herdr).
+    /// Fire a Herdr notification (best effort, detached; no-op without Herdr).
+    ///
+    /// The compatibility probe stays inside the detached effect immediately
+    /// before the mutation. Notifications are cosmetic, but an incompatible
+    /// pingable Herdr must not receive a `notification.show` request.
     pub fn notify(&self, title: String, body: Option<String>, sound: NotificationSound) {
         #[cfg(test)]
         self.record_effect("notification");
@@ -276,7 +294,7 @@ impl Daemon {
             std::thread::spawn(move || {
                 // Cosmetic and detached, but a silently missing "ready for
                 // review" toast is otherwise unexplainable to the user.
-                if let Err(error) = c.notification_show(&title, body.as_deref(), sound) {
+                if let Err(error) = send_notification(&mut c, &title, body.as_deref(), sound) {
                     trace_notification_error(&error);
                 }
             });
@@ -398,5 +416,46 @@ mod tracing_tests {
             !text.contains(SECRET),
             "secret-bearing protocol error leaked: {text}"
         );
+    }
+
+    #[test]
+    fn notification_send_pings_before_sending_a_supported_notification() {
+        let herdr = crate::testkit::herdr_server()
+            .on("notification.show", |req| {
+                crate::testkit::reply(req, serde_json::json!({"shown": true}))
+            })
+            .serve();
+        let mut client = HerdrClient::connect(&herdr.socket).unwrap();
+
+        send_notification(
+            &mut client,
+            "title",
+            Some("body"),
+            NotificationSound::Request,
+        )
+        .expect("the supported notification should be sent");
+
+        assert_eq!(herdr.methods(), vec!["ping", "notification.show"]);
+    }
+
+    #[test]
+    fn notification_send_only_pings_an_incompatible_herdr() {
+        let herdr = crate::testkit::herdr_server()
+            .version("0.8.1")
+            .on("notification.show", |req| {
+                crate::testkit::reply(req, serde_json::json!({"shown": true}))
+            })
+            .serve();
+        let mut client = HerdrClient::connect(&herdr.socket).unwrap();
+
+        assert!(send_notification(
+            &mut client,
+            "title",
+            Some("body"),
+            NotificationSound::Request,
+        )
+        .is_err());
+
+        assert_eq!(herdr.methods(), vec!["ping"]);
     }
 }

--- a/crates/board-daemon/src/supervisor/tests.rs
+++ b/crates/board-daemon/src/supervisor/tests.rs
@@ -440,7 +440,8 @@ fn fake_herdr_socket(protocol: u32) -> FakeHerdr {
             testkit::reply(
                 req,
                 serde_json::json!({"snapshot": {
-                    "version": "0.7.5", "protocol": 17,
+                    "version": board_herdr::SUPPORTED_HERDR_VERSION,
+                    "protocol": board_herdr::SUPPORTED_HERDR_PROTOCOL,
                     "workspaces": [], "tabs": [], "panes": [], "agents": []
                 }}),
             )
@@ -450,7 +451,7 @@ fn fake_herdr_socket(protocol: u32) -> FakeHerdr {
 
 #[test]
 fn herdr_runtime_snapshot_rejects_a_socket_with_the_wrong_protocol() {
-    let herdr = fake_herdr_socket(16);
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1);
     let probe = HerdrRuntime.snapshot(&SessionTarget::Default(herdr.socket.clone()));
     assert_eq!(probe, Err(ProbeFailure::Transport));
     // An incompatible socket must never yield a snapshot: a "valid snapshot
@@ -459,9 +460,12 @@ fn herdr_runtime_snapshot_rejects_a_socket_with_the_wrong_protocol() {
 }
 
 #[test]
-fn herdr_runtime_snapshot_accepts_the_pinned_protocol() {
-    let herdr = fake_herdr_socket(17);
+fn herdr_runtime_snapshot_accepts_the_supported_protocol() {
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL);
     let probe = HerdrRuntime.snapshot(&SessionTarget::Default(herdr.socket.clone()));
-    assert!(probe.is_ok(), "protocol 17 must pass the gate: {probe:?}");
+    assert!(
+        probe.is_ok(),
+        "the supported Herdr contract must pass the gate: {probe:?}"
+    );
     assert_eq!(herdr.methods(), vec!["ping", "session.snapshot"]);
 }

--- a/crates/board-daemon/src/testkit.rs
+++ b/crates/board-daemon/src/testkit.rs
@@ -4,11 +4,11 @@
 //! sibling test modules:
 //!
 //! 1. [`daemon`] — one builder for the twelve-argument [`Daemon::new`].
-//! 2. [`herdr_server`] — one fake protocol-17 Herdr Unix socket server, with a
-//!    configurable protocol/version (so protocol-gate tests can serve a *wrong*
-//!    one), per-method canned responses, an optional accept count, and recorded
-//!    request inspection. The generic protocol-17 JSON constructors used to
-//!    build those responses live here too.
+//! 2. [`herdr_server`] — one fake Herdr 0.8.0 / protocol 19 Unix socket server,
+//!    with a configurable protocol/version (so protocol-gate tests can serve a
+//!    *wrong* one), per-method canned responses, an optional accept count, and
+//!    recorded request inspection. The generic supported-contract JSON
+//!    constructors used to build those responses live here too.
 //! 3. The "nothing escaped" assertions and the armed lifecycle-fault `Db`.
 //!
 //! This module is compiled only under `cfg(test)`; nothing here is production
@@ -29,6 +29,7 @@ use board_core::config::Config;
 use board_core::db::{Db, LifecycleFaultPoint};
 use board_core::protocol::Event;
 use board_core::Error;
+use board_herdr::HerdrClient;
 
 use crate::session::SessionRegistry;
 use crate::settings::DaemonSettings;
@@ -61,6 +62,7 @@ pub(crate) struct DaemonBuilder {
     settings: DaemonSettings,
     spawner: Arc<dyn Spawner>,
     session_registry: Option<SessionRegistry>,
+    herdr: Option<HerdrClient>,
     db_path: PathBuf,
     socket_path: PathBuf,
     events_capacity: usize,
@@ -74,6 +76,7 @@ pub(crate) fn daemon() -> DaemonBuilder {
         settings: DaemonSettings::default(),
         spawner: Arc::new(LocalSpawner::new()),
         session_registry: None,
+        herdr: None,
         db_path: PathBuf::from("/tmp/board-test.db"),
         socket_path: PathBuf::from("/tmp/board-test.sock"),
         events_capacity: 16,
@@ -112,6 +115,11 @@ impl DaemonBuilder {
         self
     }
 
+    pub(crate) fn herdr(mut self, herdr: HerdrClient) -> Self {
+        self.herdr = Some(herdr);
+        self
+    }
+
     /// Point the daemon at a real on-disk database file. The socket path is
     /// derived from it unless [`DaemonBuilder::socket_path`] overrides it.
     pub(crate) fn db_path(mut self, path: PathBuf) -> Self {
@@ -142,7 +150,7 @@ impl DaemonBuilder {
             self.db_path,
             self.socket_path,
             self.spawner,
-            None, // no herdr client
+            self.herdr,
             self.session_registry,
             events_tx,
             dispatch_tx,
@@ -230,11 +238,11 @@ pub(crate) struct FakeHerdrBuilder {
 }
 
 /// Start building a fake Herdr. It answers the `ping` protocol gate itself
-/// (Herdr 0.7.5 / protocol 17 by default) and records every request.
+/// (the supported Herdr release/protocol by default) and records every request.
 pub(crate) fn herdr_server() -> FakeHerdrBuilder {
     FakeHerdrBuilder {
-        version: "0.7.5".to_string(),
-        protocol: crate::HERDR_PROTOCOL,
+        version: board_herdr::SUPPORTED_HERDR_VERSION.to_string(),
+        protocol: board_herdr::SUPPORTED_HERDR_PROTOCOL,
         take: None,
         by_method: HashMap::new(),
         fallback: None,
@@ -348,7 +356,7 @@ impl FakeHerdrBuilder {
 }
 
 // ---------------------------------------------------------------------------
-// Generic protocol-17 JSON constructors
+// Generic supported-contract JSON constructors
 // ---------------------------------------------------------------------------
 
 /// A successful response envelope for `req`.
@@ -364,7 +372,7 @@ pub(crate) fn error(req: &Value, code: &str, message: &str) -> Value {
     })
 }
 
-/// Minimal schema-valid protocol-17 `PaneInfo` fixture. In particular,
+/// Minimal schema-valid `PaneInfo` fixture. In particular,
 /// `focused` and `revision` are required by the authoritative schema.
 pub(crate) fn pane_info(id: &str) -> Value {
     json!({

--- a/crates/board-daemon/src/watchers/herdr.rs
+++ b/crates/board-daemon/src/watchers/herdr.rs
@@ -57,6 +57,11 @@ impl WatchConnector for HerdrWatchConnector {
         socket: &std::path::Path,
         panes: &[String],
     ) -> board_herdr::Result<Box<dyn WatchEventStream>> {
+        // The event stream has its own persistent connection and handshake,
+        // so gate the socket on a request connection first. This must happen
+        // before `events.subscribe`: an incompatible but pingable Herdr must
+        // never receive a subscription or become a watched generation.
+        let _client = crate::herdr_conn::connect_checked(socket)?;
         HerdrEvents::connect(socket, &watch_subscriptions(panes))
             .map(|events| Box::new(events) as Box<dyn WatchEventStream>)
     }

--- a/crates/board-daemon/src/watchers/tests/recovery.rs
+++ b/crates/board-daemon/src/watchers/tests/recovery.rs
@@ -60,10 +60,10 @@ fn pane_exit_becomes_fail_without_transition() {
 }
 
 #[test]
-fn protocol17_idle_after_done_does_not_rearm_an_awaiting_run() {
+fn trailing_idle_after_done_does_not_rearm_an_awaiting_run() {
     let (d, run_id, card_id, _events) = active_daemon();
 
-    // Protocol 17 may emit the terminal turn's `done` followed by `idle`.
+    // Herdr may emit the terminal turn's `done` followed by `idle`.
     // Done is authoritative for board review; the trailing idle must not
     // arm a second grace period while this same run remains awaiting.
     handle_event(&d, status(AgentStatus::Done));
@@ -84,6 +84,6 @@ fn protocol17_idle_after_done_does_not_rearm_an_awaiting_run() {
             .unwrap()
             .idle_since
             .is_none(),
-        "a trailing protocol-17 idle event must not rearm idle expiry while awaiting",
+        "a trailing Herdr idle event must not rearm idle expiry while awaiting",
     );
 }

--- a/crates/board-daemon/src/watchers/tests/sockets.rs
+++ b/crates/board-daemon/src/watchers/tests/sockets.rs
@@ -593,8 +593,8 @@ fn socket_a_pane_exit_does_not_finalize_socket_b_duplicate_pane() {
     );
 }
 
-/// A Herdr socket that answers the protocol gate with `protocol`, recording
-/// every method it is asked for.
+/// A Herdr socket that answers the compatibility gate with `protocol`,
+/// recording every method it is asked for.
 fn fake_herdr_socket(protocol: u32) -> FakeHerdr {
     testkit::herdr_server()
         .protocol(protocol)
@@ -602,17 +602,21 @@ fn fake_herdr_socket(protocol: u32) -> FakeHerdr {
             testkit::reply(
                 req,
                 serde_json::json!({"snapshot": {
-                    "version": "0.7.5", "protocol": 17,
+                    "version": board_herdr::SUPPORTED_HERDR_VERSION,
+                    "protocol": board_herdr::SUPPORTED_HERDR_PROTOCOL,
                     "workspaces": [], "tabs": [], "panes": [], "agents": []
                 }}),
             )
+        })
+        .on("events.subscribe", |req| {
+            testkit::reply(req, serde_json::json!({"type": "subscription_started"}))
         })
         .serve()
 }
 
 #[test]
 fn watch_snapshot_rejects_a_socket_with_the_wrong_protocol() {
-    let herdr = fake_herdr_socket(16);
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1);
     let result = HerdrWatchConnector.snapshot(&herdr.socket);
     assert!(result.is_err(), "an incompatible socket must not snapshot");
     // A snapshot that answers is authoritative here — a watched pane missing
@@ -622,10 +626,29 @@ fn watch_snapshot_rejects_a_socket_with_the_wrong_protocol() {
 }
 
 #[test]
-fn watch_snapshot_accepts_the_pinned_protocol() {
-    let herdr = fake_herdr_socket(17);
+fn watch_snapshot_accepts_the_supported_protocol() {
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL);
     HerdrWatchConnector
         .snapshot(&herdr.socket)
-        .expect("protocol 17 must pass the gate");
+        .expect("the supported Herdr contract must pass the gate");
     assert_eq!(herdr.methods(), vec!["ping", "session.snapshot"]);
+}
+
+#[test]
+fn watch_subscription_rejects_an_incompatible_socket_before_subscribing() {
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL - 1);
+    let result = HerdrWatchConnector.subscribe(&herdr.socket, &[]);
+
+    assert!(result.is_err(), "an incompatible socket must not subscribe");
+    assert_eq!(herdr.methods(), vec!["ping"]);
+}
+
+#[test]
+fn watch_subscription_accepts_the_supported_socket_after_the_gate() {
+    let herdr = fake_herdr_socket(board_herdr::SUPPORTED_HERDR_PROTOCOL);
+    let _events = HerdrWatchConnector
+        .subscribe(&herdr.socket, &[])
+        .expect("the supported Herdr contract must pass before subscribing");
+
+    assert_eq!(herdr.methods(), vec!["ping", "events.subscribe"]);
 }

--- a/crates/board-herdr/src/client.rs
+++ b/crates/board-herdr/src/client.rs
@@ -228,24 +228,55 @@ impl HerdrClient {
     }
 
     /// Require the exact Herdr release and socket protocol supported by this
-    /// client. The explicit protocol argument keeps callers' expected contract
-    /// visible at the gate.
-    pub fn require_protocol(&mut self, expected: u32) -> Result<Pong> {
+    /// client. The supported contract is owned by [`crate::SUPPORTED_HERDR_VERSION`]
+    /// and [`crate::SUPPORTED_HERDR_PROTOCOL`], so callers cannot accidentally
+    /// ask this gate to validate a different contract.
+    pub fn require_supported_protocol(&mut self) -> Result<Pong> {
         let pong = self.ping()?;
-        if pong.version != "0.7.5" || pong.protocol != expected || expected != 17 {
+        if pong.version != crate::SUPPORTED_HERDR_VERSION
+            || pong.protocol != crate::SUPPORTED_HERDR_PROTOCOL
+        {
             return Err(HerdrError::Protocol {
                 code: "incompatible_protocol".to_string(),
                 message: format!(
-                    "Herdr 0.7.5 with protocol 17 is required (found Herdr {} with protocol {})",
-                    pong.version, pong.protocol
+                    "Herdr {} with protocol {} is required (found Herdr {} with protocol {})",
+                    crate::SUPPORTED_HERDR_VERSION,
+                    crate::SUPPORTED_HERDR_PROTOCOL,
+                    pong.version,
+                    pong.protocol
                 ),
             });
         }
         Ok(pong)
     }
 
-    /// True if a `ping` currently succeeds. The daemon uses this to set its
-    /// `herdr_connected` flag.
+    /// Compatibility adapter for callers of the pre-0.8.0 API.
+    ///
+    /// The argument is retained so existing clients continue to compile, but
+    /// it is not a version selector: this crate supports only its exact pinned
+    /// Herdr 0.8.0 / protocol-19 contract. New callers should use
+    /// [`Self::require_supported_protocol`].
+    #[deprecated(
+        note = "use require_supported_protocol; the argument is retained only for source compatibility"
+    )]
+    pub fn require_protocol(&mut self, expected: u32) -> Result<Pong> {
+        if expected != crate::SUPPORTED_HERDR_PROTOCOL {
+            return Err(HerdrError::Protocol {
+                code: "incompatible_protocol".to_string(),
+                message: format!(
+                    "Herdr {} with protocol {} is the only supported contract (requested protocol {})",
+                    crate::SUPPORTED_HERDR_VERSION,
+                    crate::SUPPORTED_HERDR_PROTOCOL,
+                    expected
+                ),
+            });
+        }
+        self.require_supported_protocol()
+    }
+
+    /// True if a raw `ping` currently succeeds, indicating reachability only.
+    /// This does not enforce the supported Herdr version or socket protocol
+    /// contract; use [`Self::require_supported_protocol`] for that check.
     pub fn is_live(&mut self) -> bool {
         self.ping().is_ok()
     }
@@ -350,7 +381,7 @@ impl HerdrClient {
     /// `pane_not_found` error envelope, which is a *negative answer* to a
     /// liveness question rather than a failure, so it is modelled as `None`
     /// here and every other error still propagates. Verified against
-    /// Herdr 0.7.5 / protocol 17: `tests/fixtures/schema.json` types
+    /// Herdr 0.8.0 / protocol 19: `tests/fixtures/schema.json` types
     /// `pane.get`'s params as `PaneTarget {pane_id}` with a
     /// `{"type":"pane_info","pane":PaneInfo}` success result, and a live socket
     /// answers an unknown pane id with

--- a/crates/board-herdr/src/events/mod.rs
+++ b/crates/board-herdr/src/events/mod.rs
@@ -4,7 +4,7 @@
 //! request/response connection). This module opens that socket, subscribes,
 //! and exposes a blocking [`Iterator`] of [`HerdrEvent`].
 //!
-//! ## Subscription quirk (verified live, protocol 17)
+//! ## Subscription quirk (verified live, protocol 19)
 //! A `pane.agent_status_changed` subscription **requires a concrete `pane_id`**
 //! — herdr validates the pane exists and rejects a wildcard/missing id with
 //! `internal_error`. So the daemon must build one subscription per pane it

--- a/crates/board-herdr/src/events/parse.rs
+++ b/crates/board-herdr/src/events/parse.rs
@@ -62,7 +62,7 @@ pub fn parse_event_line(line: &str) -> Option<HerdrEvent> {
     };
     // The kind lives in `data.type` (underscore names) on some herdr builds and
     // in the top-level `event` key (dotted names) on others (verified live on
-    // protocol 17: {"event":"pane.agent_status_changed","data":{...}} with
+    // protocol 19: {"event":"pane.agent_status_changed","data":{...}} with
     // no data.type). Accept both, normalized to underscores.
     let kind = data
         .get("type")

--- a/crates/board-herdr/src/lib.rs
+++ b/crates/board-herdr/src/lib.rs
@@ -13,7 +13,7 @@
 //!   [`HerdrEvent`]s via `events.subscribe`.
 //!
 //! Method and field names are verified against `herdr api schema --json`
-//! (protocol 17), captured in `tests/fixtures/schema.json`.
+//! (Herdr 0.8.0, protocol 19), captured in `tests/fixtures/schema.json`.
 
 mod client;
 mod envelope;
@@ -22,6 +22,11 @@ mod events;
 mod params;
 mod transport;
 mod types;
+
+/// The only Herdr release supported by this client.
+pub const SUPPORTED_HERDR_VERSION: &str = "0.8.0";
+/// The only Herdr socket protocol supported by this client.
+pub const SUPPORTED_HERDR_PROTOCOL: u32 = 19;
 
 pub use client::HerdrClient;
 pub use envelope::{ErrorBody, Request, Response};

--- a/crates/board-herdr/src/params.rs
+++ b/crates/board-herdr/src/params.rs
@@ -1,7 +1,7 @@
 //! Public parameter structs for herdr RPC calls.
 //!
 //! Every struct serializes to the exact field names and shape expected by the
-//! herdr socket protocol (protocol 17). Optional fields use
+//! herdr socket protocol (protocol 19). Optional fields use
 //! `#[serde(skip_serializing_if)]` so they are omitted when absent, matching
 //! the wire behaviour of the `herdr` CLI.
 
@@ -37,7 +37,7 @@ pub struct TabCreateParams {
     pub focus: bool,
 }
 
-/// Protocol-17 params for `agent.start`. Placement, cwd, and environment are
+/// Protocol-19 params for `agent.start`. Placement, cwd, and environment are
 /// established on the target pane before starting the managed agent.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct AgentStartParams {
@@ -78,7 +78,7 @@ pub struct AgentWaitParams {
     pub timeout_ms: Option<u64>,
 }
 
-/// Params for protocol-17 `pane.split`.
+/// Params for protocol-19 `pane.split`.
 #[derive(Debug, Clone, Serialize)]
 pub struct PaneSplitParams {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/board-herdr/src/types.rs
+++ b/crates/board-herdr/src/types.rs
@@ -1,6 +1,6 @@
 //! Typed views over herdr result payloads.
 //!
-//! Field names verified against `herdr api schema --json` (protocol 17,
+//! Field names verified against `herdr api schema --json` (Herdr 0.8.0, protocol 19,
 //! captured in `tests/fixtures/schema.json`). All structs use
 //! `#[serde(default)]` on optional fields and ignore unknown fields so the
 //! client keeps working across minor herdr additions.
@@ -198,7 +198,7 @@ pub struct TabCreated {
     pub root_pane: PaneInfo,
 }
 
-/// Result of protocol-17 `agent.start`. `argv` echoes the launched command line.
+/// Result of protocol-19 `agent.start`. `argv` echoes the launched command line.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentStarted {
     pub agent: AgentInfo,

--- a/crates/board-herdr/tests/events.rs
+++ b/crates/board-herdr/tests/events.rs
@@ -81,8 +81,17 @@ fn unknown_event_kind_becomes_other() {
 }
 
 #[test]
-fn tolerates_protocol_17_additive_status_fields() {
-    // Additive protocol-17 metadata must not be required by the client model.
+fn tolerates_protocol_19_workspace_reordered_event_as_other() {
+    let line = r#"{"event":"workspace_reordered","data":{"type":"workspace_reordered","before_workspace_id":null,"workspace_ids":["w1","w2"],"workspaces":[]}}"#;
+    match parse_event_line(line).unwrap() {
+        HerdrEvent::Other(v) => assert_eq!(v["event"], "workspace_reordered"),
+        other => panic!("expected new additive event to remain Other, got {other:?}"),
+    }
+}
+
+#[test]
+fn tolerates_protocol_19_additive_status_fields() {
+    // Additive protocol-19 metadata must not be required by the client model.
     let line = r#"{"event":"pane_agent_status_changed","data":{"type":"pane_agent_status_changed","pane_id":"p","workspace_id":"w","agent_status":"working","agent":"pi","display_agent":"Pi","title":"Build","state_labels":{"phase":"coding","priority":"high"},"future_field":true}}"#;
     match parse_event_line(line).expect("event") {
         HerdrEvent::AgentStatusChanged {
@@ -143,7 +152,7 @@ fn watch_subscriptions_builds_expected_set() {
 
 #[test]
 fn parses_dotted_event_key_without_data_type() {
-    // Protocol-17 also accepts the dotted event key with no `type` inside
+    // Protocol-19 also accepts the dotted event key with no `type` inside
     // `data`.
     let line = r#"{"data":{"agent":"claude","agent_status":"done","pane_id":"w1:pB","workspace_id":"w1"},"event":"pane.agent_status_changed"}"#;
     match parse_event_line(line).unwrap() {

--- a/crates/board-herdr/tests/fixtures/schema.json
+++ b/crates/board-herdr/tests/fixtures/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocol": 17,
+  "protocol": 19,
   "schema_version": 1,
   "schemas": {
     "error_response": {
@@ -200,6 +200,38 @@
                 "type",
                 "workspace_id",
                 "insert_index",
+                "workspaces"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "before_workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "workspace_reordered",
+                  "type": "string"
+                },
+                "workspace_ids": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "workspaces": {
+                  "items": {
+                    "$ref": "#/schemas/event/$defs/WorkspaceInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_ids",
                 "workspaces"
               ],
               "type": "object"
@@ -702,6 +734,7 @@
             "workspace_closed",
             "workspace_renamed",
             "workspace_moved",
+            "workspace_reordered",
             "workspace_focused",
             "worktree_created",
             "worktree_opened",
@@ -2085,7 +2118,9 @@
             "hermes",
             "qodercli",
             "cursor",
-            "mastracode"
+            "mastracode",
+            "antigravity_cli",
+            "grok"
           ],
           "type": "string"
         },
@@ -3664,6 +3699,18 @@
             {
               "properties": {
                 "type": {
+                  "const": "workspace.reordered",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
+                "type": {
                   "const": "workspace.closed",
                   "type": "string"
                 }
@@ -4078,6 +4125,26 @@
               ]
             }
           },
+          "type": "object"
+        },
+        "WorkspaceMoveBlockParams": {
+          "properties": {
+            "before_workspace_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "workspace_ids": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "workspace_ids"
+          ],
           "type": "object"
         },
         "WorkspaceMoveParams": {
@@ -4563,6 +4630,22 @@
             },
             "params": {
               "$ref": "#/schemas/request/$defs/WorkspaceMoveParams"
+            }
+          },
+          "required": [
+            "method",
+            "params"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "method": {
+              "const": "workspace.move_block",
+              "type": "string"
+            },
+            "params": {
+              "$ref": "#/schemas/request/$defs/WorkspaceMoveBlockParams"
             }
           },
           "required": [
@@ -6336,6 +6419,38 @@
             },
             {
               "properties": {
+                "before_workspace_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "const": "workspace_reordered",
+                  "type": "string"
+                },
+                "workspace_ids": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "workspaces": {
+                  "items": {
+                    "$ref": "#/schemas/success_response/$defs/WorkspaceInfo"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "type",
+                "workspace_ids",
+                "workspaces"
+              ],
+              "type": "object"
+            },
+            {
+              "properties": {
                 "type": {
                   "const": "workspace_focused",
                   "type": "string"
@@ -6847,6 +6962,7 @@
             "workspace_closed",
             "workspace_renamed",
             "workspace_moved",
+            "workspace_reordered",
             "workspace_focused",
             "worktree_created",
             "worktree_opened",
@@ -6997,7 +7113,9 @@
             "hermes",
             "qodercli",
             "cursor",
-            "mastracode"
+            "mastracode",
+            "antigravity_cli",
+            "grok"
           ],
           "type": "string"
         },

--- a/crates/board-herdr/tests/integration_live.rs
+++ b/crates/board-herdr/tests/integration_live.rs
@@ -1,11 +1,13 @@
 //! Read-only integration tests against a *live* herdr socket.
 //!
-//! `#[ignore]` by default. Run with a real herdr running:
+//! `#[ignore]` by default. Run with Herdr 0.8.0 / protocol 19 running:
 //!   cargo test -p board-herdr -- --ignored
-//! They also self-skip (pass trivially) if no socket is present, so the
-//! ignored run is safe on machines without herdr.
+//! They self-skip (pass trivially) if no compatible socket is present, so the
+//! ignored run is safe on machines without the supported Herdr.
 
-use board_herdr::{default_socket_path, HerdrClient, ReadSource};
+use board_herdr::{
+    default_socket_path, HerdrClient, ReadSource, SUPPORTED_HERDR_PROTOCOL, SUPPORTED_HERDR_VERSION,
+};
 
 fn client_or_skip() -> Option<HerdrClient> {
     let path = default_socket_path();
@@ -13,10 +15,19 @@ fn client_or_skip() -> Option<HerdrClient> {
         eprintln!("no herdr socket at {}; skipping", path.display());
         return None;
     }
-    match HerdrClient::connect(&path) {
-        Ok(c) => Some(c),
+    let mut client = match HerdrClient::connect(&path) {
+        Ok(c) => c,
         Err(e) => {
             eprintln!("could not connect to herdr: {e}; skipping");
+            return None;
+        }
+    };
+    match client.require_supported_protocol() {
+        Ok(_) => Some(client),
+        Err(e) => {
+            eprintln!(
+                "socket is not Herdr {SUPPORTED_HERDR_VERSION} / protocol {SUPPORTED_HERDR_PROTOCOL}: {e}; skipping"
+            );
             None
         }
     }

--- a/crates/board-herdr/tests/socket.rs
+++ b/crates/board-herdr/tests/socket.rs
@@ -17,7 +17,8 @@ use std::time::Duration;
 use board_herdr::{
     AgentPromptParams, AgentStartParams, AgentStatus, AgentWaitParams, HerdrClient, HerdrError,
     HerdrEvent, HerdrEvents, PaneRenameParams, PaneSplitParams, ReadSource, SocketDeadlines,
-    SplitDirection, Subscription, WorkspaceCreateParams,
+    SplitDirection, Subscription, WorkspaceCreateParams, SUPPORTED_HERDR_PROTOCOL,
+    SUPPORTED_HERDR_VERSION,
 };
 use serde_json::Value;
 
@@ -118,71 +119,89 @@ fn reply_for(req: &Value, result_json: &str) -> Action {
 }
 
 #[test]
-fn protocol_gate_accepts_only_protocol_17() {
+fn protocol_gate_accepts_exact_supported_contract() {
     let path = serve_calls(|req| {
         assert_eq!(req["method"], "ping");
         reply_for(
             req,
-            r#"{"type":"pong","version":"0.7.5","protocol":17,"capabilities":{}}"#,
+            r#"{"type":"pong","version":"0.8.0","protocol":19,"capabilities":{}}"#,
         )
     });
 
     let mut c = HerdrClient::connect(&path).unwrap();
     let pong = c
-        .require_protocol(17)
-        .expect("protocol 17 must be accepted");
-    assert_eq!(pong.protocol, 17);
+        .require_supported_protocol()
+        .expect("Herdr 0.8.0 with protocol 19 must be accepted");
+    assert_eq!(SUPPORTED_HERDR_VERSION, "0.8.0");
+    assert_eq!(SUPPORTED_HERDR_PROTOCOL, 19);
+    assert_eq!(pong.version, SUPPORTED_HERDR_VERSION);
+    assert_eq!(pong.protocol, SUPPORTED_HERDR_PROTOCOL);
 }
 
 #[test]
-fn protocol_gate_rejects_herdr_074_even_with_protocol_17() {
+#[allow(deprecated)]
+fn deprecated_protocol_adapter_accepts_only_the_supported_protocol() {
     let path = serve_calls(|req| {
+        assert_eq!(req["method"], "ping");
         reply_for(
             req,
-            r#"{"type":"pong","version":"0.7.4","protocol":17,"capabilities":{}}"#,
+            r#"{"type":"pong","version":"0.8.0","protocol":19,"capabilities":{}}"#,
         )
     });
 
-    let mut c = HerdrClient::connect(&path).unwrap();
-    let err = c
-        .require_protocol(17)
-        .expect_err("wrong Herdr version must be rejected");
-    let text = err.to_string();
-    assert!(
-        text.contains("Herdr 0.7.5 with protocol 17 is required"),
-        "{text}"
-    );
+    let mut client = HerdrClient::connect(&path).unwrap();
+    let pong = client
+        .require_protocol(SUPPORTED_HERDR_PROTOCOL)
+        .expect("the compatibility adapter must accept protocol 19");
+
+    assert_eq!(pong.version, SUPPORTED_HERDR_VERSION);
+    assert_eq!(pong.protocol, SUPPORTED_HERDR_PROTOCOL);
 }
 
 #[test]
-fn protocol_gate_rejects_v16_with_herdr_075_message() {
+#[allow(deprecated)]
+fn deprecated_protocol_adapter_rejects_a_different_requested_protocol() {
     let path = serve_calls(|req| {
-        reply_for(
-            req,
-            r#"{"type":"pong","version":"0.7.4","protocol":16,"capabilities":{}}"#,
-        )
+        panic!("a request must not be sent for an unsupported requested protocol: {req}");
     });
 
-    let mut c = HerdrClient::connect(&path).unwrap();
-    let err = c
-        .require_protocol(17)
-        .expect_err("protocol 16 must be rejected");
-    let text = err.to_string();
-    assert!(text.contains("protocol 17"), "{text}");
-    assert!(text.contains("0.7.5"), "{text}");
+    let mut client = HerdrClient::connect(&path).unwrap();
+    let error = client
+        .require_protocol(SUPPORTED_HERDR_PROTOCOL - 1)
+        .expect_err("the compatibility adapter must not select another protocol");
+
+    assert!(error.to_string().contains("protocol 18"), "{error}");
 }
 
 #[test]
-fn protocol_gate_rejects_unknown_future_protocol() {
-    let path = serve_calls(|req| {
-        reply_for(
-            req,
-            r#"{"type":"pong","version":"0.8.0","protocol":99,"capabilities":{}}"#,
-        )
-    });
+fn protocol_gate_rejects_mismatches_with_exact_diagnostics() {
+    for (version, protocol) in [("0.7.5", 19), ("0.8.0", 17), ("0.7.5", 17), ("0.9.0", 20)] {
+        let path = serve_calls(move |req| {
+            reply_for(
+                req,
+                &format!(
+                    r#"{{"type":"pong","version":"{version}","protocol":{protocol},"capabilities":{{}}}}"#
+                ),
+            )
+        });
 
-    let mut c = HerdrClient::connect(&path).unwrap();
-    assert!(c.require_protocol(17).is_err());
+        let mut c = HerdrClient::connect(&path).unwrap();
+        let err = c
+            .require_supported_protocol()
+            .expect_err("a mismatched Herdr contract must be rejected");
+        let expected_message = format!(
+            "Herdr {SUPPORTED_HERDR_VERSION} with protocol {SUPPORTED_HERDR_PROTOCOL} is required (found Herdr {version} with protocol {protocol})"
+        );
+        assert!(matches!(
+            &err,
+            HerdrError::Protocol { code, message }
+                if code == "incompatible_protocol" && message == expected_message.as_str()
+        ));
+        assert_eq!(
+            err.to_string(),
+            format!("herdr protocol error [incompatible_protocol]: {expected_message}")
+        );
+    }
 }
 
 #[test]
@@ -190,7 +209,7 @@ fn call_happy_path_ping_and_workspace_list() {
     let path = serve_calls(|req| match req["method"].as_str().unwrap() {
         "ping" => reply_for(
             req,
-            r#"{"type":"pong","version":"9.9.9","protocol":17,"capabilities":{}}"#,
+            r#"{"type":"pong","version":"9.9.9","protocol":19,"capabilities":{}}"#,
         ),
         "workspace.list" => reply_for(
             req,
@@ -214,7 +233,7 @@ fn is_live_true_on_pong() {
     let path = serve_calls(|req| {
         reply_for(
             req,
-            r#"{"type":"pong","version":"0.7.5","protocol":17,"capabilities":{}}"#,
+            r#"{"type":"pong","version":"0.8.0","protocol":19,"capabilities":{}}"#,
         )
     });
     let mut c = HerdrClient::connect(&path).unwrap();
@@ -247,7 +266,7 @@ fn typed_result_extraction_workspace_create() {
 
 #[test]
 fn tab_list_parses_live_payload() {
-    // Captured from the protocol-17 herdr socket (`tab.list`).
+    // Captured from the protocol-19 herdr socket (`tab.list`).
     let path = serve_calls(|req| {
         assert_eq!(req["method"], "tab.list");
         // `None` workspace is sent explicitly as null.
@@ -270,7 +289,7 @@ fn tab_list_parses_live_payload() {
 }
 
 #[test]
-fn agent_start_uses_protocol_17_startup_args() {
+fn agent_start_uses_protocol_19_startup_args() {
     let path = serve_calls(|req| {
         assert_eq!(req["method"], "agent.start");
         assert_eq!(
@@ -279,13 +298,13 @@ fn agent_start_uses_protocol_17_startup_args() {
                 "name": "card-42-execute",
                 "kind": "pi",
                 "pane_id": "w1:p2",
-                "args": ["--thinking", "low", "--session-id", "p17-session"],
+                "args": ["--thinking", "low", "--session-id", "p19-session"],
                 "timeout_ms": 15000,
             })
         );
         reply_for(
             req,
-            r#"{"type":"agent_started","agent":{"agent":"pi","agent_status":"idle","cwd":"/tmp/card","focused":false,"foreground_cwd":"/tmp/card","interactive_ready":true,"name":"card-42-execute","pane_id":"w1:p2","revision":1,"screen_detection_skipped":true,"state_change_seq":1,"tab_id":"w1:t1","terminal_id":"term-2","terminal_title":"π - workspace","terminal_title_stripped":"π - workspace","workspace_id":"w1"},"argv":["pi","--thinking","low","--session-id","p17-session"]}"#,
+            r#"{"type":"agent_started","agent":{"agent":"pi","agent_status":"idle","cwd":"/tmp/card","focused":false,"foreground_cwd":"/tmp/card","interactive_ready":true,"name":"card-42-execute","pane_id":"w1:p2","revision":1,"screen_detection_skipped":true,"state_change_seq":1,"tab_id":"w1:t1","terminal_id":"term-2","terminal_title":"π - workspace","terminal_title_stripped":"π - workspace","workspace_id":"w1"},"argv":["pi","--thinking","low","--session-id","p19-session"]}"#,
         )
     });
 
@@ -298,7 +317,7 @@ fn agent_start_uses_protocol_17_startup_args() {
             "--thinking".into(),
             "low".into(),
             "--session-id".into(),
-            "p17-session".into(),
+            "p19-session".into(),
         ],
         timeout_ms: Some(15000),
     })
@@ -407,7 +426,7 @@ fn pane_rename_serializes_typed_params_and_parses_pane_info() {
 
 #[test]
 fn pane_get_decodes_pane_info_and_maps_a_dead_pane_to_none() {
-    // Envelope captured from Herdr 0.7.5 / protocol 17 (`pane.get`): params are
+    // Envelope captured from Herdr 0.8.0 / protocol 19 (`pane.get`): params are
     // `PaneTarget {pane_id}`, success is `{"type":"pane_info","pane":…}`.
     let path = serve_calls(|req| {
         assert_eq!(req["method"], "pane.get");
@@ -467,7 +486,7 @@ fn pane_focus_returns_pane_info() {
 
 #[test]
 fn pane_layout_parses_live_payload() {
-    // Captured verbatim from the protocol-17 herdr socket (`pane.layout`, focused tab).
+    // Captured verbatim from the protocol-19 herdr socket (`pane.layout`, focused tab).
     let path = serve_calls(|req| {
         assert_eq!(req["method"], "pane.layout");
         reply_for(

--- a/crates/board-herdr/tests/subscription_ack.rs
+++ b/crates/board-herdr/tests/subscription_ack.rs
@@ -53,7 +53,7 @@ fn request_id(reader: &mut BufReader<UnixStream>) -> String {
 }
 
 #[test]
-fn matching_subscription_ack_requires_protocol_17_typed_result() {
+fn matching_subscription_ack_requires_protocol_19_typed_result() {
     const INITIAL_SECRET: &str = "INITIAL_ACK_PAYLOAD_SECRET_53d1";
     const ADD_SECRET: &str = "ADD_ACK_PAYLOAD_SECRET_9ca2";
 
@@ -66,9 +66,9 @@ fn matching_subscription_ack_requires_protocol_17_typed_result() {
         .finish();
     let _guard = tracing::subscriber::set_default(subscriber);
 
-    // A matching id is not sufficient: protocol 17 requires the typed
+    // A matching id is not sufficient: protocol 19 requires the typed
     // {"type":"subscription_started"} result verified from
-    // `herdr api schema --json` (Herdr 0.7.5, protocol 17).
+    // `herdr api schema --json` (Herdr 0.8.0, protocol 19).
     let (_initial_dir, initial_path, initial_listener) = socket();
     let initial_peer = thread::spawn(move || {
         let (stream, _) = initial_listener.accept().unwrap();

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ The reference detail behind the [root README](../README.md). Start here to find 
 | Board socket | v1; `board-core::protocol` (additive `active_runs`, error `kind`/`details`) | [protocol.md](protocol.md) |
 | SQLite | schema v13; `schema.sql` + `board-core::db` migrations | [design.md](design.md) |
 | CLI | canonical nested `board board/card/comment/run/column` taxonomy; `board-cli` wiring | [README CLI reference](../README.md#cli-reference), [skill](../skill/SKILL.md) |
-| Herdr client | 0.7.5 / socket protocol 17; `board-herdr` typed calls | [herdr.md](herdr.md) |
+| Herdr client | 0.8.0 / socket protocol 19; `board-herdr` typed calls | [herdr.md](herdr.md) |
+| Herdr integrations | Pi v8; Claude v7 (installed and updated by the user) | [herdr.md](herdr.md), [install.md](install.md) |
 | Runtime launch | daemon-owned `Spawner`, placement, process/pane handles | [implementation.md](implementation.md) |
 | Config | typed `RootConfig`, one parse, environment overrides after parse | [configuration.md](configuration.md), [design.md](design.md) |
 | Live catalog | scenarios 01–29; provider-free fake/safe harness boundary | [e2e/README.md](../e2e/README.md) |
@@ -28,12 +29,12 @@ isolation is an agent prompt concern, not a board space primitive.
 | [implementation.md](implementation.md) | The cargo workspace crate layout, crate ownership, shared dependencies, key traits (`BoardClient`, `Spawner`), and the build phases with their tests. | are navigating the codebase or picking up a build task. |
 | [research.md](research.md) | The verified herdr capability map (commands/events/IDs), prior-art survey of agent-kanban tools, and verified harness invocation flags (Pi/Claude/codex/gemini/opencode). | are scoping a feature that touches herdr or a new harness, and want the background that grounded the design. |
 | [releasing.md](releasing.md) | The release contract: Prepare Release, version bumps, CI-gated tagging/publishing, artifacts, reruns, and tag policy. | are cutting a release or need the repo's release policy. |
-| [herdr.md](herdr.md) | How to learn and verify **Herdr** facts (there is no man page): the live sources of truth (`herdr api schema --json`, `herdr <cmd> --help`, `herdr api snapshot`), per-harness agent integrations, and the exact compatibility gate (Herdr 0.7.5 / protocol 17 only; no protocol-16 path). | hit a Herdr command/shape that misbehaves, or need to confirm what the installed Herdr actually does. |
-| [testing.md](testing.md) | The testing pyramid in this repo (unit/pure → daemon+CLI integration → TUI snapshots → live E2E), how the provider-free fake Pi/Claude suite works (including protocol-17 scenarios 16/17), and how to write a scenario. The use case ↔ scenario catalog lives in [`../e2e/README.md`](../e2e/README.md). | are adding a feature and need to test it, or are writing/running the live E2E suite. |
+| [herdr.md](herdr.md) | How to learn and verify **Herdr** facts (there is no man page): the live sources of truth (`herdr api schema --json`, `herdr <cmd> --help`, `herdr api snapshot`), the Herdr 0.8.0/protocol-19 delta, per-harness integrations, and the exact compatibility gate. | hit a Herdr command/shape that misbehaves, or need to confirm what the installed Herdr actually does. |
+| [testing.md](testing.md) | The testing pyramid in this repo (unit/pure → daemon+CLI integration → TUI snapshots → live E2E), how the provider-free fake Pi/Claude suite works (including the current pane-first scenarios 16/17, whose filenames are historical), and how to write a scenario. The use case ↔ scenario catalog lives in [`../e2e/README.md`](../e2e/README.md). | are adding a feature and need to test it, or are writing/running the live E2E suite. |
 
 The [`schema.sql`](../schema.sql) at the repo root is the fresh SQLite schema; migration behavior
 and upgrade tests live in `board-core::db`. Before handoff, check that docs still point to existing
-files, that the version matrix above says schema v13 / protocol v1 / Herdr 0.7.5-protocol 17, and that
+files, that the version matrix above says board protocol v1 / schema v13 / Herdr 0.8.0 / socket protocol 19, and that
 the scenario catalog lists every `e2e/NN-*.sh` from 01 through 29.
 
 ## Test gates (single source)
@@ -58,7 +59,7 @@ bash e2e/ci.sh
 
 CI runs the fast commands as independent `fmt`, `clippy`, `docs`, `scripts`, `e2e-safety`, and
 `test` jobs split by what each protects. The dependent `live-e2e` job starts only after all six
-succeed, installs SHA-verified Herdr 0.7.5, and runs the wrapper above. This keeps cheap failures
+succeed, installs the SHA-verified Herdr 0.8.0 binary, and runs the wrapper above. This keeps cheap failures
 fast while making the complete live suite part of the same required `CI` workflow. `test_docs.py`
 asserts that every `scripts/tests/test_*.py` is matched by a pattern above, so a new module cannot
 land in no job at all.
@@ -74,6 +75,6 @@ provider, which is why it belongs in CI. It overlaps `test_e2e_safety.py` by des
 implementations of the same checks, which is why they share the `e2e-safety` job.
 
 `e2e/ci.sh` is the CI and local-equivalent live gate. It caches only the exact SHA-verified Herdr
-0.7.5 Linux x86_64 binary, verifies protocol 17, runs `e2e/run-all.sh --require-all`, and exports
+0.8.0 Linux x86_64 binary, verifies socket protocol 19, runs `e2e/run-all.sh --require-all`, and exports
 sanitized runner/scenario evidence to `e2e-artifacts/` for the workflow's always-run 30-day upload.
 The standard suite remains provider-free and uses only suite-owned ephemeral resources.

--- a/docs/design.md
+++ b/docs/design.md
@@ -76,14 +76,37 @@ about whether the document is valid.
 ### Herdr compatibility and launch boundary
 
 The public boardd socket protocol remains **v1**. That is independent of the upstream Herdr socket
-contract: this version supports **exactly Herdr 0.7.5 / protocol 17** and has no protocol-16 launch
-path. On the card's selected session socket, dispatch first calls `ping` and requires both exact
-values. This happens before workspace discovery or `workspace.create`; the spawner repeats the gate
-as its first call before `tab.create`, `pane.split`, `agent.start`, or the configured-harness runner.
-A mismatch fails the queued run without mutating the workspace.
+contract: this version supports **exactly Herdr 0.8.0 / protocol 19**. The daemon opens a fresh
+Herdr request connection per operation, so compatibility is checked at each boundary rather than
+only once at startup:
 
-Protocol 17 is pane-first. New durable runs place each card in a stable short `card-<id>` tab. The
-root created by `tab.create` is reserved as a labeled shell anchor (`card-<id>-anchor`); it is never
+- **Status:** `daemon.status` re-pings its configured Herdr socket and reports `herdr_connected`
+  only when both exact values match.
+- **Event subscription:** the per-session supervisor gates a request connection before opening the
+  persistent `events.subscribe` stream. The typed subscription acknowledgement must complete before
+  the supervisor takes its first snapshot; an incompatible socket receives neither subscription
+  nor snapshot work.
+- **Notifications:** the detached `notification.show` effect performs the same compatibility probe
+  immediately before sending the cosmetic notification, so an incompatible Herdr is not mutated.
+- **Dispatch and discovery:** card space resolution pings before `workspace.list` or
+  `workspace.create`; `space.list` and the read-only space preflight use the same gate. The spawner
+  repeats it as the first call before `tab.create`, `pane.split`, a managed-agent launch, or the
+  configured-harness runner. The session registry's `herdr session list --json` enumeration is a
+  separate CLI discovery step; every selected socket is still gated before socket discovery or use.
+- **Pane operations:** caller-targeted focus/title operations, durable placement, rescue discovery,
+  and managed/configured launch all use a checked connection before `pane.get`, `pane.focus`,
+  `pane.rename`, `pane.split`, `agent.start`, `agent.prompt`, or the configured runner.
+
+The deliberate exception is cleanup and liveness for an already-owned pane handle: the spawner's
+`kill`/`pane.close` and `is_alive`/snapshot paths retain an ungated connection so the daemon can
+close or observe its own pane after Herdr becomes incompatible. That exception does not authorize
+new discovery, placement, focus, notification, or launch; supervisor reconciliation and the
+caller-visible focus/rescue paths remain checked. A mismatch on a checked dispatch path fails the
+queued run without mutating the workspace.
+
+The managed launch contract is pane-first. New durable runs place each card in a stable short
+`card-<id>` tab. The root created by `tab.create` is reserved as a labeled shell anchor
+(`card-<id>-anchor`); it is never
 an agent target. Every run, including the first, splits a child from that anchor with the run's `cwd`
 and `env`, and only that child receives `agent.start` or the configured `pane run` bridge. The anchor
 keeps a predictable strip: the prototype targets a 0.40 ratio for the initial split (clamped on
@@ -209,8 +232,8 @@ Cards target a **herdr session** plus a space in it. Because two sessions can ea
 
 ### new_workspace flow
 
-On first dispatch of a `new_workspace` card: preflight the selected socket for exact Herdr
-0.7.5/protocol 17, then list the session's workspaces; if one's label matches `space_ref`
+On first dispatch of a `new_workspace` card: preflight the selected socket for exact Herdr 0.8.0 /
+protocol 19, then list the session's workspaces; if one's label matches `space_ref`
 (case-insensitive) reuse it, else `workspace.create {label:space_ref, cwd:space_cwd, focus:false}`.
 Then proceed identically to a `workspace` card (cwd snapshot, pane-first per-card tab placement). If the reused or existing workspace snapshot fails, or contains no live cwd, dispatch fails; it never falls back to process cwd or a stale snapshot.
 
@@ -365,7 +388,7 @@ that never recorded a pane at all. End to end:
    pane, so quitting would only discard the explanation). Refusals and Herdr errors stay visible as a
    non-fatal toast that leaves the board usable, and never fall back to a different run's pane.
 
-**Credentials: a rescued pane is not the run.** Protocol-17 placement is pane-first, so the pane's
+**Credentials: a rescued pane is not the run.** Pane-first placement means the pane's
 environment comes from the `pane.split` that creates it; the daemon installs the persisted run env
 plus `BOARD_CARD_ID`, `BOARD_SOCKET`, `BOARD_BIN`, `BOARD_RESCUE=1`, `BOARD_RESUME_SESSION_ID` and
 `BOARD_RESCUED_RUN_ID`. `BOARD_RUN_ID` is **withheld on purpose**. It is not documentation but the
@@ -497,7 +520,7 @@ Claude: claude [--model M] [--effort E] [--permission-mode P]
 ```
 
 After pane-first placement, boardd writes `system_prompt` to a temporary mode-`0600` file and calls
-Herdr protocol 17 as follows:
+the supported managed-agent interface as follows:
 
 ```
 agent.start {
@@ -548,8 +571,8 @@ opens the script, the residual configured-script orphan is an accepted asynchron
 2. **User drags card → Plan** (TUI → boardd `card.move`).
 3. Column engine: *Plan* is `trigger=auto` → **enqueue run** on the card's space queue.
 4. Dispatcher (respecting per-space serial queue + global cap):
-   a. Resolve the card's session socket and `ping` it. Anything except exact Herdr 0.7.5/protocol 17 fails before workspace discovery/creation. Then reuse workspace `w4`, or create/reuse the card's labeled `new_workspace`; repository worktree isolation remains an agent prompt responsibility.
-   b. Preflight the selected socket again at the spawner boundary. For a new durable run, the card's **`card-<id>` tab** is resolved by exact owned id (reconstructed from the newest matching durable pane in the same session/workspace when boardd restarts), or `tab.create {workspace_id,cwd,env,…}` supplies a new shell anchor. The anchor is labeled `card-<id>-anchor`, its exact id is persisted on the promoted run, and the run child is always created by `pane.split` from that anchor; `agent.start`/`pane run` never target the root. A renamed anchor is still selected only by exact identity; a closed anchor is recreated only from a durable board-run child in the exact proven tab, and missing proof creates a fresh tab without selecting a duplicate-label user tab. Exact ended children may be reclaimed before a later split so the anchor keeps usable geometry. The child receives the run env; the anchor receives only stable card identity. If multiple historical panes are live, newest run id wins; legacy rows retain their old lookup. There is no protocol-16 placement inside `agent.start`.
+   a. Resolve the card's session socket and `ping` it. Anything except exact Herdr 0.8.0 / protocol 19 fails before workspace discovery/creation. Then reuse workspace `w4`, or create/reuse the card's labeled `new_workspace`; repository worktree isolation remains an agent prompt responsibility.
+   b. Preflight the selected socket again at the spawner boundary. For a new durable run, the card's **`card-<id>` tab** is resolved by exact owned id (reconstructed from the newest matching durable pane in the same session/workspace when boardd restarts), or `tab.create {workspace_id,cwd,env,…}` supplies a new shell anchor. The anchor is labeled `card-<id>-anchor`, its exact id is persisted on the promoted run, and the run child is always created by `pane.split` from that anchor; `agent.start`/`pane run` never target the root. A renamed anchor is still selected only by exact identity; a closed anchor is recreated only from a durable board-run child in the exact proven tab, and missing proof creates a fresh tab without selecting a duplicate-label user tab. Exact ended children may be reclaimed before a later split so the anchor keeps usable geometry. The child receives the run env; the anchor receives only stable card identity. If multiple historical panes are live, newest run id wins; legacy rows retain their old lookup. Placement, cwd, and environment are not `agent.start` fields; the call receives neither the workspace placement nor the anchor pane id.
    c. For Pi/Claude, write the snapshotted system prompt to a mode-`0600` temporary file; issue `agent.start {name,kind,pane_id,args}` on the split child with prompt-free startup args; a typed `agent_pane_busy` retries the exact request on that same child with bounded 100ms/200ms backoff (never another split); poll `agent.get` for readiness; then send only the task snapshot through `agent.prompt`. Remove the file. Card status → `running`; record the exact child pane/workspace ids. The pane is **visible** — you can watch or type into it anytime.
 
    **Pane naming and ownership**: the managed agent name is `card-<id>-<column-slug>` (e.g. `card-42-plan`, `card-42-execute`). Herdr names are exclusive while a pane is open, so `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`. A persistent `agent_pane_busy` closes only the board-owned child and leaves the pre-existing anchor. If a placement target disappears, boardd closes only the pane it created (a missing pane is already clean), restarts discovery from `tab.list`, and retries the complete placement once. A terminal launch error also closes only that board-owned pane; pre-existing user panes are never cleanup targets.
@@ -695,13 +718,13 @@ boundaries are responsibility-oriented: daemon operations/watchers/dispatch/spaw
 app/forms/view, core engine/client, and Herdr events each own their corresponding implementation
 and private tests. This is guidance for ownership, not an exhaustive file list.
 
-herdr panes are fully drivable from the CLI (`pane send-keys` with named keys, `pane send-text`, `pane read`, `workspace create/close`), so the board can be tested end-to-end inside a real herdr — in a disposable test workspace or an isolated named session.
+herdr panes are fully drivable from the CLI (`pane send-keys` with named keys, `pane send-text`, `pane read`, `workspace create/close`), so the board can be tested end-to-end in a collision-resistant ephemeral named Herdr session plus a disposable workspace created for that test. Every interactive/live test must use both and never a user's live session, workspace, or tab.
 
 | Level | What | How |
 |---|---|---|
 | 1. Unit | column engine, prompt assembly, queue, transitions | plain Rust tests, in-memory SQLite; no herdr |
 | 2. TUI snapshot | every view/modal/keybind incl. `?` help | ratatui `TestBackend` + fed `KeyEvent`s + `insta` snapshots; no herdr, no terminal |
 | 3. Daemon integration | dispatch → run → done → auto-move, without tokens | config fake harness plus built-in Pi adapter tests; real boardd paths, no provider call |
-| 4. Full E2E | real Herdr wiring | disposable named session/workspace; the standard suite uses checked-in fake Pi/Claude/configured harnesses and asserts protocol-17 placement/prompt/argv contracts with zero provider cost. A separate opt-in real-Claude Haiku/low smoke is never in `run-all.sh`; its intended contract is one authorized attempt with no retry or fallback. |
+| 4. Full E2E | real Herdr wiring | collision-resistant ephemeral named Herdr session plus disposable workspace; the standard suite uses checked-in fake Pi/Claude/configured harnesses and asserts pane-first placement/prompt/argv contracts against the current Herdr 0.8.0 / protocol 19 gate with zero provider cost. A separate opt-in real-Claude Haiku/low smoke is never in `run-all.sh`; its intended contract is one authorized attempt with no retry or fallback. |
 
-Isolation rules for level 3–4: `BOARD_DB=/tmp/…` + dedicated daemon socket per test run so tests never touch the real board; prefer a separate `herdr --session board-test` (or headless `herdr server`) in CI so the user's session is untouched; inside an interactive dev loop, a throwaway workspace in the live session is fine.
+Isolation rules for level 3–4: `BOARD_DB=/tmp/…` + dedicated daemon socket per test run so tests never touch the real board; every interactive/live test must create and use a collision-resistant ephemeral named Herdr session plus a disposable workspace, never a user's session, workspace, or tab. The session may run headlessly in CI, but it must retain the same named-session and workspace requirements.

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -25,6 +25,29 @@ Rule of thumb (mirrors [AGENTS.md](../AGENTS.md)): **never assume a herdr
 command, flag, or JSON shape from memory — verify against `api schema` /
 `--help`, and pin the argv you verified in a test comment.**
 
+## Compatibility gate: Herdr 0.8.0 / socket protocol 19
+
+The supported matrix is exact: **Herdr 0.8.0**, **socket protocol 19**, board protocol
+v1, and SQLite schema v13. `board-herdr` rejects a different Herdr version or
+protocol before the daemon performs workspace discovery, pane placement, an agent
+launch, a configured runner action, or a notification mutation. This is a policy
+gate, not a protocol-negotiation fallback.
+
+Use these read-only probes before changing a wire call or debugging a live session:
+
+```bash
+test "$(herdr --version)" = "herdr 0.8.0"
+herdr api schema --json | python3 -c \
+  'import json, sys; s=json.load(sys.stdin); assert s["protocol"] == 19, s'
+herdr api snapshot
+herdr integration status
+```
+
+`herdr api schema --output PATH` saves the same authoritative schema. Use the
+specific command help before pinning an argv: `herdr agent start --help`,
+`herdr agent prompt --help`, `herdr pane report-agent --help`, and
+`herdr integration install --help` are especially relevant to board integration.
+
 ## herdr ships its own agent integrations
 
 herdr can install its **own** per-harness integration hooks so a harness reports
@@ -34,17 +57,34 @@ live agent status (idle / working / blocked / done) back to herdr. Manage them w
 - `herdr integration install <name>` / `herdr integration uninstall <name>`
 - `herdr integration status [--outdated-only]`
 
-As of herdr 0.7.5 the installable integrations are: **pi, omp, claude, codex,
+Herdr 0.8.0's installable integration targets are: **pi, omp, claude, codex,
 copilot, devin, droid, kimi, opencode, kilo, hermes, qodercli, cursor,
-mastracode** (get the current list from `herdr integration install --help`). On the
-2026-07-22 verification host, `herdr integration status` reported Pi **v6** and
-Claude **v7** as current.
+mastracode, antigravity-cli, grok**. Get the authoritative spelling and current
+list from `herdr integration install --help`; the socket schema uses
+`antigravity_cli` for the hyphenated CLI target. On the host inspected for this
+update, `herdr integration status` reports Pi **current (v8)** and Claude
+**current (v7)**.
+
+Herdr 0.8.0 also provides `herdr --skill`, which prints Herdr's own agent-driving
+skill. It is distinct from this repository's `board skill` / `skill/SKILL.md`.
 
 Installing one **writes into that harness's own config** (`pi` installs
 `~/.pi/agent/extensions/herdr-agent-state.ts`; `claude` installs a hook under
 `~/.claude`). Because it mutates personal configuration, **herdr-board never installs or
 updates integrations** — running `herdr integration install <harness>` is a **user
-prerequisite** for live lifecycle signals.
+prerequisite** for live lifecycle signals. Check the reported version with
+`herdr integration status`; the board's current support matrix expects Pi v8 and
+Claude v7 when those harnesses are dispatched.
+
+### 0.8.0 lifecycle implications
+
+Herdr 0.8.0 tightened lifecycle ownership around confirmed process exit. A known
+agent can restart with the same saved session and retain lifecycle state; nested
+or ephemeral Codex sessions do not replace the owning pane's resumable session;
+and Pi RPC/JSON/print processes do not claim lifecycle authority intended for a
+Pi TUI session. These rules reduce false ownership changes, but Herdr status is
+still a signal rather than board completion: `pane.exited` and explicit
+`board done` remain the reliable run boundaries.
 
 What the integration buys you:
 
@@ -65,18 +105,46 @@ To verify what a running herdr actually reports, inspect the live state:
 Pi users who need precise live working/blocked/done status and session references must run
 `herdr integration install pi`; the matching integration is a prerequisite for whichever harness
 is being dispatched. Without it, the board continues in the degraded mode described above. The
-standard E2E uses checked-in fake Pi and Claude executables and tests watcher status mapping
-deterministically rather than changing integrations or calling a provider.
+standard E2E uses checked-in fake Pi and Claude executables and is designed
+to exercise watcher status mapping deterministically rather than changing integrations or calling a provider.
 
-## Protocol 17 launch contract
+## Protocol 19 delta: additive upstream surface
 
-Herdr 0.7.5 uses pane-first managed-agent launch. For a new durable card tab,
-herdr-board first creates a shell root and reserves it as `card-<id>-anchor`.
-It then splits a run child with the required cwd/environment and calls
-`agent.start` with `{name, kind, pane_id, args, timeout_ms}` on that child only.
-The anchor is never an `agent.start` target. `kind` selects Herdr's canonical
-agent executable and `args` contains only that executable's arguments. The old
-workspace/tab/split/env placement fields are not part of `agent.start`.
+The Herdr 0.8.0/protocol-19 schema keeps the RPC shapes herdr-board uses unchanged.
+The board's typed calls still use the same request/result envelopes for `ping`,
+`session.snapshot`, workspace list/create/close, tab create/list, pane
+split/list/get/focus/rename/read/send-text/send-keys/close/layout, agent
+start/get/prompt/wait, `notification.show`, and `events.subscribe`.
+
+The delta is additive and outside the board client surface:
+
+- `workspace.move_block` accepts `workspace_ids` plus an optional
+  `before_workspace_id` for atomic block movement, including worktree groups.
+- `workspace.reordered` is a new emitted event and subscription selector. Its
+  data includes `workspace_ids`, `workspaces`, and an optional
+  `before_workspace_id`.
+- `antigravity_cli` (CLI spelling `antigravity-cli`) and `grok` are new
+  integration targets with session reporting/native restore. They do not add
+  board built-in harnesses.
+
+The client does not call the new workspace method. It preserves unknown additive
+events rather than treating them as a change to the used transport. The current
+schema has 90 request methods, 26 emitted event kinds, and 27 subscription
+selectors; re-check those facts with `herdr api schema --json` rather than
+copying them from this page.
+
+## Pane-first managed launch contract
+
+The stable transport rule is pane-first and intentionally independent of a
+protocol number: create or split the target pane with its cwd/environment first,
+then start the agent in that existing pane. Under the exact Herdr 0.8.0 / socket
+protocol 19 gate, herdr-board first creates a shell root for a new durable card
+tab and reserves it as `card-<id>-anchor`. It then splits a run child with the required
+cwd/environment and calls `agent.start` with `{name, kind, pane_id, args,
+timeout_ms}` on that child only. The anchor is never an `agent.start` target.
+`kind` selects Herdr's canonical agent executable and `args` contains only that
+executable's arguments. Workspace/tab/split/env placement fields are not part of
+`agent.start`.
 
 After start, `agent.get <target>` exposes `interactive_ready` and
 `launch_pending`. herdr-board waits for `interactive_ready=true` and
@@ -95,12 +163,13 @@ Labels are display metadata and never authorize a tab or pane.
 `agent.read` remains a terminal screen/scrollback read, not a semantic result
 channel.
 
-Two protocol-17 facts the rescue depends on, both observed on a live 0.7.5 socket
-via `e2e/27-rescue-dead-pane.sh` rather than assumed: a pane label set with
-`pane.rename` survives a subsequent `agent.start`; and when a managed agent's
-process exits, Herdr **clears** `PaneInfo.agent` while keeping the pane open as a
-plain shell (label included). The second is why "does this pane still have a
-registered agent" is a sound liveness test and a label match alone is not.
+The rescue depends on two runtime facts that are not guaranteed by the request
+shapes: a pane label set with `pane.rename` must survive a subsequent
+`agent.start`; and when a managed agent's process exits, Herdr must **clear**
+`PaneInfo.agent` while keeping the pane open as a plain shell (label included).
+The second is why "does this pane still have a registered agent" is a sound
+liveness test and a label match alone is not. The current validation target is
+Herdr 0.8.0/protocol 19; do not infer either behavior from the schema alone.
 `PaneInfo.agent` is also not the exclusive name passed to `agent.start` — the
 schema carries `agent` and `name` separately — so it is only ever tested for
 presence, never compared to a board-chosen name.
@@ -108,25 +177,56 @@ presence, never compared to a board-chosen name.
 Reopening a run whose pane was closed (`run.focus` rescue) reuses this exact
 contract, not a second one: `board-daemon::spawner::rescue` calls the same
 `allocate_owned_pane` placement (with an empty reclaim list, so reopening one run
-never closes another's pane), the same `require_protocol` gate, and the same
-`agent.start` + `interactive_ready` wait. Three things differ, all
+never closes another's pane), the same `require_supported_protocol` gate, and
+the same `agent.start` + `interactive_ready` wait. Three things differ, all
 deliberate: `agent.prompt` is **not** sent (the conversation already contains the
 task, and re-sending it would re-run the work); the new pane is renamed to
 `card-<id>-r<run>-rescue` before launch so a later reopen can find it again with
 one `pane.list` scan (a name built from stable ids only, never from a column
-name that a user can change — and `agent.start` is verified to leave that label
-intact, so it is set once); and the pane env omits `BOARD_RUN_ID`, since a
-rescued pane must not hold the credential that writes to a finished run. Nothing is persisted for that pane — Herdr's
-own pane label/agent name is the only record of it, which is why the dedup scan
+name that a user can change — the launch contract relies on `agent.start` leaving
+that label intact, so it is set once); and the pane env omits `BOARD_RUN_ID`, since a
+rescued pane must not hold the credential that writes to a finished run. Nothing is persisted for that pane —
+Herdr's own pane label/agent name is the only record of it, which is why the dedup scan
 is a hint rather than proof (see `docs/design.md` → Limitations). The dead
 `pane_id` is never reused or revived.
 
-Configured harnesses are intentionally unmanaged. Protocol 17 has a
-`herdr pane run <PANE_ID> <COMMAND>...` CLI command but no `pane.run` socket
-method, so the daemon invokes that CLI against the selected session socket via
-a temporary runner script. Agents must still use `board comment` and `board
-done`; the configured runner reports a silent child exit back to boardd as a
-failed run with no automatic column transition.
+Configured harnesses are intentionally unmanaged. The current Herdr CLI has a
+`herdr pane run <PANE_ID> <COMMAND>...` command but the socket schema has no
+`pane.run` method, so the daemon invokes that CLI against the selected session
+socket via a temporary runner script. Agents must still use `board comment` and
+`board done`; the configured runner reports a silent child exit back to boardd
+as a failed run with no automatic column transition.
+
+## 0.8.0 runtime behaviors behind live validation
+
+The release notes describe behavior that a schema diff cannot prove. Keep these
+checks separate from the exact compatibility gate and do not treat a local
+read-only probe as an end-to-end test result:
+
+- **Prompt settling:** Herdr waits briefly after sending prompt text before it
+  presses Enter. The board therefore checks readiness first and uses
+  `agent.prompt` for the exact task, rather than sending text and a synthetic
+  key sequence. A managed fixture must observe the multiline task after
+  readiness before it can finish.
+- **Headless resume:** a headless server can resume a restored agent session
+  without a TUI client attaching. `run.focus` rescue and restart recovery must
+  work from the socket/session boundary, not depend on a desktop client being
+  present.
+- **Plugin-root resolution:** relative commands in a plugin manifest resolve
+  from that plugin's root. Install/open validation should therefore use a
+  disposable session and a caller-independent cwd; it should exercise the
+  manifest's relative build/action paths, not only invoke a script from the
+  checkout root.
+- **Read truncation and history:** `pane.read` and `agent.read` report a
+  `truncated` flag when older terminal rows are omitted. Herdr may automatically
+  collect text history for idle alternate-screen agents and restore the
+  application viewport. Board code treats reads as bounded screen/scrollback
+  diagnostics, never as a semantic result or completion channel.
+
+These behaviors motivate the live validation cases around lifecycle signals,
+managed prompt delivery, rescue/resume, plugin opening, and pane reads. The
+provider-free scenarios use disposable sessions and fake harnesses; this page
+makes no claim that a live suite has been run for the current checkout.
 
 ## Socket request and subscription bounds
 
@@ -152,13 +252,19 @@ diagnostics.
 `board-herdr` deliberately exposes only the typed Herdr methods used by the daemon and tests:
 workspace, tab, pane, agent, notification, session, and events. The upstream worktree methods and
 DTOs are not part of this crate's public surface; repository isolation belongs in the agent prompt.
-The checked-in schema fixture remains an upstream reference and is not rewritten during API cleanup.
+The checked-in schema fixture is regenerated from the installed Herdr contract and
+is not rewritten during unrelated API cleanup. The board fixture and typed client
+are currently pinned to **Herdr 0.8.0 / protocol 19**; board protocol v1 and DB
+schema v13 remain independent and unchanged.
 
-This repo's herdr facts — [`docs/research.md`](research.md), [`docs/design.md`](design.md),
-and the wire shapes hard-coded in `board-herdr` — were **verified against
-Herdr 0.7.5 / protocol 17 on 2026-07-22**.
+This repo's current Herdr facts — [`docs/research.md`](research.md),
+[`docs/design.md`](design.md), and the wire shapes hard-coded in `board-herdr` —
+must be rechecked with the installed binary before a support change. The local
+0.8.0 inspection for this update used `herdr api schema --json`, the relevant
+`--help` commands, `herdr api snapshot`, and `herdr integration status`; it did
+not substitute an end-to-end test run.
 
-herdr updates independently of this repo (`herdr update`, stable/preview channels).
+Herdr updates independently of this repo (`herdr update`, stable/preview channels).
 When something that used to work misbehaves on a newer herdr — an unknown method, a
 changed field name, a new error code — **re-verify against `herdr api schema
 --json` FIRST**, before patching board code. Confirm the current `protocol` number

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -23,7 +23,7 @@ in root Cargo.toml. Never edit another crate. Phase A creates all five crates co
 ## Contract versions and source ownership
 
 The final compatibility matrix is: board protocol **v1**, SQLite schema **v13**, and exactly
-Herdr **0.7.5 / socket protocol 17**. The versioned source of truth is `schema.sql` for fresh
+Herdr **0.8.0 / socket protocol 19**. The versioned source of truth is `schema.sql` for fresh
 SQLite databases and `board-core::db` migrations for upgrades; `board-core::protocol` owns the
 board wire DTOs; `board-herdr` owns only the verified Herdr socket surface; and `docs/design.md`
 and `docs/protocol.md` explain behavior rather than defining duplicate serde shapes. Schema v13 adds
@@ -31,6 +31,14 @@ soft-deleted comments and immutable comment-history snapshots; the CLI exposes t
 and history commands while boardd remains the sole SQLite writer. The complete live use-case catalog
 is [`../e2e/README.md`](../e2e/README.md), scenarios **01–29**; the safe
 static harness is `e2e/test-harness.sh`, while `e2e/run-all.sh` is the opt-in live gate.
+
+The current Herdr boundary is deliberately narrower than the upstream schema. The 0.8.0/protocol-19
+fixture adds `workspace.move_block` and the `workspace.reordered` event/subscription for
+atomic workspace/worktree-group reordering, plus the `antigravity_cli` and `grok` integration
+targets. Those are additive and are not board dependencies;
+the existing workspace, tab, pane, agent, notification, session, and event calls retain their
+checked request/result shapes. Re-verify any future change with `herdr api schema --json` before
+changing `board-herdr`.
 
 ## Configuration boundary
 
@@ -157,11 +165,15 @@ A (core+scaffold) → B (herdr client) ∥ C (TUI) → D (daemon+CLI+integration
   resumability evidence), prompt assembly (with/without comments, truncation to last 20), adapter
   argv building (session mint/resume/fork; bypass refusal; overrides), migrations idempotent,
   config parsing.
-- B: unit: envelope encode/decode. Integration (ignored-by-default `#[ignore]` + run when HERDR_SOCK exists): read-only calls `session.snapshot`, `workspace.list` against live herdr.
+- B: unit: envelope encode/decode. Integration (ignored-by-default `#[ignore]` + run when HERDR_SOCK exists): read-only calls `session.snapshot`, `workspace.list` against a Herdr 0.8.0 / protocol-19 live socket.
 - C: insta snapshots via `ratatui::backend::TestBackend` + synthetic key events + FakeBoardClient: empty board (Todo only + hints), board with example pipeline & cards (status glyphs), new-card modal, column form, card detail w/ comments+runs, `?` help, delete-column prompt, move flow.
 - Restart recovery (`board-daemon::supervisor`) is a conservative one-pass classifier. Session resolution and snapshot I/O are injectable and happen before mutation. `Alive` adopts scheduler/watch intent and replays terminal status, `Gone` uses the existing pane-exit finalizer, and `Unknown` does nothing. The apply phase re-reads the open run/card, making duplicate passes idempotent and rejecting stale observations. Startup constructs/runs this pass for the Herdr spawner regardless of whether its initial best-effort client connected. The always-on supervisor then maintains independent per-socket streams and backoff, subscribes before taking a fresh bounded snapshot, and periodically reconciles missed events without resetting healthy sockets.
 - D: integration test (no herdr): start daemon on temp socket + temp DB with LocalSpawner + fake harness script → create card → move to auto column → fake agent comments + done → assert auto-transition, comments, run rows, statuses; timeout path; cancel path; queue serialization (two cards same space key run serially). The daemon comment suite also checks actor ownership, system-comment immutability, soft deletion, audit history, and event routing.
-- E: scenarios `e2e/01-core.sh` through `e2e/29-diagnostic-logs.sh` (real Herdr, fake
-  harnesses): disposable workspaces, protocol-17 placement, typed prompt delivery, bounded
-  same-pane `agent_pane_busy` retry, supervisor recovery, timer refresh, and identity-gated cleanup. CLI comment creation/context and system transition comments are covered by the live suite; CRUD/audit parity is kept hermetic in the CLI contracts. Run `bash e2e/test-harness.sh` for the
+- E: scenarios `e2e/01-core.sh` through `e2e/29-diagnostic-logs.sh` (real Herdr 0.8.0 / socket
+  protocol 19, fake harnesses): disposable workspaces, pane-first placement, typed prompt delivery,
+  bounded same-pane `agent_pane_busy` retry, supervisor recovery, timer refresh, and
+  identity-gated cleanup. The managed fixtures use Pi integration v8 and Claude integration v7
+  when exercising precise lifecycle/session signals; the configured fixture remains unmanaged.
+  CLI comment creation/context and system transition comments are covered by the live suite;
+  CRUD/audit parity is kept hermetic in the CLI contracts. Run `bash e2e/test-harness.sh` for the
   provider-free static safety checks; reserve `e2e/run-all.sh` for the separate live gate.

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,15 +4,47 @@ The install steps the [root README](../README.md) summarizes, plus everything op
 them: a custom CLI directory, a Herdr keybinding, the harness integration, the agent skill, and
 named Herdr sessions.
 
-Requires exactly **Herdr 0.7.5 (protocol 17)**, Git, and a Rust toolchain with `cargo`; Linux and
-macOS are supported. See the README for the one-line install command itself.
+Requires exactly **Herdr 0.8.0 (socket protocol 19)**, Git, and a Rust toolchain with `cargo`; Linux
+and macOS are supported. The board-side compatibility contract remains board protocol v1 and
+SQLite schema v13. See the README for the one-line install command itself.
+
+| Component | Required support level | How to verify |
+|---|---|---|
+| Herdr binary | 0.8.0 | `herdr --version` → `herdr 0.8.0` |
+| Herdr socket | protocol 19 | `herdr api schema --json` → top-level `protocol: 19`; a running session's `herdr api snapshot` also reports `version` and `protocol` |
+| Board socket | v1 | `docs/protocol.md` and `board-core::protocol` |
+| SQLite | schema v13 | `schema.sql` and `board-core::db` migrations |
+| Pi integration | v8 for precise Pi lifecycle/session signals | `herdr integration status` |
+| Claude integration | v7 for precise Claude lifecycle/session signals | `herdr integration status` |
+
+The board rejects a different Herdr version or socket protocol before workspace discovery or pane
+placement; it does not silently fall back to an older wire contract. The integration versions are
+user-managed prerequisites, not plugin files installed by herdr-board.
+
+## Verify the installed Herdr before installing
+
+These are read-only checks against the binary and session you are about to use:
+
+```bash
+test "$(herdr --version)" = "herdr 0.8.0"
+herdr api schema --json | python3 -c \
+  'import json, sys; s=json.load(sys.stdin); assert s["protocol"] == 19, s'
+herdr api snapshot
+herdr integration status
+```
+
+Use `herdr api schema --output PATH` when you need a saved schema for review. Confirm that the
+status output shows Pi **current (v8)** and Claude **current (v7)** before relying on precise
+working/blocked/done or session-identity signals. `herdr integration install --help` is the
+source of truth for the installable target names; install only the harness integrations you use.
 
 ## Installation details and a custom CLI directory
 
-Herdr first shows an interactive trust preview of the plugin's build commands. After approval it
-checks out the source, builds the release binary, registers the plugin, and copies the CLI to
-`~/.local/bin/board` as a regular executable. After reviewing the manifest and scripts, a
-noninteractive install is available:
+Herdr 0.8.0 first shows an interactive trust preview of the plugin's build commands. Relative
+plugin commands resolve from the plugin root, so the manifest's build/action paths do not depend on
+the caller's current directory. After approval Herdr checks out the source, builds the release
+binary, registers the plugin, and copies the CLI to `~/.local/bin/board` as a regular executable.
+After reviewing the manifest and scripts, a noninteractive install is available:
 
 ```bash
 herdr plugin install nelsonPires5/herdr-board --ref v0.10.0 --yes
@@ -39,16 +71,17 @@ command = "herdr plugin action invoke open-board --plugin herdr-board"
 ## Install the harness integration and optional agent skill
 
 For precise Pi status (`idle`, `working`, `blocked`, `done`) and session references, install Herdr's
-Pi integration. Installation changes your personal Pi extension config, so herdr-board never does it
-automatically — it is a user prerequisite. Without it (degraded mode), spawn, explicit `board done`,
-timeout, and pane-exit handling still work, but Herdr's `working`/`blocked`/`done` signals do not
-exist and a card can only reach `awaiting` (pending review) via the idle grace path.
+**Pi v8** integration. Installation changes your personal Pi extension config, so herdr-board never
+does it automatically — it is a user prerequisite. Without it (degraded mode), spawn, explicit
+`board done`, timeout, and pane-exit handling still work, but Herdr's `working`/`blocked`/`done`
+signals do not exist and a card can only reach `awaiting` (pending review) via the idle grace path.
 
 ```bash
 herdr integration install pi
 ```
 
-Claude users can similarly run `herdr integration install claude`. The repository's optional
+Claude users can similarly run `herdr integration install claude` (the supported Claude integration
+is v7). The repository's optional
 [`skill/SKILL.md`](../skill/SKILL.md) teaches interactive or dispatched agents to comment, call
 `board done`, and queue work. GitHub plugin installation does not copy the skill; the
 local-development installer below can do so.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -40,11 +40,36 @@ protocol version.
 
 ## Herdr compatibility gate
 
-boardd supports **exactly Herdr 0.7.5 / protocol 17**; there is no protocol-16 compatibility path.
-For each dispatch, it calls `ping` on the card's selected session socket and requires both exact
-values before workspace discovery or `workspace.create`. The spawner repeats the same check as its
-first socket operation before any tab/pane placement, managed-agent call, or configured-harness
-runner action. A mismatch fails the run before workspace mutation.
+boardd supports **exactly Herdr 0.8.0 / protocol 19**. The board protocol remains v1 and the
+SQLite schema remains v13; neither version is the upstream Herdr socket contract. Because the
+daemon opens a fresh Herdr request connection per operation, the compatibility probe is repeated
+at each operation boundary rather than treated as a one-time startup check:
+
+- `daemon.status` re-pings its configured socket and reports `herdr_connected: true` only for the
+  exact supported version and protocol.
+- The event supervisor gates a request connection before opening its persistent `events.subscribe`
+  stream. The subscription acknowledgement must be the typed `subscription_started` success
+  response, and it completes before the first reconciliation snapshot. An incompatible socket
+  receives neither a subscription
+  nor snapshot work.
+- The detached notification effect gates immediately before `notification.show`; an incompatible
+  but pingable Herdr is not sent even a cosmetic notification.
+- Dispatch and workspace discovery gate before `workspace.list`, `workspace.create`, or a live
+  workspace-cwd snapshot. The spawner repeats the gate as its first call before tab/pane placement,
+  managed-agent launch, or a configured-harness runner. `space.list` and the read-only space
+  preflight are checked the same way. The `herdr session list --json` registry enumeration is a
+  separate CLI discovery step, not a socket call; once it selects a socket, socket operations are
+  gated.
+- New pane operations are checked before `pane.get`/`pane.focus` for `run.focus`, `pane.rename` for
+  `pane.set_title`, and `pane.list`/`pane.layout`/`pane.split`/`pane.rename`, agent calls, and the
+  configured runner used by placement and rescue.
+
+There is one deliberate exception: cleanup and liveness for panes already owned by a daemon run.
+The spawner's `kill`/`pane.close` and `is_alive`/snapshot paths retain an ungated connection so a
+Herdr upgrade or incompatibility cannot prevent the daemon from closing or observing its own
+handle. This exception does not authorize new discovery, placement, focus, notification, or launch;
+supervisor reconciliation and caller-visible focus/rescue operations remain checked. A mismatch on
+a checked dispatch path fails the run before workspace mutation.
 
 ## Auto-start
 
@@ -257,8 +282,8 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   re-threaded onto a resume without re-sending that task, so it is refused (error 3) rather than
   rewritten.
 
-  **Environment of a rescued pane.** Protocol-17 placement is pane-first, so the environment is
-  established by the `pane.split` that creates the pane. A rescued pane receives the persisted run
+  **Environment of a rescued pane.** Pane-first placement establishes the environment on the
+  `pane.split` that creates the pane. A rescued pane receives the persisted run
   environment plus `BOARD_CARD_ID`, `BOARD_SOCKET`, `BOARD_BIN`, `BOARD_RESCUE=1`,
   `BOARD_RESUME_SESSION_ID=<conversation id>`, and `BOARD_RESCUED_RUN_ID=<run id>`.
   **`BOARD_RUN_ID` is deliberately withheld.** It is not a label but the *actor credential*:
@@ -291,7 +316,7 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
 
   Matching is on the pane **label**, the one field the daemon both sets (`pane.rename`) and reads
   back (`PaneInfo.label`); the same string is also used as the `agent.start` name purely for Herdr's
-  `agent_name_taken` exclusivity backstop. Verified live against Herdr 0.7.5: `agent.start` leaves a
+  `agent_name_taken` exclusivity backstop. Verified live against Herdr 0.8.0 / protocol 19: `agent.start` leaves a
   board-set label untouched, so labelling once before the launch is sufficient. A matching pane only counts as *live* if its harness is
   still there: a Herdr pane label outlives the process, so for a managed harness the pane must still
   have a registered `agent` (a *presence* test — `PaneInfo.agent` is the agent kind, not the chosen
@@ -346,7 +371,7 @@ it, a residual configured-script orphan is an explicitly documented limitation.
   in one pane's border, in the **caller's own** herdr session. `origin_socket` names that session
   exactly as it does for `run.focus` (only the caller knows which Herdr it runs inside); the path is
   canonicalized and then opened through the same gated connect as every other operation, so the
-  pinned Herdr 0.7.5 / protocol 17 check runs before the rename. Maps to herdr `pane.rename`, and
+  pinned Herdr 0.8.0 / protocol 19 check runs before the rename. Maps to herdr `pane.rename`, and
   touches no board state — the daemon exists here only because it owns every Herdr call.
   Error 1 for an empty `pane_id`, error 4 for an unavailable socket, a socket that fails the
   protocol gate, or a `pane.rename` herdr refuses (e.g. an unknown pane). A rename that did not
@@ -388,7 +413,7 @@ decider, and the daemon applies its decision in one place.
 | herdr `working` | `running`; clears `blocked`/`awaiting` (+reason). From `awaiting` this is the review loop: feedback typed into the pane wakes the agent. |
 | herdr `blocked` | `blocked`; run stays active. |
 | herdr `done` (run active, no `board done`) | `awaiting` + `agent_done` (immediate, no grace) + notification. On an already-`awaiting` card it refreshes the reason to `agent_done` without re-notifying. |
-| `idle` past `idle_grace_seconds` (no `board done`) | `awaiting` + `idle_expired` + notification. On an already-`awaiting` card it's a no-op (keeps the more specific reason). Protocol 17 may emit `done` then trailing `idle`; that `idle` does not re-arm the grace timer or replace `agent_done`. |
+| `idle` past `idle_grace_seconds` (no `board done`) | `awaiting` + `idle_expired` + notification. On an already-`awaiting` card it's a no-op (keeps the more specific reason). Herdr may emit `done` then trailing `idle`; that `idle` does not re-arm the grace timer or replace `agent_done`. |
 | herdr `unknown`, or any signal on a non-live card | ignored. |
 | Herdr `pane_exited` without `board done` | run `fail`, card `failed`, **no** transition (unchanged); watcher identity is `(session socket, pane id)`. |
 | configured child returns while its exact run is open (`queued` or `started`) | internal run-id guard records `fail`, card `failed`, **no** transition; callback-before-registration is accepted, while stale/completed and built-in runs are rejected. `board done` likewise requires the exact `BOARD_RUN_ID` during the queued exception, preventing a stale child from completing a replacement. |
@@ -426,9 +451,9 @@ Coarse by design — the TUI refetches only its selected `board.get {board_id}` 
 3. Spawn (daemon, via `Spawner` trait):
    - resolve session: card `session` (null = default) → Herdr socket via the session registry; an unknown/not-running session fails the run with a clear error listing known sessions. The per-session client is used for workspace resolve/create, spawn, kill, and liveness.
    - harness session: resume `card.session_id` unless `column.fresh_session` or none. Pi mint/resume use exact `--session-id`; Pi retry forks old → a newly minted target id. Claude retains mint/`--resume`/`--fork-session`. Existing cards keep their stored harness/session.
-   - **preflight before workspace mutation:** `ping` the selected socket and require exact Herdr 0.7.5/protocol 17. Only then resolve `workspace` by id/case-insensitive label, or resolve `new_workspace` by label and, if absent, call `workspace.create {label,cwd,focus:false}`. Read the workspace cwd from its pane snapshot; snapshot failure or missing live cwd fails dispatch, never falling back to process cwd or a stale snapshot.
+   - **preflight before workspace mutation:** `ping` the selected socket and require exact Herdr 0.8.0 / protocol 19. Only then resolve `workspace` by id/case-insensitive label, or resolve `new_workspace` by label and, if absent, call `workspace.create {label,cwd,focus:false}`. Read the workspace cwd from its pane snapshot; snapshot failure or missing live cwd fails dispatch, never falling back to process cwd or a stale snapshot.
    - **preflight again at the spawner boundary:** this is the spawner's first protocol call, before placement, managed launch, or the configured runner.
-   - build the run-child env `{BOARD_CARD_ID,BOARD_RUN_ID,BOARD_SOCKET,BOARD_BIN}` plus configured-harness prompt env. Current schema v13 runs place each card in a stable short `card-<id>` tab whose `tab.create` root is a shell anchor labeled `card-<id>-anchor`. The anchor receives only stable card identity; every run child is created by `pane.split` from it with the complete run cwd/env. Promotion persists the exact anchor id with the run. The daemon reuses only exact tab/anchor identities reconstructed from the newest matching durable panes in the same session/workspace; labels are display metadata, never ownership. A renamed anchor remains selected by identity; a closed anchor is recreated only by splitting a currently live durable board child, otherwise a fresh tab is created. The initial split targets ratio `0.40` and clamps it on narrow terminals so the anchor remains reusable; later splits use layout geometry. Both fresh and recovered placement fail closed unless the live layout can provide a 24x6 anchor and a 12x8 child. Concurrent first allocations for one `(session,workspace,card)` key are serialized; if multiple historical panes are live, newest run id wins. Legacy rows retain the historical `kanban` lookup. Thus cwd/env/placement exist **before** launch; protocol-17 `agent.start` receives none of them and never receives the anchor pane id.
+   - build the run-child env `{BOARD_CARD_ID,BOARD_RUN_ID,BOARD_SOCKET,BOARD_BIN}` plus configured-harness prompt env. Current schema v13 runs place each card in a stable short `card-<id>` tab whose `tab.create` root is a shell anchor labeled `card-<id>-anchor`. The anchor receives only stable card identity; every run child is created by `pane.split` from it with the complete run cwd/env. Promotion persists the exact anchor id with the run. The daemon reuses only exact tab/anchor identities reconstructed from the newest matching durable panes in the same session/workspace; labels are display metadata, never ownership. A renamed anchor remains selected by identity; a closed anchor is recreated only by splitting a currently live durable board child, otherwise a fresh tab is created. The initial split targets ratio `0.40` and clamps it on narrow terminals so the anchor remains reusable; later splits use layout geometry. Both fresh and recovered placement fail closed unless the live layout can provide a 24x6 anchor and a 12x8 child. Concurrent first allocations for one `(session,workspace,card)` key are serialized; if multiple historical panes are live, newest run id wins. Legacy rows retain the historical `kanban` lookup. Thus cwd/env/placement exist **before** launch; pane-first `agent.start` receives none of them and never receives the anchor pane id.
    - managed Pi/Claude: create a mode-`0600` file containing the snapshotted system prompt; call `agent.start {name,kind,pane_id,args,timeout_ms:30000}` on the newly split child with prompt-free startup args and the harness-specific file flag. A typed `agent_pane_busy` response is treated as a bounded transient on that same child: retry the exact same request on the same pane at most twice, with 100ms then 200ms backoff; do not split or allocate another pane. Persistent busy is terminal and follows child-only cleanup, leaving the anchor. This is distinct from `pane_not_found`, which is a placement race: close the child when present, rediscover from `tab.list`, and retry complete placement once. Poll `agent.get {target:pane_id}` for at most 30s until `interactive_ready && !launch_pending`; then call `agent.prompt {target:pane_id,text:prompt_snapshot}`. Remove the prompt file before returning, including error paths.
    - managed pane name is `card-<id>-<column-slug>` (e.g. `card-14-execute`); `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`.
    - configured harness: `pane.rename` the owned pane, create one mode-`0700` self-removing script whose POSIX-quoted command is the exact configured argv, and invoke exactly the selected Herdr binary (`HERDR_BIN_PATH` when nonempty, otherwise `herdr`) as `pane run <pane_id> <script_path>` with `HERDR_SOCKET_PATH` set to the selected socket. The script runs the child, preserves its status, then calls hidden `board __pane-exited --run-id "$BOARD_RUN_ID"`; the internal run-id guard accepts only the exact open queued/started configured run (including callback-before-registration), rejects stale/completed and built-in runs, and never applies `on_fail`.
@@ -455,12 +480,12 @@ Their persisted startup argv contains neither system nor card prompt:
   `pi [--model provider/model] [--thinking off|minimal|low|medium|high|xhigh|max] (--session-id ID | --fork OLD --session-id NEW)`
   - omitted model/thinking means Pi uses its configured defaults;
   - no permission, approval, or `--allowedTools` flag is added; Pi project trust is separate;
-  - protocol-17 launch uses `kind:"pi"`, startup args without `pi`, then appends
+  - pane-first managed launch uses `kind:"pi"`, startup args without `pi`, then appends
     `--append-system-prompt <mode-0600-file>`; only after readiness does `agent.prompt` carry the
     unprefixed `prompt_snapshot`.
 - Built-in `claude`:
   `claude [--model M] [--effort E] [--permission-mode P] --allowedTools "Bash(board:*)" (--session-id UUID | --resume ID [--fork-session])`
-  - protocol-17 launch uses `kind:"claude"`, startup args without `claude`, then appends
+  - pane-first managed launch uses `kind:"claude"`, startup args without `claude`, then appends
     `--append-system-prompt-file <mode-0600-file>`; `agent.prompt` separately carries the card task.
 - Config-defined harnesses (`~/.config/herdr-board/config.toml`) remain unmanaged even if their
   executable is named `pi` or `claude`:
@@ -483,7 +508,7 @@ Legacy pre-v7 rows are deliberately not backfilled: NULL built-in rows remain un
 their persisted historical all-in-one argv, avoiding duplicate prompt delivery; NULL configured rows
 retain the historical current-column system-prompt reconstruction at spawn. The local test spawner
 materializes the historical all-in-one Pi/Claude argv from explicit managed metadata, but the Herdr
-path always uses the separated protocol-17 channels.
+path always uses the separated pane-first channels.
 
 Pi lifecycle status comes from Herdr's official Pi integration and the existing event watcher; there
 is no Pi-specific watcher. Without `herdr integration install pi`, explicit `board done`, spawn

--- a/docs/research.md
+++ b/docs/research.md
@@ -1,32 +1,53 @@
-# Research notes (verified through 2026-07-22)
+# Research notes (verified through 2026-08-04)
 
 This page is historical research and verification context, not a runtime or wire-contract source.
 The current contract is the typed code plus [`docs/README.md`](README.md), `docs/protocol.md`,
 `schema.sql`, and the migration tests.
 
-Condensed output of three research passes: local herdr introspection, prior art, and technical building blocks.
+Condensed output of three research passes: local Herdr introspection, prior art, and technical building blocks.
 
-## A. herdr capability map (v0.7.5, protocol 17, verified locally)
+## A. Herdr capability map (Herdr 0.8.0, socket protocol 19; local introspection)
 
-JSON request/response + events use the Unix socket at
+JSON request/response and events use the Unix socket at
 `~/.config/herdr/herdr.sock` (or `HERDR_SOCKET_PATH` for a named session).
-The captured `herdr api schema --json` contains 89 request methods and 26 event
-subscription selectors. `herdr api snapshot` exposes live
-workspaces/tabs/panes/agents. IDs remain shaped like `w3`, `w3:t1`, `w3:p1`.
+The captured `herdr api schema --json` contains **90 request methods, 26 emitted event
+kinds, and 27 event-subscription selectors**. `herdr api snapshot` exposes live
+workspaces/tabs/panes/agents, with IDs shaped like `w3`, `w3:t1`, and `w3:p1`.
 
-| Need | Herdr 0.7.5 command / protocol-17 API |
+| Need | Herdr 0.8.0 command / current socket API |
 |---|---|
 | Create workspace | `herdr workspace create --cwd PATH --label TEXT --env K=V --no-focus` |
 | Worktree per card | `herdr worktree create --workspace ID\|--cwd PATH --branch NAME --base REF --json` (+ open/remove/list) |
-| Place a pane first | Use `tab.create` or `pane.split {workspace_id, target_pane_id, cwd, env, direction, focus}`. Placement, cwd, and environment are established before managed launch. |
-| Start a managed agent | `herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- [AGENT_ARG…]`; socket `agent.start` is `{name, kind, pane_id, args, timeout_ms}`. `kind` chooses the canonical executable; `args` excludes it. The protocol-16 workspace/tab/split/env start fields are gone. |
+| Place a pane first | Use `tab.create` or `pane.split {workspace_id, target_pane_id, cwd, env, direction, ratio, focus}`. Placement, cwd, and environment are established before managed launch. |
+| Start a managed agent | `herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- [AGENT_ARG…]`; the socket `agent.start` request is `{name, kind, pane_id, args, timeout_ms}`. `kind` selects the canonical executable and `args` excludes it. Board-side launch therefore stays pane-first rather than embedding placement in the agent request. |
 | Inspect readiness | `herdr agent get TARGET` / `agent.get {target}` returns `interactive_ready` and `launch_pending`; readiness is `interactive_ready=true && launch_pending=false`. `agent.wait` waits for agent status, not this startup predicate. |
-| Submit a card task | `herdr agent prompt TARGET TEXT`; `agent.prompt {target,text,wait?}` preserves multiline text and optionally waits for status. No keystroke/Enter pair is needed. |
-| Read output | `herdr agent read TARGET --source recent-unwrapped --lines N` / `agent.read` reads terminal screen/scrollback, not a semantic result. |
-| Run an unmanaged command | `herdr pane run PANE_ID COMMAND…` exists only as a CLI boundary: protocol 17 exposes no `pane.run` socket method. It schedules the command, so herdr-board uses a temporary self-cleaning runner and a board callback for silent child exit. |
-| Event stream | `events.subscribe` is a persistent raw-socket connection. Subscriptions use dotted names; emitted envelopes may use underscore `data.type` names or a dotted top-level `event` with no `data.type`. See exact shapes below. |
+| Submit a card task | `herdr agent prompt TARGET TEXT`; `agent.prompt {target,text,wait?}` preserves multiline text and optionally waits for status. Herdr handles the short send-text/Enter settling delay; no synthetic keystroke/Enter pair is needed. |
+| Read output | `herdr agent read TARGET --source recent-unwrapped --lines N` / `agent.read` reads terminal screen/scrollback, not a semantic result. Read responses include `truncated`; `true` means older terminal rows were omitted. |
+| Run an unmanaged command | `herdr pane run PANE_ID COMMAND…` remains a CLI-only boundary: the current socket schema has no `pane.run` method. It schedules the command, so herdr-board uses a temporary self-cleaning runner and a board callback for silent child exit. |
+| Event stream | `events.subscribe` is a persistent raw-socket connection. Subscription entries use dotted names; emitted envelopes may use underscore `data.type` names or a dotted top-level `event` with no `data.type`. See exact shapes below. |
 | Notify human | `herdr notification show TITLE --body … --sound none\|done\|request` |
 | Integration input | `herdr pane report-agent PANE --source ID --agent LABEL --state idle\|working\|blocked\|unknown [--seq N]`; `done` is an output status, not an accepted report input. |
+
+### The protocol-19 delta
+
+The board-used RPC shapes are unchanged between the earlier capture and the current
+contract: `ping`, `session.snapshot`, workspace list/create/close, tab create/list,
+pane split/list/get/focus/rename/read/send-text/send-keys/close/layout, agent
+start/get/prompt/wait, `notification.show`, and `events.subscribe` retain their
+request fields, result envelopes, and event forms. The delta is additive:
+
+- `workspace.move_block` accepts `workspace_ids` and an optional `before_workspace_id`
+  for atomic block movement, including worktree groups.
+- `workspace.reordered` is a new emitted event, and a matching
+  `workspace.reordered` subscription selector is available. Its event data carries
+  `workspace_ids`, `workspaces`, and an optional `before_workspace_id`.
+- The integration target vocabulary adds `antigravity_cli` (CLI spelling
+  `antigravity-cli`) and `grok`, including their session-reporting/native-restore
+  support. They are not board built-in harnesses.
+
+The board client does not call `workspace.move_block` and does not need to decode
+`workspace.reordered` to run its queue. Unknown additive events remain observable as
+unhandled events rather than changing the used transport.
 
 **Event shapes**: a status subscription is
 `{"type":"pane.agent_status_changed","pane_id":"w1:p2"}` and requires a
@@ -36,14 +57,42 @@ concrete existing pane. Emitted status data requires
 `pane.exited`/`pane.closed`; their emitted data carries `pane_id` and
 `workspace_id`. The client accepts both
 `{"event":"pane_agent_status_changed","data":{"type":"pane_agent_status_changed","pane_id":"w1:p2","workspace_id":"w1","agent_status":"working","agent":"pi"}}`
-and protocol-17's observed
+and
 `{"event":"pane.agent_status_changed","data":{"pane_id":"w1:p2","workspace_id":"w1","agent_status":"working","agent":"pi"}}`
-form.
+forms.
 
-**Agent status**: per-harness integrations report precise lifecycle and session
-identity. On 2026-07-22, `herdr integration status` reported Pi current at **v6**
-(`~/.pi/agent/extensions/herdr-agent-state.ts`) and Claude current at **v7**
-(`~/.claude/hooks/herdr-agent-state.sh`). Installation mutates personal harness
+### 0.8.0 behavior that shaped live validation
+
+The release notes include several runtime changes that are not new board RPC
+fields, but matter at the Herdr boundary:
+
+- **Lifecycle ownership:** known-agent integrations now leave pane ownership with a
+  confirmed process exit. Restarting Pi with the same saved session can restore its
+  lifecycle state; nested or ephemeral Codex sessions do not replace the owning
+  pane's resumable session, and Pi RPC/JSON/print processes do not claim the TUI
+  pane's lifecycle. Board status is still a hint: `pane.exited` and explicit
+  `board done` remain the reliable run boundaries.
+- **Prompt delivery:** Herdr now waits briefly after sending prompt text before
+  pressing Enter. The board still waits for `interactive_ready && !launch_pending`,
+  then uses `agent.prompt` for the exact multiline task; live validation must check
+  arrival at the agent, not just startup success.
+- **Headless restore:** headless servers can resume restored agent sessions without
+  waiting for a TUI client to attach. This is relevant to `run.focus` rescue and
+  restart recovery, which must not assume an attached desktop client.
+- **Plugin root:** relative plugin commands resolve from the plugin root. A plugin's
+  build/action commands are therefore not allowed to depend on the caller's cwd;
+  installation and the open-board action should be checked from a disposable session.
+- **Read truncation/history:** pane and agent reads report `truncated: true` when
+  older terminal rows were omitted. Herdr may collect text history for idle
+  alternate-screen agents and restore the application viewport afterward. Neither
+  read text nor a truncated flag is a completion/result channel; board agents report
+  through comments and `board done`.
+
+**Agent status and integrations**: the installed 0.8.0 CLI exposes the integration
+targets from `herdr integration install --help`. On the host inspected for this
+update, `herdr integration status` reports Pi **current (v8)** at
+`~/.pi/agent/extensions/herdr-agent-state.ts` and Claude **current (v7)** at
+`~/.claude/hooks/herdr-agent-state.sh`. Installation mutates personal harness
 configuration, so herdr-board never performs it; the matching integration is a
 user prerequisite for precise live status. On a managed pane, Herdr can derive
 output `done` from the integration's terminal end-of-turn idle report.
@@ -51,9 +100,14 @@ output `done` from the integration's terminal end-of-turn idle report.
 `board done` remains terminal truth, while agent `done` parks the card in
 `awaiting` for review.
 
-**Plugin architecture** (learned from installed `herdr-file-viewer`): manifest `herdr-plugin.toml` with `id/name/version/min_herdr_version`, `[[build]]` (install-time command), `[[panes]]` (id, title, placement=split/tab/overlay, command argv → herdr spawns the TUI in a pane), `[[actions]]` (shell commands, invocable via `herdr plugin action invoke` or `[[keys.command]]` keybindings, receive `PluginInvocationContext`: focused pane/cwd/agent, workspace/tab, selected text). Install from github or local → `~/.config/herdr/plugins/…`, registry `plugins.json`. Runtime env: `HERDR_BIN_PATH`, `HERDR_PLUGIN_CONFIG_DIR`, `HERDR_PLUGIN_CONTEXT_JSON`. Plugins have no special powers — they shell out to the same CLI/socket.
+**Plugin architecture** (learned from installed `herdr-file-viewer`): manifest `herdr-plugin.toml` with `id/name/version/min_herdr_version`, `[[build]]` (install-time command), `[[panes]]` (id, title, placement=split/tab/overlay, command argv → Herdr spawns the TUI in a pane), `[[actions]]` (shell commands, invocable via `herdr plugin action invoke` or `[[keys.command]]` keybindings, receive `PluginInvocationContext`: focused pane/cwd/agent, workspace/tab, selected text). Install from GitHub or local → `~/.config/herdr/plugins/…`, registry `plugins.json`. Herdr 0.8.0 resolves relative command paths from the plugin root. Runtime env: `HERDR_BIN_PATH`, `HERDR_PLUGIN_CONFIG_DIR`, `HERDR_PLUGIN_CONTEXT_JSON`. Plugins have no special powers — they shell out to the same CLI/socket.
 
-**Gaps to design around**: Herdr has no per-agent model/effort abstraction (the adapter layer is ours); configured commands need a CLI bridge because `pane.run` is absent from the socket schema; terminal output remains screen-scrape, so agents should write files/comments; and `events.subscribe` needs a persistent raw-socket client with one concrete status subscription per watched pane.
+**Gaps to design around**: Herdr has no per-agent model/effort abstraction (the adapter layer is ours); configured commands need a CLI bridge because `pane.run` is absent from the socket schema; terminal reads are bounded screen/scrollback observations and may be truncated, so agents should write files/comments; and `events.subscribe` needs a persistent raw-socket client with one concrete status subscription per watched pane.
+
+> **Historical comparison only — not support policy:** the earlier Herdr 0.7.5 / protocol-17
+> capture had 89 request methods, 25 emitted event kinds, 26 subscription selectors, and Pi
+> integration v6. It is retained solely to explain the additive protocol-19 delta above; all
+> current gates and integration instructions use Herdr 0.8.0 / protocol 19, Pi v8, and Claude v7.
 
 ## B. Prior art
 
@@ -73,10 +127,10 @@ More in the space: Cline kanban, Fusion, Nimbalyst, Crystal, Conductor, Omnara �
 ## C. Harness CLI capabilities (verified locally, 2026-07-17)
 
 The flags below describe direct/local CLI capabilities and historical adapter research; they are
-**not** the shipped managed-launch transport. Under Herdr 0.7.5/protocol 17, herdr-board creates a
+**not** the shipped managed-launch transport. For a shipped managed run, herdr-board creates a
 pane first, starts the explicit agent kind with prompt-free startup args, supplies the system prompt
 through a temporary `0600` file, waits for `interactive_ready`, and sends the card prompt only via
-`agent.prompt`.
+`agent.prompt` under the exact Herdr 0.8.0/protocol-19 gate described above.
 
 **Pi Coding Agent 0.80.10**: `--model <provider/model>`; `--thinking off|minimal|low|medium|high|xhigh|max`; direct CLI supports `--append-system-prompt <text>` and positional prompts; exact mint/resume via `--session-id <id>`; retry fork via `--fork <source-id> --session-id <new-id>`. Pi has no per-tool permission prompts; `--approve`/`--no-approve` controls project trust and must not be mapped to the board permission field. Models are runtime provider/auth/user configuration, so the board does not persist a parsed `--list-models` catalog. At verification time the user default was `openai-codex/gpt-5.6-sol`, thinking `xhigh`; the isolated smoke detects this at runtime and overrides only the invocation to `low`.
 
@@ -98,4 +152,4 @@ through a temporary `0600` file, waits for `interactive_ready`, and sends the ca
 - **TUI kanbans that exist** (rust_kanban, kanban-tui/ratatui, kanbanban) are standalone apps, not embeddable libs — we write our own view (ratatui or bubbletea).
 - **Cost/safety**: per-run timeout; `--max-budget-usd` where supported; `bypassPermissions` explicit opt-in only.
 
-Sources: vibe-kanban repo/DeepWiki/docs, claude-task-master, claude-squad, Backlog.md, kandev, ai-agent-board, agent-kanban, Copilot coding-agent docs, claude-code-action docs, Claude Code hooks reference, Agent SDK TS/Python refs, codex/gemini/opencode docs. (Full links in the repos above; local herdr facts verified with `herdr api schema`, `herdr --default-config`, `herdr integration status`.)
+Sources: vibe-kanban repo/DeepWiki/docs, claude-task-master, claude-squad, Backlog.md, kandev, ai-agent-board, agent-kanban, Copilot coding-agent docs, claude-code-action docs, Claude Code hooks reference, Agent SDK TS/Python refs, codex/gemini/opencode docs. (Full links in the repos above; the current Herdr facts were checked with `herdr api schema --json`, relevant `--help` commands, `herdr api snapshot`, and `herdr integration status`.)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 How herdr-board is tested, and how to add tests for a change. The final contract is board
-protocol v1, SQLite schema v13, and Herdr 0.7.5 / protocol 17. Four layers, cheap and hermetic
+protocol v1, SQLite schema v13, and Herdr 0.8.0 / protocol 19. Four layers, cheap and hermetic
 first, expensive and live last:
 
 ```
@@ -14,8 +14,9 @@ unit / pure (per crate)                 no I/O, no daemon        — cargo test
                                            workspaces
 ```
 
-All four layers run in CI. The live job starts only after the cheaper gates pass, installs the
-pinned Herdr 0.7.5 binary, and boots only suite-owned ephemeral servers — see [Running](#running).
+CI is configured to run all four layers. The live job starts only after the cheaper gates pass,
+installs the pinned Herdr 0.8.0 binary, and boots only suite-owned ephemeral servers — see
+[Running](#running).
 
 ## The pyramid
 
@@ -37,10 +38,11 @@ The stable ownership layout is responsibility-oriented, not a file manifest:
 
 The public core suites cover deterministic engine decisions, schema-v13 migrations and atomic
 run units of work, protocol-v1 serde, typed client boundaries, configuration, prompt assembly,
-harness planning, and scoped-board behavior. Herdr suites cover protocol-17 event decoding and
-socket behavior against an in-process fake server. Daemon private suites cover queue claims,
-spawn/finalization atomicity, pane placement, configured and managed launch characterization,
-request routing, watcher signals, timeout handling, per-session recovery, and comment actor policy.
+harness planning, and scoped-board behavior. Herdr suites cover the Herdr 0.8.0 / protocol 19
+event and socket contract against an in-process fake server. Daemon private suites cover queue
+claims, spawn/finalization atomicity, pane placement, configured and managed launch
+characterization, request routing, watcher signals, timeout handling, per-session recovery, and
+comment actor policy.
 TUI suites cover fake-client reducer behavior, forms, and ratatui snapshots. Keep descriptions at
 this ownership level; add a path only when it is a stable boundary or a useful entry point.
 
@@ -52,16 +54,31 @@ a dozen near-identical hand-rolled setups that drift apart and then hide bugs in
 - **`crates/board-daemon/src/testkit.rs`** (`cfg(test)` only) provides three things. `daemon()` is
   one builder for the twelve-argument `Daemon::new`, with an in-memory store, a `LocalSpawner` and
   dummy paths by default; `build()` also hands back the event and dispatch receivers, so a test can
-  prove that a rolled-back operation emitted *nothing*. `herdr_server()` is one fake protocol-17
-  Herdr Unix socket with a settable protocol/version (so the compatibility gate can be served a
-  **wrong** one), per-method canned responses, an optional accept count, and recorded-request
-  inspection, plus the protocol-17 JSON constructors (`pane_info`, `agent_started`, …) used to build
-  those responses. Finally the shared negative assertions `assert_no_events`, `assert_no_effects`,
+  prove that a rolled-back operation emitted *nothing*. `herdr_server()` is one fake Herdr 0.8.0 /
+  protocol 19 Unix socket with a settable protocol/version (so the compatibility gate can be served
+  a **wrong** one), per-method canned responses, an optional accept count, and recorded-request
+  inspection, plus the current-contract JSON constructors (`pane_info`, `agent_started`, …) used to
+  build those responses. Finally the shared negative assertions `assert_no_events`, `assert_no_effects`,
   `assert_no_rollback_effects`, and `fault_db`, the armed lifecycle-fault `Db`.
 - **`crates/board-tui/src/testkit.rs`** (feature `fake-client`) holds `DemoClient`, the driver and
   synthetic-input helpers, and the rendering helpers. It lives in the library rather than in a test
   file because each `tests/*.rs` is its own crate and its own link step — per-file helpers would be
   compiled once per test binary.
+
+### Compatibility-gate coverage
+
+The Herdr 0.8.0 / protocol 19 upgrade is tested at every compatibility-sensitive boundary, not
+only at daemon startup: `daemon.status` checks the reported connection state; the supervisor checks
+compatibility before `events.subscribe` and its acknowledgement/snapshot generation; detached
+notifications check before `notification.show`; dispatch checks before workspace resolution and
+placement; discovery checks include `space.list` and the read-only space preflight; and pane tests
+cover `pane.set_title`, `run.focus`, placement, managed launch, and configured-runner operations.
+The event tests also preserve the required subscribe-ack-before-snapshot order.
+
+Cleanup and liveness for an already-owned pane remain intentionally ungated in the spawner's
+`kill`/`pane.close` and `is_alive`/snapshot paths, so an incompatible Herdr cannot strand a pane the
+daemon already owns. Those paths are not new discovery or launch authority; supervisor recovery
+snapshots and caller-visible focus/rescue operations still use the checked connection.
 
 ### The fake-client ↔ daemon parity guard
 
@@ -102,10 +119,19 @@ The current parity/schema-v13 change is specified test-first:
   `meta.rs` (command-tree refusals, `template apply`, version/status separation, `skill`, and the
   JSON error envelope); `compat.rs` protects top-level aliases and `exit_codes.rs` pins the process
   exit contract.
-- **CLI/E2E boundary:** live scenarios 01, 04, 06, 08, 09, 11, 16, and 17 exercise CLI comment
+- **CLI/E2E boundary:** scenarios 01, 04, 06, 08, 09, 11, 16, and 17 exercise CLI comment
   creation, transition/silent-exit/timeout system comments, comment context in later prompts, and
-  managed/configured comment completion against disposable Herdr. CRUD/audit semantics stay in
-  hermetic core/daemon/CLI tests; the live suite does not duplicate every management RPC.
+  managed/configured comment completion against disposable Herdr. The managed and configured
+  scenarios use the current Herdr 0.8.0 / protocol 19 contract; their files,
+  `16-managed-p17.sh` and `17-configured-p17-runner.sh`, retain the historical `p17` names.
+  CRUD/audit semantics stay in hermetic core/daemon/CLI tests; the live suite does not duplicate
+  every management RPC.
+
+The authoritative [`e2e/README.md`](../e2e/README.md) catalog currently covers scenarios 01–29,
+and `e2e/run-all.sh` includes every numbered script. Scenarios 18–29 extend the live coverage with
+nullable/validation, late-start and recovery, active-run timing, TUI layout and board transfers,
+pane rescue, Pi catalog behavior, and diagnostics. This document describes the intended coverage
+and gate configuration; it does **not** claim that the full live E2E suite has passed.
 
 Nullable update coverage in `board-core` is table-driven across every column/card nullable:
 protocol tests verify omitted/null/value serde states, database tests verify set → clear and reopen
@@ -219,15 +245,15 @@ Deterministic daemon tests cover working→running, blocked, Herdr's output-only
 `awaiting` (`agent_done`), idle grace→`awaiting` (`idle_expired`; never `lost`), timeout paused
 while `awaiting`, pane exit without sleeps, and managed `agent_pane_busy` retry/cleanup without
 allocating a second pane. The busy tests assert exact request preservation, bounded backoff, and
-that persistent failure closes only the owned child rather than its pre-existing anchor. Herdr 0.7.5 / protocol 17 does not accept `done`
+that persistent failure closes only the owned child rather than its pre-existing anchor. Herdr 0.8.0 / protocol 19 does not accept `done`
 as a `pane.report_agent` input (`idle|working|blocked|unknown` only), so the live
-`15-awaiting.sh` scenario uses Pi integration v6's supported report shape; on a managed
+`15-awaiting.sh` scenario uses Pi integration v8's supported report shape; on a managed
 `agent.start` pane Herdr derives output `done` from the end-of-turn idle report. The scenario covers
 blocked → working → Herdr done → `awaiting` → confirm → board `done` end to end. The opt-in real-Pi
 smoke records live status when observable but does not require sampling `working` from a fast run.
 
-Protocol-17 managed launch is covered separately by scenario 16. Its fake Pi and fake Claude
-(via the same launch surface used with Pi integration v6 / Claude integration v7) are interactive
+Pane-first managed launch is covered separately by scenario 16. Its fake Pi and fake Claude
+(via the same launch surface used with Pi integration v8 / Claude integration v7) are interactive
 terminal fixtures, not provider stubs that can pass at process startup: each reports ordered
 session identity then idle, waits for Herdr readiness, and refuses to call `board done` until the
 exact card prompt arrives through `agent.prompt`. Scenario 17 proves configured harnesses remain
@@ -235,9 +261,9 @@ unmanaged and receive exact `BOARD_PROMPT`/`BOARD_SYSTEM_PROMPT` values through 
 `pane run` bridge. Scenario 28 stages only isolated Pi `auth.json`/`models-store.json`, proves the auth-scoped
 `harness.capabilities` result, and cycles the real TUI effort selector without submitting a card or
 starting Pi. The real-Claude smoke is separate: it stages only completed onboarding/theme, exact
-workspace trust, the installed Herdr hook, credentials, and approved `remote-settings.json`,
-so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied.
-Its intended contract is one authorized Haiku/low attempt with no retry or fallback.
+workspace trust, the current Claude integration v7 hook, credentials, and approved
+`remote-settings.json`, so startup dialogs cannot consume `agent.prompt`; no broad personal Claude
+state is copied. Its intended contract is one authorized Haiku/low attempt with no retry or fallback.
 
 `scripts/e2e.sh` is a thin compat wrapper that `exec`s `run-all.sh`.
 
@@ -386,7 +412,7 @@ Checklist:
 | **Tab labels are not unique** | New runs resolve `card-<id>` tabs and shell anchors only by exact ids reconstructed from scoped durable panes; schema v13 retains the anchor id introduced in v12. Duplicate tab/anchor labels and legacy `kanban` are never adopted as ownership proof. A renamed exact anchor remains owned; a missing anchor is recovered only from an exact durable child, otherwise a fresh tab is created. Legacy rows retain their historical lookup. |
 | **Agent names are exclusive** | While a pane is open its agent name is reserved. A collision (e.g. the session already has a `card-1-execute` pane) makes the daemon retry as `card-1-execute-r<run>`. Assertions must accept the optional `-r<n>` suffix. |
 | **A newly split pane can be busy** | Herdr may return typed `agent_pane_busy` while the child still drains prior state. The daemon retries the exact managed `agent.start` request twice on that same owned child with 100ms/200ms backoff; persistent busy closes only that child and leaves the shell anchor. Do not treat it as `pane_not_found`: that error triggers one bounded full placement rediscovery from `tab.list`. |
-| **Managed and configured pane identity differ** | Protocol-17 managed Pi/Claude panes expose the managed kind in `pane.agent`; configured panes are renamed to the daemon-assigned `card-<id>-<column>` label and remain unmanaged. Match the appropriate field and still accept the optional `-r<n>` name suffix. |
+| **Managed and configured pane identity differ** | Pane-first managed Pi/Claude panes expose the managed kind in `pane.agent`; configured panes are renamed to the daemon-assigned `card-<id>-<column>` label and remain unmanaged. Match the appropriate field and still accept the optional `-r<n>` name suffix. |
 | **`pane.layout` nests under `layout`** | `hrpc pane.layout …` returns `{"type":"pane_layout","layout":{…panes,splits…}}`; read `.layout.panes`. |
 | **Never `pkill` by "board daemon"** | That pattern matches your own shell too. Stop only the daemon you started after verifying its signed platform identity token (`e2e_daemon_stop`); PID liveness alone is insufficient. Linux uses `/proc`; Darwin uses native process APIs. Inspect only exact PIDs emitted by the invocation. |
 | **Leaked ephemeral session from an aborted run** | If a run is killed before cleanup, an `hb-e2e-*` session may linger. Remove it wholesale: `herdr session stop <name> && herdr session delete <name>` (this closes its workspaces too). List leftovers with `herdr session list`. |
@@ -406,14 +432,14 @@ E2E_REAL_PI=1 e2e/real-pi-smoke.sh  # explicit real-provider opt-in; may incur c
 E2E_REAL_CLAUDE_HAIKU=1 e2e/real-claude-haiku-smoke.sh  # one authorized Haiku/low attempt; may incur cost
 ```
 
-- Standard suite requires **exactly Herdr 0.7.5 / socket protocol 17**, `python3`, Bash ≥4, and `cargo`. It supports Linux and macOS; `run-all.sh` resolves Herdr and Bash absolutely before narrowing `PATH`. Every scenario preflights both `herdr --version` and a socket `ping`; protocol 16 and unknown/future protocols fail before dispatch. The forced-build standard suite scenarios 01–29 pass with no provider calls. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages minimal completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved `remote-settings.json` under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied, and it has no retry or fallback. Its independent identity implementation remains Linux-only and is outside the portable provider-free gate. Both opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
+- Standard suite requires **exactly Herdr 0.8.0 / socket protocol 19**, `python3`, Bash ≥4, and `cargo`. It supports Linux and macOS; `run-all.sh` resolves Herdr and Bash absolutely before narrowing `PATH`. Every scenario preflights both `herdr --version` and a socket `ping`; older and unknown/future protocols fail before dispatch. The forced-build standard suite is configured to exercise scenarios 01–29 without provider calls; this is coverage guidance, not a claim that a full live run has passed. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages minimal completed onboarding/theme, exact workspace trust, the current Claude integration hook, credentials, and approved `remote-settings.json` under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied, and it has no retry or fallback. Its independent identity implementation remains Linux-only and is outside the portable provider-free gate. Both opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
   the release binary once; scenarios reuse it. Every scenario boots and cleans its own ephemeral
   session; scenario 03 additionally owns an independently tokened secondary session.
 - Exit codes: scenario `0` = PASS, `3` = SKIP, other = FAIL; `run-all.sh` exits
   non-zero if any scenario FAILED.
-- **The provider-free live suite runs in CI.** After the static/Python/Rust jobs succeed,
-  `bash e2e/ci.sh` installs or reuses only the pinned SHA-verified Herdr 0.7.5 Linux x86_64 binary,
-  verifies protocol 17, and runs every standard scenario with `--require-all`. It never enables
+- **The provider-free live suite is a CI gate.** After the static/Python/Rust jobs succeed,
+  `bash e2e/ci.sh` installs or reuses only the pinned SHA-verified Herdr 0.8.0 Linux x86_64 binary,
+  verifies protocol 19, and runs every standard scenario with `--require-all`. It never enables
   the real-Pi or real-Claude opt-ins or propagates provider credentials. The wrapper preserves the
   suite's newly-created private artifact root, copies only that exact validated root into
   `e2e-artifacts/`, and the workflow uploads the evidence under `if: always()` for 30 days. The

--- a/e2e/10-archive-filter-title.sh
+++ b/e2e/10-archive-filter-title.sh
@@ -15,7 +15,7 @@ tab_json="$(e2e_herdr_mutate -- tab create --workspace "$WS_ID" --label archive-
 PANE_ID="$(printf '%s' "$tab_json" | jget pane_id)"
 [ -n "$PANE_ID" ] || fail "could not find pane for archive-filter tab"
 
-# Verified against Herdr 0.7.5 / protocol 17: `pane rename <pane_id> <label>`.
+# Verified against Herdr 0.8.0 / protocol 19: `pane rename <pane_id> <label>`.
 # The plugin variables reproduce the real pane context without linking a plugin
 # into anything except this disposable session/workspace.
 e2e_launch_tui "$PANE_ID" \

--- a/e2e/11-pi-harness.sh
+++ b/e2e/11-pi-harness.sh
@@ -157,6 +157,6 @@ assert x["session_id"] in os.path.basename(x["agent_session_path"])
 assert x["prompt_received_via_stdin"] is True and x["prompt_matches_run_snapshot"] is True
 assert x["prompt"] == show["runs"][-1]["prompt_snapshot"]
 PY
-ok "retry forked $SESSION1 -> $SESSION2 with the same P17 system-file/task split"
+ok "retry forked $SESSION1 -> $SESSION2 with the same managed system-file/task split"
 
 step "11-pi-harness: ALL CHECKS PASSED"

--- a/e2e/15-awaiting.sh
+++ b/e2e/15-awaiting.sh
@@ -2,22 +2,28 @@
 # 15-awaiting.sh — a live Herdr agent-status signal parks a run in `awaiting`;
 # explicit board confirmation then closes it as `done` in the same column.
 #
-# Herdr 0.7.5 / protocol 17 and Pi integration v6 were verified before
+# Herdr 0.8.0 / protocol 19 and Pi integration v8 were verified before
 # pinning the argv below:
 #   herdr pane report-agent <pane_id> --source ID --agent LABEL
 #     --state idle|working|blocked|unknown [--seq N]
 # `done` is an output AgentStatus but is NOT an accepted pane.report_agent input
-# state, so a supported CLI cannot inject it directly. This scenario emulates
-# the installed Pi integration's public report path (`source=herdr:pi`): prove
-# blocked/working events reach boardd, then report the integration's end-of-turn
-# idle state. On a managed agent.start pane Herdr derives the output status
-# `done`; the scenario asserts that live status and the board's `agent_done` arm.
+# state, so a supported CLI cannot inject it directly. This scenario uses the
+# checked-in managed Pi fixture to emulate the installed Pi integration's public
+# report path (`source=herdr:pi`): prove blocked/working events reach boardd,
+# then report the integration's end-of-turn idle state. On a managed agent.start
+# pane Herdr derives the output status `done`; the scenario asserts that live
+# status and the board's `agent_done` arm.
 set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lib.sh"
 
-# Keep the pane alive without board done. Cleanup closes its disposable workspace.
-export E2E_FAKE_ENV="FAKE_AGENT_SLEEP=300"
-
+# Keep the managed Pi pane alive without board done. Cleanup closes its
+# disposable workspace. The trap must be armed before fake-managed roots exist.
+trap e2e_cleanup EXIT
+e2e_enable_fake_pi
+# Herdr launches the managed fixture directly in the pane, so export the
+# hold before its owned server/workspace are created. This keeps it past the
+# awaiting confirmation while preserving the scenario's four-second timeout.
+export FAKE_PI_SLEEP=300
 e2e_init
 e2e_build
 e2e_isolate
@@ -41,9 +47,9 @@ step "Create an auto column with no on_success and a four-second test timeout"
 EXEC_ID="$(col_create '{"name":"Await Execute","trigger":"auto","timeout_minutes":4}')"
 [ -n "$EXEC_ID" ] || fail "could not create Await Execute column"
 
-step "Create and dispatch a held fake-agent card"
+step "Create and dispatch a held managed-Pi card"
 card_json="$("$BOARD_BIN" card new --title "Awaiting Card" \
-  --description "wait for human confirmation" --harness fake \
+  --description "wait for human confirmation" --harness pi --model p17/pi-model --effort low \
   --space-kind workspace --space-ref "$WS_ID" --json)"
 CARD_ID="$(printf '%s' "$card_json" | jget id)" || fail "could not parse card id"
 mut "board move $CARD_ID 'Await Execute' -> agent.start in $WS_ID"
@@ -61,6 +67,18 @@ for _ in $(seq 1 80); do
   sleep .1
 done
 [ -n "$PANE_ID" ] || { fail "run never recorded a live pane"; }
+AGENT_SESSION_PATH=""
+for _ in $(seq 1 80); do
+  AGENT_SESSION_PATH="$(hrpc pane.get "{\"pane_id\":\"$PANE_ID\"}" 2>/dev/null | python3 -c '
+import json, sys
+pane = json.load(sys.stdin).get("pane", {})
+session = pane.get("agent_session") or {}
+print(session.get("value") or "")
+' 2>/dev/null || true)"
+  [ -n "$AGENT_SESSION_PATH" ] && break
+  sleep .1
+done
+[ -n "$AGENT_SESSION_PATH" ] || fail "managed Pi session identity was not recorded"
 clock_ms() { python3 -c 'import time; print(time.time_ns() // 1_000_000)'; }
 RUN_STARTED_OBSERVED_MS="$(clock_ms)"
 ok "run started in live pane $PANE_ID"
@@ -76,13 +94,16 @@ wait_status() {
   fail "card status '$actual' (expected '$expected')"
 }
 
-# Use increasing authoritative-integration sequence numbers.
-SEQ="$(( $(date +%s) * 1000 ))"
+# Herdr orders integration reports by the authoritative source sequence. Start
+# at nanosecond scale so this scenario cannot be rejected as stale after an
+# earlier Pi v8 report on the same pane/source.
+SEQ="$(python3 -c 'import time; print(time.time_ns())')"
 report_agent() {
   local state="$1"
   SEQ=$((SEQ + 1))
   e2e_herdr_mutate -- pane report-agent "$PANE_ID" \
-    --source herdr:pi --agent pi --state "$state" --seq "$SEQ" >/dev/null
+    --source herdr:pi --agent pi --agent-session-path "$AGENT_SESSION_PATH" \
+    --state "$state" --seq "$SEQ" >/dev/null
 }
 
 step "Prove the live pane.agent_status_changed subscription reaches boardd"

--- a/e2e/16-managed-p17.sh
+++ b/e2e/16-managed-p17.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# 16-managed-p17.sh — protocol-17 managed Pi/Claude launch contract.
+# 16-managed-p17.sh — protocol-19/current managed Pi/Claude launch contract.
+# The p17 filename is retained as a historical catalog name for compatibility.
 #
 # The provider-free terminal fixtures validate the authoritative 0600 system
 # file, report session identity then idle lifecycle against HERDR_PANE_ID, emit
@@ -55,7 +56,7 @@ print(cwds[0])
 printf '  disposable workspace pane cwd: %s\n' "$MANAGED_PANE_CWD"
 EXEC_ID="$(col_create '{"name":"P17 Execute","trigger":"auto"}')"
 
-step "Dispatch fake Pi through managed protocol-17 launch"
+step "Dispatch fake Pi through managed protocol-19/current launch"
 pi_json="$("$BOARD_BIN" card new --title 'P17 Pi' --description $'description with spaces\nand a newline' \
   --harness pi --model p17/pi-model --effort low --space-kind workspace --space-ref "$WS_ID" --json)"
 PI_ID="$(printf '%s' "$pi_json" | jget id)"
@@ -110,7 +111,7 @@ assert not any("description with spaces" in arg or "herdr-board protocol" in arg
 print("  Pi: 0600 system file exact; readiness reported; exact agent.prompt captured on tty")
 PY
 
-step "Dispatch fake Claude through managed protocol-17 launch"
+step "Dispatch fake Claude through managed protocol-19/current launch"
 claude_json="$("$BOARD_BIN" card new --title 'P17 Claude' --description $'claude description with spaces\nand a newline' \
   --harness claude --model p17/claude-model --effort low --permission acceptEdits \
   --space-kind workspace --space-ref "$WS_ID" --json)"

--- a/e2e/17-configured-p17-runner.sh
+++ b/e2e/17-configured-p17-runner.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# 17-configured-p17-runner.sh — unmanaged protocol-17 harness contract.
+# 17-configured-p17-runner.sh — unmanaged protocol-19/current harness contract.
+# The p17 filename is retained as a historical catalog name for compatibility.
 # The disposable runner records startup/env evidence and never invokes a provider.
 set -euo pipefail
 . "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lib.sh"
@@ -62,7 +63,7 @@ print(cwds[0])
 printf '  disposable workspace pane cwd: %s\n' "$EXPECTED_PANE_CWD"
 EXEC_ID="$(col_create '{"name":"P17 Runner","trigger":"auto"}')"
 
-step "Dispatch configured harness through the protocol-17 runner bridge"
+step "Dispatch configured harness through the protocol-19/current runner bridge"
 card_json="$($BOARD_BIN card new --title 'P17 configured' \
   --description $'configured prompt with spaces\nand a newline' --harness p17-runner --effort low \
   --space-kind workspace --space-ref "$WS_ID" --json)"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,8 +12,8 @@ isolation/safety design, and the **how-to-write-a-scenario** guide, see
 every numbered scenario from **01 through 29** must appear here and in `run-all.sh`. The provider-free
 safe boundary is `fake-agent.sh`,
 `fake-bin/{pi,claude}`, and `test-harness.sh`; prompt/system-prompt contents are never logged.
-Scenario 21 is the active-run timer/event-refresh characterization. The complete catalog is run by
-the CI live gate after the cheaper static checks succeed.
+Scenario 21 is the active-run timer/event-refresh characterization. The CI live gate is configured to
+exercise the complete catalog after the cheaper static checks succeed.
 
 ## Use case ↔ scenario ↔ status
 
@@ -34,8 +34,8 @@ the CI live gate after the cheaper static checks succeed.
 | Canonical CLI `card run focus` and card-detail `o` focus one **selected** run of a two-run card: `o` on the older run (whose pane was reclaimed) is refused without closing the overlay, `o` on the newest one focuses its held pane and closes the real plugin overlay | `13-jump-to-pane.sh` | live |
 | A column `harness_override` (TUI select) drives a run via a config-defined harness; `harness.list` advertises config harnesses; effort/permission overrides flow into the run argv | `14-column-config.sh` | live |
 | Integration-style status reports on a live managed pane: blocked → working → end-of-turn idle (Herdr derives `done`) → `awaiting` (`agent_done`), timeout paused; `board done ok` → `done` in the same column | `15-awaiting.sh` | live |
-| Managed protocol-17 Pi + Claude: pane-first placement, exact 0600 system file, readiness/session reports, exact `agent.prompt` task delivery, and held layout | `16-managed-p17.sh` | live, checked-in fake `pi` + `claude`, zero provider cost |
-| Unmanaged protocol-17 configured harness: exact argv/multiline env/cwd/socket bridge through CLI-only `pane run`, held layout, explicit completion | `17-configured-p17-runner.sh` | live, temporary runner, zero provider cost |
+| Managed protocol-19/current Pi + Claude: pane-first placement, exact 0600 system file, readiness/session reports, exact `agent.prompt` task delivery, and held layout | `16-managed-p17.sh` | live, checked-in fake `pi` + `claude`, zero provider cost; historical filename |
+| Unmanaged protocol-19/current configured harness: exact argv/multiline env/cwd/socket bridge through CLI-only `pane run`, held layout, explicit completion | `17-configured-p17-runner.sh` | live, temporary runner, zero provider cost; historical filename |
 | Nullable omitted/null/value semantics, merged capability validation, atomic rejection, and provider-free dispatch after clears | `18-nullable-clear.sh` | live, zero provider cost |
 | Daemon starts before Herdr; late supervisor connection observes one exact pane exit | `19-daemon-before-herdr.sh` | live, zero provider cost |
 | Proxy outage/restart preserves `Unknown` and timeout budget; reconnect snapshot repairs an event gap once | `20-herdr-recovery.sh` | live, zero provider cost |
@@ -51,10 +51,10 @@ the CI live gate after the cheaper static checks succeed.
 
 ### How the live scenario produces Herdr `done`
 
-Herdr 0.7.5 / protocol 17 exposes `done` as an output `AgentStatus`, but its
+Herdr 0.8.0 / protocol 19 exposes `done` as an output `AgentStatus`, but its
 supported integration input, `pane.report_agent`, accepts only
 `idle|working|blocked|unknown` (`herdr pane report-agent --help` and `herdr api
-schema --json`). Pi integration v6 uses that API with `source=herdr:pi` and
+schema --json`). Pi integration v8 uses that API with `source=herdr:pi` and
 reports `working`/`blocked`/`idle`; there is no supported `herdr ... --state
 done` argv to inject. On a managed `agent.start` pane, Herdr
 derives the output status `done` from the integration's end-of-turn idle report.
@@ -72,7 +72,7 @@ require the sample because a fast provider response can finish between polls.
 
 ## Prerequisites
 
-- **Exactly Herdr 0.7.5 / socket protocol 17**, `python3`, and Bash ≥4. The provider-free standard suite supports Linux and macOS; `run-all.sh` resolves absolute Herdr and Bash paths before applying its controlled `PATH`. Every scenario checks both `herdr --version` and the ephemeral server's `ping` before dispatch; protocol 16 and unknown/future protocols are rejected. Your real sessions are never
+- **Exactly Herdr 0.8.0 / socket protocol 19**, `python3`, and Bash ≥4. The provider-free standard suite supports Linux and macOS; `run-all.sh` resolves absolute Herdr and Bash paths before applying its controlled `PATH`. Every scenario checks both `herdr --version` and the ephemeral server's `ping` before dispatch; older and unknown/future protocols are rejected. Your real sessions are never
   touched — the suite boots its own **ephemeral** Herdr server/session.
 - `cargo` on `PATH` — `run-all.sh` builds the release `board` binary once
   (`scripts/build.sh`); scenarios reuse it.
@@ -119,8 +119,9 @@ unmarked, or out-of-root paths. Named-session sockets must be at most 92 bytes, 
 15 bytes below Linux's 108-byte AF_UNIX limit. The board DB/socket/config and scope remain under the separate
 short `/tmp/hb-e2e.XXXXXX` isolated root. `TMPDIR` is pinned to that exact marker-owned root, so
 generated configured-harness scripts remain contained even if asynchronous `pane run` never opens
-their normal self-removing script. The forced-build standard suite passes
-scenarios 01–29 without provider calls. Scenarios 18–29 use only the configured or managed
+their normal self-removing script. The forced-build standard suite is configured and required to exercise
+scenarios 01–29 without provider calls; this is a coverage requirement, not a claim that a live run
+has completed. Scenarios 18–29 use only the configured or managed
 fake harnesses and never record prompt or system-prompt bodies.
 
 ## Running
@@ -146,12 +147,12 @@ Exit codes: scenario `0` = PASS, `3` = SKIP (missing precondition), anything els
 FAIL. `run-all.sh` captures the scenario side of its logging pipeline via `PIPESTATUS[0]` and exits
 non-zero if any scenario failed; `--require-all` also converts SKIP to failure. Per-scenario logs,
 status, exact owned session name, and sanitized manifest events are written below the run artifact root. In CI,
-`e2e/ci.sh` downloads or reuses the exact SHA-verified Herdr 0.7.5 Linux x86_64 asset, verifies
-protocol 17, invokes `run-all.sh --require-all`, and validates the one private artifact root printed
+`e2e/ci.sh` downloads or reuses the exact SHA-verified Herdr 0.8.0 Linux x86_64 asset, verifies
+protocol 19, invokes `run-all.sh --require-all`, and validates the one private artifact root printed
 by that invocation before copying it to the deterministic `e2e-artifacts/` upload directory. Runner
 and scenario evidence is uploaded even on failure and retained for 30 days. The same wrapper is the
 local CI equivalent; it never runs either real-provider smoke. The real-Claude smoke stages only completed onboarding/theme,
-exact workspace trust, the installed Herdr hook, credentials, and approved
+exact workspace trust, the installed current Claude integration v7 hook, credentials, and approved
 `remote-settings.json`, so startup dialogs cannot consume `agent.prompt`; it copies no broad
 personal Claude state. Its intended contract is one authorized attempt with no retry or fallback. The real-Claude smoke retains its independent Linux `/proc` identity implementation and is outside the portable standard-suite guarantee.
 
@@ -162,10 +163,10 @@ personal Claude state. Its intended contract is one authorized attempt with no r
 | `lib.sh` | Shared harness sourced by every scenario: logging, isolated stack, cleanup registry, daemon + workspace helpers, pollers (`wait_ok`/`wait_runs`), JSON/`hrpc`/`brpc`/`col_create` helpers. |
 | `test-harness.sh` | Deterministic Linux/macOS shell safety checks for signed ownership tokens, key scrubbing, every exact-resource ledger kind, replacement, malformed record, and standalone parity; starts no Herdr resources. |
 | `process_identity.py` | Standard-library platform backend: Linux `/proc`; Darwin `libproc`/`KERN_PROCARGS2`; exact argv/start/executable capture and HMAC verification. |
-| `fake-agent.sh` | Config-defined fake harness used by scenarios 01–10 and 13–15. |
+| `fake-agent.sh` | Config-defined/shared fake harness used by provider-free configured-harness scenarios. |
 | `fake-bin/pi` / `fake-bin/claude` | Executables exposed only inside disposable standard-E2E Herdr servers/workspaces. They emulate interactive readiness/session reports, require the exact `agent.prompt` bytes before completion, record evidence under isolated temp, and never modify installed tools or call a provider. |
-| `16-managed-p17.sh` | Managed pane-first Pi/Claude protocol-17 launch and no-provider boundary. |
-| `17-configured-p17-runner.sh` | Unmanaged configured-command `pane run` bridge and exact argv/env evidence. |
+| `16-managed-p17.sh` | Managed pane-first Pi/Claude protocol-19/current launch and no-provider boundary (historical filename). |
+| `17-configured-p17-runner.sh` | Unmanaged protocol-19/current configured-command `pane run` bridge and exact argv/env evidence (historical filename). |
 | `18-nullable-clear.sh` | Nullable clearing, merged validation, atomic rejection, and post-clear configured dispatch; no prompt-body logging. |
 | `19-daemon-before-herdr.sh` | Late Herdr availability and exact pane-exit observation. |
 | `20-herdr-recovery.sh` / `herdr-proxy.py` | Controllable owned proxy for conservative outage/restart, dropped-stream recovery, and typed `agent_pane_busy` fault injection. |
@@ -178,8 +179,8 @@ personal Claude state. Its intended contract is one authorized attempt with no r
 | `27-rescue-dead-pane.sh` | `run.focus` rescue of a run whose pane is gone: resume-mode relaunch of the managed fixture with the recorded conversation id (no re-sent task), idempotent second focus, a byte-for-byte unchanged `runs` row, and an explicit non-destructive refusal for an unresumable run; provider-free. |
 | `28-pi-effort-catalog.sh` | Auth-scoped Pi file discovery plus exact board-RPC and real-TUI proof of sparse/null thinking-level semantics; never starts Pi or submits a card. |
 | `29-diagnostic-logs.sh` | Daily NDJSON validity, private modes, exact 30-day retention boundary, board/Herdr completion metadata, sentinel absence, and exact cleanup. |
-| `real-pi-smoke.sh` | Fail-closed real-provider poem smoke. Detects Pi's runtime default model, passes low thinking, isolates board/Pi session output under `/tmp`, verifies integration/WezTerm, poem/comments/argv/git/settings, and supports keep mode for visual audit. Not in `run-all.sh`. |
-| `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages only completed onboarding/theme, exact workspace trust, the installed Herdr hook, credentials, and approved remote-settings bytes under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied. Independently identity-gates the daemon and Herdr server and cleans exact resources. Not in `run-all.sh`. |
+| `real-pi-smoke.sh` | Fail-closed real-provider poem smoke. Detects Pi's runtime default model, passes low thinking, isolates board/Pi session output under `/tmp`, verifies the current Pi integration v8/WezTerm, poem/comments/argv/git/settings, and supports keep mode for visual audit. Not in `run-all.sh`. |
+| `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages only completed onboarding/theme, exact workspace trust, the installed current Claude integration v7 hook, credentials, and approved remote-settings bytes under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied. Independently identity-gates the daemon and Herdr server and cleans exact resources. Not in `run-all.sh`. |
 | `hrpc.py` | One-shot raw **herdr** socket RPC (honours `HERDR_SOCKET_PATH`) for structural asserts (`tab.list`/`pane.list`/`pane.layout`). |
 | `12-cwd-boards.sh` | Scoped board identity/isolation plus real TUI title/picker. |
 | `13-jump-to-pane.sh` | Canonical CLI and same-session TUI focus of a deliberately selected run through a real plugin overlay. |

--- a/e2e/ci.sh
+++ b/e2e/ci.sh
@@ -9,10 +9,10 @@ rm -rf "$EXPORT_DIR"
 mkdir -m 700 "$EXPORT_DIR"
 exec > >(tee "$EXPORT_DIR/runner.log") 2>&1
 
-HERDR_VERSION=0.7.5
-HERDR_PROTOCOL=17
-HERDR_URL=https://github.com/herdrdev/herdr/releases/download/v0.7.5/herdr-linux-x86_64
-HERDR_SHA256=3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253
+HERDR_VERSION=0.8.0
+HERDR_PROTOCOL=19
+HERDR_URL=https://github.com/herdrdev/herdr/releases/download/v0.8.0/herdr-linux-x86_64
+HERDR_SHA256=b872ea7e40fa2cb17e857ac9b62b1bf26db7b403c622f5d2f3f5b35f6e9acd28
 CACHE_DIR="${HERDR_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/herdr-board/herdr-$HERDR_VERSION-linux-x86_64}"
 HERDR_BIN="$CACHE_DIR/herdr"
 mkdir -p "$CACHE_DIR"
@@ -48,12 +48,12 @@ actual_version="$("$HERDR_BIN" --version)"
   exit 1
 }
 "$HERDR_BIN" api schema --json | python3 -c \
-  'import json,sys; p=json.load(sys.stdin).get("protocol"); print(f"Herdr socket protocol: {p}"); raise SystemExit(p != 17)'
+  'import json,sys; p=json.load(sys.stdin).get("protocol"); expected=int(sys.argv[1]); print(f"Herdr socket protocol: {p}"); raise SystemExit(p != expected)' "$HERDR_PROTOCOL"
 echo "Pinned Herdr SHA-256: $HERDR_SHA256"
 
 export HERDR_BIN_PATH="$HERDR_BIN"
 set +e
-"$REPO_ROOT/e2e/run-all.sh" --require-all 2>&1 | tee "$EXPORT_DIR/suite.log"
+E2E_FORCE_BUILD=1 "$REPO_ROOT/e2e/run-all.sh" --require-all 2>&1 | tee "$EXPORT_DIR/suite.log"
 suite_status=${PIPESTATUS[0]}
 set -e
 printf '%s\n' "$suite_status" >"$EXPORT_DIR/suite.status"

--- a/e2e/fake-agent.sh
+++ b/e2e/fake-agent.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # fake-agent.sh — the fake harness the live e2e scenarios dispatch instead of a
-# real coding agent. It receives the board env the daemon injects at agent.start
+# real coding agent. It receives the board env the daemon injects at launch
 # (BOARD_PROMPT / BOARD_CARD_ID / BOARD_RUN_ID / BOARD_SOCKET) and the built
 # `board` binary via BOARD_BIN (passed through the config argv env-wrapper, since
 # herdr panes do NOT inherit workspace-level env). It reports back through the

--- a/e2e/fake-bin/claude
+++ b/e2e/fake-bin/claude
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Hermetic, no-provider Claude stand-in for protocol-17 managed launches.
+# Hermetic, no-provider Claude stand-in for protocol-19 managed launches.
 # The card prompt is forbidden in startup argv and must arrive through the
 # interactive terminal only after the system-prompt file has been consumed.
 set -euo pipefail
@@ -51,7 +51,7 @@ while (($#)); do
       [ -z "$system_file" ] || { echo 'fake claude: duplicate system-prompt file' >&2; exit 2; }
       system_file="$2"; shift 2 ;;
     --append-system-prompt|--)
-      echo "fake claude: invalid protocol-17 startup option: $1" >&2; exit 2 ;;
+      echo "fake claude: invalid protocol-19 startup option: $1" >&2; exit 2 ;;
     -*) echo "fake claude: unexpected startup option: $1" >&2; exit 2 ;;
     *) echo "fake claude: card prompt leaked into startup argv: $1" >&2; exit 2 ;;
   esac
@@ -132,6 +132,6 @@ fi
 FAKE_MANAGED_KIND=claude \
   python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/managed-terminal-shim.py" "$record"
 sleep "${FAKE_CLAUDE_SLEEP:-1.5}"
-"${BOARD_BIN:?BOARD_BIN required}" comment "fake claude: protocol-17 system file and agent.prompt validated"
+"${BOARD_BIN:?BOARD_BIN required}" comment "fake claude: protocol-19 system file and agent.prompt validated"
 "$BOARD_BIN" done --outcome ok
 sleep "${FAKE_MANAGED_HOLD:-60}"

--- a/e2e/fake-bin/managed-terminal-shim.py
+++ b/e2e/fake-bin/managed-terminal-shim.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""No-provider terminal shim for protocol-17 managed-agent E2E fixtures.
+"""No-provider terminal shim for protocol-19 managed-agent E2E fixtures.
 
 The real Herdr `agent.prompt` call writes the card task to the managed process's
 terminal.  This helper keeps that terminal interactive, captures the bytes from

--- a/e2e/fake-bin/pi
+++ b/e2e/fake-bin/pi
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Hermetic, no-provider Pi stand-in for protocol-17 managed launches.
+# Hermetic, no-provider Pi stand-in for protocol-19 managed launches.
 # It validates the authoritative startup-only system-prompt file, rejects card
 # prompt material in argv, reports through HERDR_PANE_ID, and then blocks on its
 # interactive tty until Herdr's agent.prompt delivers the card task on stdin.
@@ -46,7 +46,7 @@ while (($#)); do
       [ -z "$system_file" ] || { echo 'fake pi: duplicate --append-system-prompt' >&2; exit 2; }
       system_file="$2"; shift 2 ;;
     --append-system-prompt-file|--)
-      echo "fake pi: invalid protocol-17 startup option: $1" >&2; exit 2 ;;
+      echo "fake pi: invalid protocol-19 startup option: $1" >&2; exit 2 ;;
     -*) echo "fake pi: unexpected startup option: $1" >&2; exit 2 ;;
     *) echo "fake pi: card prompt leaked into startup argv: $1" >&2; exit 2 ;;
   esac
@@ -133,6 +133,6 @@ FAKE_MANAGED_KIND=pi \
 # Spawn registration commits only after readiness polling + agent.prompt return.
 # Keep the pre-done delay, then retain the pane for bounded structural asserts.
 sleep "${FAKE_PI_SLEEP:-1.5}"
-"${BOARD_BIN:?BOARD_BIN required}" comment "fake pi: protocol-17 system file and agent.prompt validated"
+"${BOARD_BIN:?BOARD_BIN required}" comment "fake pi: protocol-19 system file and agent.prompt validated"
 "$BOARD_BIN" done --outcome ok
 sleep "${FAKE_MANAGED_HOLD:-60}"

--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -274,26 +274,26 @@ e2e_require() {
   [ -f "$HRPC" ] || fail "hrpc.py missing at $HRPC"
 }
 
-# Protocol-17 preflight. Keep this exact and early: no scenario may dispatch
-# against a protocol-16 or unknown/future Herdr, since the wire launch contract
-# is intentionally not backward compatible. The ping evidence is printed so a
-# RED run records both the CLI version and the socket's negotiated protocol.
+# Protocol-19 preflight. Keep this exact and early: no scenario may dispatch
+# against an older or unknown/future Herdr, since the wire launch contract is
+# intentionally not backward compatible. The ping evidence is printed so a
+# failed run records both the CLI version and the socket's negotiated protocol.
 e2e_protocol_preflight() {
   local version ping protocol reported_version
   version="$($HERDR_BIN --version 2>&1 || true)"
   printf '  Herdr preflight: %s\n' "$version"
-  [ "$version" = "herdr 0.7.5" ] \
-    || fail "requires exactly Herdr 0.7.5 (got: $version)"
+  [ "$version" = "herdr 0.8.0" ] \
+    || fail "requires exactly Herdr 0.8.0 (got: $version)"
   ping="$(hrpc ping '{}')" \
     || fail "Herdr protocol preflight ping failed"
   protocol="$(printf '%s' "$ping" | python3 -c 'import json,sys; print(json.load(sys.stdin)["protocol"])' 2>/dev/null || true)"
   reported_version="$(printf '%s' "$ping" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version", ""))' 2>/dev/null || true)"
   printf '  Herdr ping evidence: version=%s protocol=%s payload=%s\n' \
     "$reported_version" "$protocol" "$ping"
-  [ "$reported_version" = "0.7.5" ] \
-    || fail "requires Herdr 0.7.5 from ping (got: $reported_version)"
-  [ "$protocol" = "17" ] \
-    || fail "requires Herdr protocol 17 (got: ${protocol:-missing})"
+  [ "$reported_version" = "0.8.0" ] \
+    || fail "requires Herdr 0.8.0 from ping (got: $reported_version)"
+  [ "$protocol" = "19" ] \
+    || fail "requires Herdr protocol 19 (got: ${protocol:-missing})"
 }
 
 # e2e_build — build the release binary if absent (or E2E_FORCE_BUILD=1). cargo is
@@ -438,7 +438,7 @@ e2e_board_herdr_mutate() {
 # forces the width ratatui sees.
 #
 # Two empirical constraints found while wiring this up, both against real
-# Herdr 0.7.5 panes (see the task write-up for the full A/B):
+# Herdr 0.8.0 panes (see the task write-up for the full A/B):
 #
 # 1. COLUMNS-ONLY, never `rows`. A pane's row count is Herdr's own fixed
 #    internal bookkeeping (visible, unchanging, via `pane.list`'s
@@ -1569,7 +1569,7 @@ e2e_isolate() {
 }
 
 # e2e_write_config <path> — write the isolated daemon config. The fake harness
-# is a configured (unmanaged) command launched through the protocol-17 pane-run
+# is a configured (unmanaged) command launched through the protocol-19 pane-run
 # bridge, not `agent.start`. Its `env` argv wrapper pins BOARD_BIN independently
 # of pane/workspace environment and carries optional fake-agent knobs from
 # E2E_FAKE_ENV (a space-separated list of KEY=VAL, e.g.

--- a/e2e/real-claude-haiku-smoke.sh
+++ b/e2e/real-claude-haiku-smoke.sh
@@ -301,11 +301,11 @@ if declare -F claude >/dev/null 2>&1; then
 fi
 
 HERDR_VERSION="$($HERDR_BIN --version 2>&1)"
-[ "$HERDR_VERSION" = "herdr 0.7.5" ] \
-  || fail "requires exactly Herdr 0.7.5 (got: $HERDR_VERSION)"
+[ "$HERDR_VERSION" = "herdr 0.8.0" ] \
+  || fail "requires exactly Herdr 0.8.0 (got: $HERDR_VERSION)"
 HERDR_SCHEMA="$($HERDR_BIN api schema --json)"
-printf '%s' "$HERDR_SCHEMA" | jq -e '.protocol == 17' >/dev/null \
-  || fail "requires Herdr schema protocol 17"
+printf '%s' "$HERDR_SCHEMA" | jq -e '.protocol == 19' >/dev/null \
+  || fail "requires Herdr schema protocol 19"
 CLAUDE_VERSION="$($CLAUDE_BIN --version 2>&1)"
 INTEGRATION_LINE="$($HERDR_BIN integration status | awk '$1 == "claude:" {print; exit}')"
 printf '%s\n' "$INTEGRATION_LINE" \
@@ -361,7 +361,7 @@ printf 'logged_in=yes\nconfig=staged\n' >"$EVIDENCE/auth-preflight.txt"
 
 {
   printf 'herdr_version=%s\n' "$HERDR_VERSION"
-  printf 'herdr_schema_protocol=17\n'
+  printf 'herdr_schema_protocol=19\n'
   printf 'claude_version=%s\n' "$CLAUDE_VERSION"
   printf 'claude_binary=%s\n' "$CLAUDE_BIN"
   printf 'claude_integration=%s\n' "$INTEGRATION_LINE"
@@ -373,8 +373,8 @@ printf '%s\n' "$INTEGRATION_LINE" >"$EVIDENCE/integration.txt"
 # Build and test this checkout's candidate in an isolated target. --locked
 # prevents dependency resolution from changing the checkout.
 CARGO_TARGET_DIR="$TARGET" "$CARGO_BIN" test --locked \
-  --manifest-path "$ROOT/Cargo.toml" -p board-core --test protocol17_spawn \
-  >"$EVIDENCE/protocol17-test.log" 2>&1
+  --manifest-path "$ROOT/Cargo.toml" -p board-core --test managed_spawn \
+  >"$EVIDENCE/protocol19-test.log" 2>&1
 CARGO_TARGET_DIR="$TARGET" "$CARGO_BIN" build --locked --release \
   --manifest-path "$ROOT/Cargo.toml" -p board-cli \
   >"$EVIDENCE/candidate-build.log" 2>&1
@@ -447,8 +447,8 @@ e2e_process_identity_verify "$SERVER_PID" "$SERVER_IDENTITY" \
   || fail "disposable Herdr server failed identity check before socket publication"
 write_state
 PING="$(HERDR_SOCKET_PATH="$SOCK" python3 "$ROOT/e2e/hrpc.py" ping '{}')"
-printf '%s' "$PING" | jq -e '.version == "0.7.5" and .protocol == 17' >/dev/null \
-  || fail "disposable session ping is not Herdr 0.7.5 protocol 17"
+printf '%s' "$PING" | jq -e '.version == "0.8.0" and .protocol == 19' >/dev/null \
+  || fail "disposable session ping is not Herdr 0.8.0 protocol 19"
 printf '%s\n' "$PING" >"$EVIDENCE/herdr-ping.json"
 
 printf 'HERDR MUTATION: create one disposable workspace in %s\n' "$SESSION"

--- a/e2e/real-pi-smoke.sh
+++ b/e2e/real-pi-smoke.sh
@@ -27,9 +27,16 @@ DEFAULT_THINKING="$(jq -er '.defaultThinkingLevel' "$SETTINGS")"
 PI_VERSION="$(pi --version)"
 MODEL_ROW="$(pi --list-models "$DEFAULT_MODEL" | awk -v p="$PROVIDER" -v m="$MODEL" '$1==p && $2==m {print; found=1} END{if(!found) exit 1}')" \
   || { echo "real-pi-smoke: default model $DEFAULT_MODEL not in pi --list-models" >&2; exit 2; }
-INTEGRATION="$("$HERDR_BIN" integration status | awk '$1=="pi:" {print}')"
-printf '%s\n' "$INTEGRATION" | grep -q 'current' \
-  || { echo "real-pi-smoke: Pi Herdr integration is not current: $INTEGRATION" >&2; exit 2; }
+HERDR_VERSION="$("$HERDR_BIN" --version 2>&1)"
+[ "$HERDR_VERSION" = "herdr 0.8.0" ] \
+  || { echo "real-pi-smoke: requires exactly Herdr 0.8.0 (got: $HERDR_VERSION)" >&2; exit 2; }
+HERDR_SCHEMA="$("$HERDR_BIN" api schema --json)"
+printf '%s' "$HERDR_SCHEMA" | jq -e '.protocol == 19' >/dev/null \
+  || { echo "real-pi-smoke: requires Herdr schema protocol 19" >&2; exit 2; }
+INTEGRATION="$("$HERDR_BIN" integration status | awk '$1=="pi:" {print; exit}')"
+printf '%s\n' "$INTEGRATION" \
+  | grep -Eq '^pi:[[:space:]]+current[[:space:]]+\(v8\)([[:space:]]+\(.+\))?$' \
+  || { echo "real-pi-smoke: Pi Herdr integration must be exactly current v8 (got: ${INTEGRATION:-missing})" >&2; exit 2; }
 
 RUN_ID="$$"
 SESSION="hb-pi-$RUN_ID"

--- a/e2e/test-harness.sh
+++ b/e2e/test-harness.sh
@@ -257,12 +257,22 @@ wait "$bad_server" 2>/dev/null || true
   [ "$E2E_SESSION_IDENTITY" = standalone-token ]
 )
 
-# Cleanup traps precede fake-managed root creation in both managed scenarios.
-python3 - "$E2E_LIB_DIR/11-pi-harness.sh" "$E2E_LIB_DIR/16-managed-p17.sh" <<'PY'
+# Cleanup traps precede fake-managed root creation in every managed fake-Pi
+# scenario, and fake-Pi setup precedes its e2e_init/e2e_boot call.
+python3 - "$E2E_LIB_DIR" <<'PY'
+import pathlib
+import re
 import sys
-for path in sys.argv[1:]:
-    text=open(path,encoding='utf-8').read()
-    assert text.index('trap e2e_cleanup EXIT') < text.index('e2e_enable_fake_pi')
+
+root = pathlib.Path(sys.argv[1])
+for path in sorted(root.glob('[0-9][0-9]-*.sh')):
+    text = path.read_text(encoding='utf-8')
+    if 'e2e_enable_fake_pi' not in text:
+        continue
+    enable = re.search(r'(?m)^\s*e2e_enable_fake_pi\s*$', text)
+    init = re.search(r'(?m)^\s*(?:e2e_init|e2e_boot)(?:\s|$)', text)
+    assert enable and init and enable.start() < init.start(), path
+    assert text.index('trap e2e_cleanup EXIT') < enable.start(), path
 PY
 
 # Spawn cleanup is armed/deferred before each race-prone full registration;

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -5,14 +5,14 @@
 # a real AI coding agent into a visible herdr pane. This manifest wires the board
 # TUI into herdr as an overlay pane plus a keybindable action to summon it.
 #
-# Field reference validated against `herdr plugin` in Herdr 0.7.5. The manifest
-# enforces the install-time version floor; runtime also requires exactly 0.7.5
-# and rejects every socket protocol other than 17.
+# Field reference validated against `herdr plugin` in Herdr 0.8.0. The manifest
+# enforces the install-time version floor; runtime also requires exactly 0.8.0
+# and rejects every socket protocol other than 19.
 id = "herdr-board"
 name = "Herdr Board"
 version = "0.10.0"
 description = "Kanban board for AI coding agents: cards are prompts, columns are pipeline stages; moving a card dispatches an agent into a herdr pane."
-min_herdr_version = "0.7.5"
+min_herdr_version = "0.8.0"
 platforms = ["linux", "macos"]
 
 # Build the `board` binary at install time (idempotent: cargo no-ops when nothing
@@ -27,7 +27,7 @@ command = ["./scripts/build.sh"]
 command = ["./scripts/install-cli.sh"]
 
 # The kanban TUI, spawned by Herdr in an overlay pane. `overlay` is accepted by
-# Herdr 0.7.5 / protocol 17. The same binary auto-starts the boardd daemon if it
+# Herdr 0.8.0 / protocol 19. The same binary auto-starts the boardd daemon if it
 # is not already running.
 [[panes]]
 id = "board"

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -136,7 +136,8 @@ class DocumentationContractTests(unittest.TestCase):
         for surface, expected in (
             ("Board socket", "v1;"),
             ("SQLite", "schema v13"),
-            ("Herdr client", "0.7.5 / socket protocol 17"),
+            ("Herdr client", "0.8.0 / socket protocol 19"),
+            ("Herdr integrations", "Pi v8; Claude v7"),
             ("Runtime launch", "daemon-owned"),
             ("Config", "typed `RootConfig`"),
             ("Live catalog", f"scenarios 01–{last_number}"),
@@ -379,10 +380,10 @@ class DocumentationContractTests(unittest.TestCase):
         fixture = ROOT / "crates/board-herdr/tests/fixtures/schema.json"
         schema = json.loads(fixture.read_text(encoding="utf-8"))
         hint = (
-            "regenerate with `herdr api schema --json` from exactly Herdr 0.7.5 "
+            "regenerate with `herdr api schema --json` from exactly Herdr 0.8.0 "
             "and re-verify docs/herdr.md before changing this"
         )
-        self.assertEqual(schema.get("protocol"), 17, f"protocol must stay 17 — {hint}")
+        self.assertEqual(schema.get("protocol"), 19, f"protocol must stay 19 — {hint}")
         self.assertEqual(schema.get("schema_version"), 1, hint)
 
         methods = {

--- a/scripts/tests/test_e2e_ci.py
+++ b/scripts/tests/test_e2e_ci.py
@@ -7,6 +7,15 @@ from pathlib import Path
 from _support import REPO_ROOT as ROOT
 
 
+HERDR_VERSION = "0.8.0"
+HERDR_PROTOCOL = 19
+HERDR_SHA256 = "b872ea7e40fa2cb17e857ac9b62b1bf26db7b403c622f5d2f3f5b35f6e9acd28"
+HERDR_URL = (
+    "https://github.com/herdrdev/herdr/releases/download/"
+    f"v{HERDR_VERSION}/herdr-linux-x86_64"
+)
+
+
 class LiveE2ECIContractTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -17,6 +26,11 @@ class LiveE2ECIContractTests(unittest.TestCase):
             if cls.wrapper_path.exists()
             else ""
         )
+        cls.lib = (ROOT / "e2e/lib.sh").read_text(encoding="utf-8")
+        cls.real_claude = (ROOT / "e2e/real-claude-haiku-smoke.sh").read_text(
+            encoding="utf-8"
+        )
+        cls.real_pi = (ROOT / "e2e/real-pi-smoke.sh").read_text(encoding="utf-8")
 
     def test_workflow_has_one_bounded_read_only_live_job_after_fast_gates(self) -> None:
         self.assertEqual(len(re.findall(r"^  live-e2e:\s*$", self.workflow, re.M)), 1)
@@ -44,23 +58,147 @@ class LiveE2ECIContractTests(unittest.TestCase):
     def test_workflow_caches_exact_pinned_binary_without_credentials(self) -> None:
         job = self.workflow.split("  live-e2e:", 1)[1]
         self.assertIn("uses: actions/cache@v4", job)
-        self.assertIn("0.7.5", job)
+        self.assertIn(f"Cache Herdr {HERDR_VERSION}", job)
+        self.assertIn(f"herdr-board-{HERDR_VERSION}-linux-x86_64", job)
         self.assertIn("x86_64", job)
-        self.assertIn("3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253", job)
-        for forbidden in ("HERDR_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "E2E_REAL_PI"):
+        self.assertIn(HERDR_SHA256, job)
+        self.assertIn(
+            f"key: herdr-${{{{ runner.os }}}}-x86_64-{HERDR_VERSION}-{HERDR_SHA256}",
+            job,
+        )
+        for forbidden in (
+            "HERDR_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "E2E_REAL_PI",
+            "0.7.5",
+            "protocol 17",
+            "3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253",
+        ):
             self.assertNotIn(forbidden, job)
 
     def test_wrapper_pins_and_verifies_supply_chain_and_protocol(self) -> None:
         self.assertTrue(self.wrapper_path.is_file())
         self.assertIn("set -euo pipefail", self.wrapper)
         self.assertIn("umask 077", self.wrapper)
-        self.assertIn("https://github.com/herdrdev/herdr/releases/download/v0.7.5/herdr-linux-x86_64", self.wrapper)
-        self.assertIn("3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253", self.wrapper)
+        self.assertIn(HERDR_URL, self.wrapper)
+        self.assertIn(HERDR_SHA256, self.wrapper)
         self.assertIn('"$HERDR_BIN" --version', self.wrapper)
-        self.assertIn("HERDR_VERSION=0.7.5", self.wrapper)
+        self.assertIn(f"HERDR_VERSION={HERDR_VERSION}", self.wrapper)
+        self.assertIn(f"HERDR_PROTOCOL={HERDR_PROTOCOL}", self.wrapper)
         self.assertIn("protocol", self.wrapper)
-        self.assertIn("17", self.wrapper)
         self.assertIn('"$REPO_ROOT/e2e/run-all.sh" --require-all', self.wrapper)
+        self.assertNotIn("v0.7.5", self.wrapper)
+        self.assertNotIn("protocol 17", self.wrapper)
+        self.assertNotIn(
+            "3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253",
+            self.wrapper,
+        )
+
+    def test_plugin_manifest_pins_exact_minimum_herdr_version(self) -> None:
+        manifest = (ROOT / "herdr-plugin.toml").read_text(encoding="utf-8")
+        self.assertEqual(
+            re.findall(r'(?m)^min_herdr_version = "([^"]+)"$', manifest),
+            [HERDR_VERSION],
+        )
+
+    def test_wrapper_forces_one_fresh_release_build_before_scenarios(self) -> None:
+        command = (
+            'E2E_FORCE_BUILD=1 "$REPO_ROOT/e2e/run-all.sh" --require-all '
+            '2>&1 | tee "$EXPORT_DIR/suite.log"'
+        )
+        self.assertEqual(self.wrapper.count(command), 1)
+
+    def test_e2e_preflights_and_real_claude_pin_the_same_exact_contract(self) -> None:
+        self.assertIn(f'[ "$version" = "herdr {HERDR_VERSION}" ]', self.lib)
+        self.assertIn(f'[ "$reported_version" = "{HERDR_VERSION}" ]', self.lib)
+        self.assertIn(f'[ "$protocol" = "{HERDR_PROTOCOL}" ]', self.lib)
+        self.assertIn(
+            f'[ "$HERDR_VERSION" = "herdr {HERDR_VERSION}" ]', self.real_claude
+        )
+        self.assertIn(f".protocol == {HERDR_PROTOCOL}", self.real_claude)
+        self.assertIn(f"herdr_schema_protocol={HERDR_PROTOCOL}", self.real_claude)
+        self.assertIn(
+            f'.version == "{HERDR_VERSION}" and .protocol == {HERDR_PROTOCOL}',
+            self.real_claude,
+        )
+        self.assertIn(
+            r"claude:[[:space:]]+current[[:space:]]+\(v7\)",
+            self.real_claude,
+        )
+        for source in (self.lib, self.real_claude):
+            self.assertNotIn("0.7.5", source)
+            self.assertNotIn("protocol 17", source)
+
+    def test_real_pi_pins_exact_herdr_protocol_and_pi_v8(self) -> None:
+        source = self.real_pi
+        self.assertIn(f'[ "$HERDR_VERSION" = "herdr {HERDR_VERSION}" ]', source)
+        self.assertIn(f".protocol == {HERDR_PROTOCOL}", source)
+        self.assertIn(
+            "grep -Eq '^pi:[[:space:]]+current[[:space:]]+\\(v8\\)([[:space:]]+\\(.+\\))?$'",
+            source,
+        )
+        self.assertNotIn("grep -q 'current'", source)
+
+    def test_awaiting_scenario_uses_nanosecond_report_sequences(self) -> None:
+        awaiting = (ROOT / "e2e/15-awaiting.sh").read_text(encoding="utf-8")
+        self.assertIn(
+            "SEQ=\"$(python3 -c 'import time; print(time.time_ns())')\"",
+            awaiting,
+        )
+        self.assertNotIn("date +%s", awaiting)
+        self.assertIn("--harness pi", awaiting)
+        self.assertIn('--agent-session-path "$AGENT_SESSION_PATH"', awaiting)
+
+    def test_active_e2e_descriptions_use_current_protocol_and_integrations(self) -> None:
+        readme = (ROOT / "e2e/README.md").read_text(encoding="utf-8")
+        managed = (ROOT / "e2e/16-managed-p17.sh").read_text(encoding="utf-8")
+        configured = (ROOT / "e2e/17-configured-p17-runner.sh").read_text(
+            encoding="utf-8"
+        )
+        awaiting = (ROOT / "e2e/15-awaiting.sh").read_text(encoding="utf-8")
+        fake_agent = (ROOT / "e2e/fake-agent.sh").read_text(encoding="utf-8")
+        fake_pi = (ROOT / "e2e/fake-bin/pi").read_text(encoding="utf-8")
+        fake_claude = (ROOT / "e2e/fake-bin/claude").read_text(encoding="utf-8")
+        terminal_shim = (ROOT / "e2e/fake-bin/managed-terminal-shim.py").read_text(
+            encoding="utf-8"
+        )
+        for source in (
+            readme,
+            managed,
+            configured,
+            awaiting,
+            fake_agent,
+            fake_pi,
+            fake_claude,
+            terminal_shim,
+        ):
+            self.assertNotIn("0.7.5", source)
+            self.assertNotIn("protocol-17", source)
+            self.assertNotIn("protocol 17", source)
+        self.assertIn("Herdr 0.8.0 / socket protocol 19", readme)
+        self.assertIn("protocol-19/current", readme)
+        self.assertIn("Pi integration v8", readme)
+        self.assertIn("Pi integration v8", awaiting)
+        self.assertIn("current Claude integration v7", readme)
+        self.assertIn("protocol-19", managed)
+        self.assertIn("protocol-19", configured)
+        self.assertIn("protocol-19", fake_pi)
+        self.assertIn("protocol-19", fake_claude)
+        self.assertIn("protocol-19", terminal_shim)
+        for path in sorted((ROOT / "e2e").glob("*.sh")):
+            source = path.read_text(encoding="utf-8")
+            with self.subTest(path=path.name):
+                self.assertNotIn("0.7.5", source)
+                self.assertNotIn("protocol-17", source)
+                self.assertNotIn("protocol 17", source)
+                self.assertNotIn("Pi integration v6", source)
+        issue_template = (ROOT / ".github/ISSUE_TEMPLATE/bug_report.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('placeholder: "0.8.0"', issue_template)
+        self.assertTrue((ROOT / "e2e/16-managed-p17.sh").is_file())
+        self.assertTrue((ROOT / "e2e/17-configured-p17-runner.sh").is_file())
 
     def test_wrapper_preserves_private_artifact_ownership_and_suite_status(self) -> None:
         self.assertIn("PIPESTATUS[0]", self.wrapper)

--- a/scripts/tests/test_prepare_release.py
+++ b/scripts/tests/test_prepare_release.py
@@ -60,7 +60,7 @@ class PrepareReleaseTests(unittest.TestCase):
                 name = "Herdr Board"
                 version = "{plugin_version}"
                 description = "Kanban board for AI coding agents."
-                min_herdr_version = "0.7.5"
+                min_herdr_version = "0.8.0"
                 platforms = ["linux"]
                 """
             ).lstrip(),


### PR DESCRIPTION
## What / why

Upgrade the Herdr boundary to the exact Herdr 0.8.0 / socket protocol 19 contract while preserving board protocol v1 and SQLite schema v13.

- `board-herdr` owns the pinned version/protocol constants, updated typed client and schema fixture, and exact compatibility diagnostics.
- `board-daemon` routes discovery, placement, mutations, notifications, and event subscriptions through the centralized gate. Recovery and cleanup/liveness for panes already owned by the daemon remain available when Herdr becomes incompatible.
- `board-core` keeps pane-first managed-launch metadata and compatibility tests aligned with the current transport while retaining legacy launch behavior.
- Docs, plugin metadata, E2E fixtures, and CI now document and enforce Herdr 0.8.0 / protocol 19, Pi v8, and Claude v7.

## Crates touched

- `board-herdr` — Herdr 0.8.0/protocol-19 client, events, schema fixture, and tests.
- `board-daemon` — centralized gate coverage, supervisor/recovery behavior, and operation tests.
- `board-core` — managed-launch compatibility fixture and documentation updates.
- `docs/`, E2E harnesses, CI, plugin metadata, and Python contract tests.

## Gates

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`
- [x] 83 Python tests
- [x] `bash e2e/test-harness.sh`
- [x] Schema byte comparison
- [x] Provider-free live E2E scenarios 01–29

Optional real-Pi validation is not counted as a PASS: the isolated call selected the exact OpenRouter model `deepseek/deepseek-v4-flash-0731`, reported run outcome `ok`, and verified cleanup. The wrapper exited 1 because the disposable settings gained `lastChangelogVersion`.

## Docs

- [x] Docs updated (`CHANGELOG.md` and the relevant `docs/` pages) for Herdr 0.8.0/protocol 19, Pi v8, Claude v7, gate behavior, recovery, and E2E/CI coverage.

## Related

N/A
