### PR TITLE
chore(ci): adopt dev as the long-lived integration branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # main is production; dev is the long-lived integration branch. The Release
+    # workflow stays bound to main, so a dev push runs CI but never publishes.
+    branches: [main, dev]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,6 +11,14 @@ on:
           - patch
           - minor
           - major
+      base:
+        description: Branch to branch from and target — dev for normal releases, main for hotfixes.
+        required: false
+        type: choice
+        default: dev
+        options:
+          - dev
+          - main
 
 concurrency:
   group: prepare-release
@@ -34,7 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          # The release branch is cut from the selected base: dev for normal
+          # releases, main only for hotfixes. The branch stays serialized by the
+          # concurrency group above regardless of base.
+          ref: ${{ inputs.base }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -139,19 +150,20 @@ jobs:
           set -euo pipefail
           title="chore(release): v$TARGET"
           body="$(printf '%s\n' \
-            "Prepare release branch for v$TARGET." \
+            "Prepare release branch for v$TARGET (base \`${{ inputs.base }}\`)." \
             "" \
             "- release files synced by scripts/prepare-release.py" \
             "- CI is dispatched explicitly from this workflow" \
-            "- release workflow waits for CI green on main")"
+            "- the Release workflow waits for CI green on main and tags the promotion commit")""
 
           pr_json="$(gh pr list --head "$BRANCH" --state open --json number,url)"
           if [ "$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" -gt 0 ]; then
             pr_number="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["number"])')"
             pr_url="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["url"])')"
-            gh pr edit "$pr_number" --title "$title" --body "$body"
+            # Retarget on reruns: an earlier run may have used another base.
+            gh pr edit "$pr_number" --title "$title" --body "$body" --base "${{ inputs.base }}"
           else
-            pr_url="$(gh pr create --head "$BRANCH" --base main --title "$title" --body "$body")"
+            pr_url="$(gh pr create --head "$BRANCH" --base "${{ inputs.base }}" --title "$title" --body "$body")"
           fi
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
           echo "PR: $pr_url"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -154,7 +154,8 @@ jobs:
             "" \
             "- release files synced by scripts/prepare-release.py" \
             "- CI is dispatched explicitly from this workflow" \
-            "- the Release workflow waits for CI green on main and tags the promotion commit")""
+            "- base dev: the Promote workflow merges dev -> main, then Release tags the green commit" \
+            "- base main (hotfix): Release tags the green main commit directly")""
 
           pr_json="$(gh pr list --head "$BRANCH" --state open --json number,url)"
           if [ "$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" -gt 0 ]; then

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,130 @@
+name: Promote
+
+# The action-owned half of a normal release: when CI completes green on a push
+# to `dev` whose workspace version is ahead of `main`, this workflow opens (or
+# updates) the `dev -> main` promotion PR, waits for its required checks, and
+# merges it with a merge commit. The resulting `main` push runs CI again, and
+# the Release workflow — still bound to green pushes on `main` — creates the
+# tag at that exact merge SHA. This workflow never creates or moves tags.
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
+      - dev
+
+# Serialize promotions for the same dev SHA without dropping a pending one
+# when later dev commits complete CI. Different dev SHAs may promote in
+# parallel only if the decide step finds the older one already on main.
+concurrency:
+  group: promote-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  promote:
+    name: promote dev to main
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Decide promotion
+        id: decide
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          remote_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch "$remote_url" main
+          main_sha="$(git rev-parse FETCH_HEAD)"
+          if git merge-base --is-ancestor "$HEAD_SHA" "$main_sha"; then
+            echo "dev tip is already on main; promotion is a no-op."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          workspace_version() {
+            git show "$1" | python3 -c 'import sys,tomllib; print(tomllib.loads(sys.stdin.read())["workspace"]["package"]["version"])'
+          }
+          dev_version="$(workspace_version "$HEAD_SHA:Cargo.toml")"
+          main_version="$(workspace_version "$main_sha:Cargo.toml")"
+          echo "Cargo.toml version: main=$main_version dev=$dev_version"
+          if [ "$dev_version" = "$main_version" ]; then
+            echo "dev carries no pending bump over main; promotion is a no-op."
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+          echo "version=$dev_version" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha" >> "$GITHUB_OUTPUT"
+          echo "Promoting v$dev_version from dev to main."
+
+      - name: Create or update promotion PR
+        if: steps.decide.outputs.needed == 'true'
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.decide.outputs.version }}
+        run: |
+          set -euo pipefail
+          title="chore(release): promote v$VERSION to main"
+          body="$(printf '%s\n' \
+            "Automatic promotion from \`dev\` after green \`dev\` CI (version v$VERSION)." \
+            "" \
+            "- opened and merged by the Promote workflow" \
+            "- the Release workflow tags this merge commit once \`main\` CI is green")"
+
+          pr_json="$(gh pr list --head dev --base main --state open --json number,url)"
+          if [ "$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" -gt 0 ]; then
+            pr_number="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["number"])')"
+            pr_url="$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(json.load(sys.stdin)[0]["url"])')"
+            gh pr edit "$pr_number" --title "$title" --body "$body"
+          else
+            pr_url="$(gh pr create --head dev --base main --title "$title" --body "$body")"
+            pr_number="$(printf '%s' "$pr_url" | python3 -c 'import sys; print(sys.argv[1].rstrip("/").split("/")[-1])')"
+          fi
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "PR: $pr_url"
+
+      - name: Wait for required checks on the promotion PR
+        if: steps.decide.outputs.needed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: gh pr checks "$PR_NUMBER" --watch --interval 30
+
+      - name: Merge promotion PR (merge commit)
+        if: steps.decide.outputs.needed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR_NUMBER" --merge --delete-branch=false
+          merged_sha="$(gh pr view "$PR_NUMBER" --json mergeCommit -q '.mergeCommit.oid')"
+          echo "Promoted dev to main at $merged_sha; Release will tag it after main CI is green."

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -115,7 +115,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: gh pr checks "$PR_NUMBER" --watch --interval 30
+        run: |
+          set -euo pipefail
+          # gh pr checks --watch exits 0 immediately when no check has been
+          # reported yet, so first wait until the PR's checks actually exist.
+          for _ in $(seq 1 80); do
+            n="$(gh pr view "$PR_NUMBER" --json statusCheckRollup -q '.statusCheckRollup | length')"
+            [ "${n:-0}" -gt 0 ] && break
+            sleep 15
+          done
+          gh pr checks "$PR_NUMBER" --watch --interval 30
 
       - name: Merge promotion PR (merge commit)
         if: steps.decide.outputs.needed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - CI
     types:
       - completed
+    # dev pushes run the same CI, but only a green push to main may publish:
+    # the tag is created at the promotion commit merged into main. Never widen
+    # this filter to dev — a dev CI completion must not become a release path.
     branches:
       - main
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 Cross-agent contributor guide for herdr-board. Read this before touching the repo. herdr-board is a
 kanban board that dispatches AI coding agents into visible herdr panes; the single `board` binary is
 TUI + daemon + CLI. Rust, cargo workspace, edition 2021, all crates share the workspace version.
+Feature PRs target the long-lived `dev` branch; `main` is production (branch model:
+[`docs/releasing.md`](docs/releasing.md)).
 
 ## Workspace layout & crate ownership
 
@@ -109,9 +111,14 @@ Full layering, test placement, harness details, and how to add tests live in
   per-session supervisor reconnects and reconciles conservatively.
 - Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change. Keep each `CHANGELOG.md` entry to one line prefixed by a clickable link to its PR, e.g. `- [#31](https://github.com/nelsonPires5/herdr-board/pull/31) Pin Herdr plugin installs to a released tag.` (GitHub does not auto-link bare `#NN` inside rendered markdown files, so use the full link) so the changelog links the PR rather than reproducing it — long rationale lives in the PR body. Write the one-line description first, then fill in the PR link once the PR is open.
 - Release/version changes follow [`docs/releasing.md`](docs/releasing.md). Agents must never create,
-  push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its PR,
-  and the **Release** workflow creates the tag only after `main` CI is green. No tag ruleset currently
-  enforces this; it is repository policy.
+  push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its
+  PR into `dev`, promotes `dev -> main`, and the **Release** workflow creates the tag only after
+  `main` CI is green at that promotion SHA. A repository tag ruleset protects `v*`; this is policy
+  and workflow validation together.
+- Branching: `dev` is the long-lived integration branch and the default target for feature PRs;
+  `main` is production (default branch, Release's only publish path). Hotfixes and the `dev -> main`
+  promotion are the only PRs that target `main`. After every promotion or hotfix, back-merge
+  `main -> dev` before the next normal release.
 
 ## herdr gotchas (field-tested)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,13 +112,14 @@ Full layering, test placement, harness details, and how to add tests live in
 - Definition of done for a user-facing change: update the docs and `CHANGELOG.md` in the same change. Keep each `CHANGELOG.md` entry to one line prefixed by a clickable link to its PR, e.g. `- [#31](https://github.com/nelsonPires5/herdr-board/pull/31) Pin Herdr plugin installs to a released tag.` (GitHub does not auto-link bare `#NN` inside rendered markdown files, so use the full link) so the changelog links the PR rather than reproducing it — long rationale lives in the PR body. Write the one-line description first, then fill in the PR link once the PR is open.
 - Release/version changes follow [`docs/releasing.md`](docs/releasing.md). Agents must never create,
   push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its
-  PR into `dev`, promotes `dev -> main`, and the **Release** workflow creates the tag only after
-  `main` CI is green at that promotion SHA. A repository tag ruleset protects `v*`; this is policy
-  and workflow validation together.
+  PR into `dev`, the **Promote** workflow merges `dev -> main`, and the **Release** workflow creates
+  the tag only after `main` CI is green at that promotion SHA. Repository rulesets protect `main`
+  (PR-only, merge-commit, signed commits) and `v*` tags (deletion/force-update); this is policy and
+  workflow validation together.
 - Branching: `dev` is the long-lived integration branch and the default target for feature PRs;
-  `main` is production (default branch, Release's only publish path). Hotfixes and the `dev -> main`
-  promotion are the only PRs that target `main`. After every promotion or hotfix, back-merge
-  `main -> dev` before the next normal release.
+  `main` is production (default branch, Release's only publish path). The `dev -> main` promotion
+  and hotfix PRs are opened/merged by the workflows themselves. After every promotion or hotfix,
+  back-merge `main -> dev` before the next normal release.
 
 ## herdr gotchas (field-tested)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-- [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): adopt `dev` as the long-lived integration branch — feature/release PRs target `dev`, Prepare Release defaults to `base=dev` (`main` only for hotfixes), and each release promotes `dev -> main` so the Release workflow tags the exact green promotion commit; `main` stays production/default and `v*` tags remain Release-owned only.
+- [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): adopt `dev` as the long-lived integration branch — feature/release PRs target `dev`, Prepare Release defaults to `base=dev` (`main` only for hotfixes), the Promote workflow automatically merges `dev -> main` after green dev CI, and the Release workflow tags the exact green promotion commit; `main` stays production/default with PR-only, merge-commit and signed-commit protection, and `v*` tags remain Release-owned only.
 
 ## [0.12.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): adopt `dev` as the long-lived integration branch — feature/release PRs target `dev`, Prepare Release defaults to `base=dev` (`main` only for hotfixes), and each release promotes `dev -> main` so the Release workflow tags the exact green promotion commit; `main` stays production/default and `v*` tags remain Release-owned only.
+
 ## [0.12.0] - 2026-08-08
 
 - [#59](https://github.com/nelsonPires5/herdr-board/pull/59) Redesign the board TUI mobile-first: boxed cards with one semantic glyph on each dedicated status row, direct visibility filters, persistent chrome around content overlays, transparent white `[ NAME ]` controls, icon detail toggles, no Board-card Edit/Delete controls (keyboard `e`/`d` preserved), drag-only card movement, and a reduced bottom action row.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,9 @@ Harnesses are pluggable behind a `HarnessAdapter`. To add one:
 
 - One focused change per PR. Update the docs and `CHANGELOG.md` (`[Unreleased]`) in the same PR as a
   user-facing change — a change isn't done until the docs match it.
-- Release policy: [`docs/releasing.md`](docs/releasing.md) for the Prepare Release → CI-green publish flow.
+- Branch targeting: feature PRs open against **`dev`** (the long-lived integration branch); only
+  hotfixes and the `dev -> main` promotion open against **`main`** (production).
+- Release policy: [`docs/releasing.md`](docs/releasing.md) for the Prepare Release → promote → CI-green
+  tag flow.
 - The gates above pass. Reference the design in `docs/design.md` / the contract in `docs/protocol.md`
   when a change touches behavior or the wire.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,8 @@ Harnesses are pluggable behind a `HarnessAdapter`. To add one:
 - One focused change per PR. Update the docs and `CHANGELOG.md` (`[Unreleased]`) in the same PR as a
   user-facing change — a change isn't done until the docs match it.
 - Branch targeting: feature PRs open against **`dev`** (the long-lived integration branch); only
-  hotfixes and the `dev -> main` promotion open against **`main`** (production).
+  hotfixes open against **`main`** (production) — the `dev -> main` promotion is opened and merged
+  by the Promote workflow.
 - Release policy: [`docs/releasing.md`](docs/releasing.md) for the Prepare Release → promote → CI-green
   tag flow.
 - The gates above pass. Reference the design in `docs/design.md` / the contract in `docs/protocol.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ The reference detail behind the [root README](../README.md). Start here to find 
 | Runtime launch | daemon-owned `Spawner`, placement, process/pane handles | [implementation.md](implementation.md) |
 | Config | typed `RootConfig`, one parse, environment overrides after parse | [configuration.md](configuration.md), [design.md](design.md) |
 | Live catalog | scenarios 01–30; provider-free fake/safe harness boundary | [e2e/README.md](../e2e/README.md) |
-| Branches | `dev` integration; `main` production; tags only from green `main` | [releasing.md](releasing.md) |
+| Branches | `dev` integration; `main` production (PR-only, merge-commit, signed); action-owned promotion; tags only from green `main` | [releasing.md](releasing.md) |
 
 Keep these links as navigation, not duplicate wire definitions: serde types and migrations are the
 source of truth. The old worktree API is intentionally absent from `board-herdr`; repository
@@ -29,7 +29,7 @@ isolation is an agent prompt concern, not a board space primitive.
 | [protocol.md](protocol.md) | The boardd unix-socket protocol (v1) — transport (NDJSON), auto-start, every method and event, error codes. **The single source of truth** for the daemon⇄client contract; serde types live in `board-core::protocol`. | are writing a client, adding a method, or debugging the wire. |
 | [implementation.md](implementation.md) | The cargo workspace crate layout, crate ownership, shared dependencies, key traits (`BoardClient`, `Spawner`), and the build phases with their tests. | are navigating the codebase or picking up a build task. |
 | [research.md](research.md) | The verified herdr capability map (commands/events/IDs), prior-art survey of agent-kanban tools, and verified harness invocation flags (Pi/Claude/codex/gemini/opencode). | are scoping a feature that touches herdr or a new harness, and want the background that grounded the design. |
-| [releasing.md](releasing.md) | The release contract: the `dev`/`main` branch model (feature → dev, promotion to main, hotfix, back-merge), Prepare Release, version bumps, CI-gated tagging/publishing, artifacts, reruns, and tag policy. | are cutting a release or need the repo's release policy. |
+| [releasing.md](releasing.md) | The release contract: the `dev`/`main` branch model (feature → dev, action-owned promotion to main, hotfix, back-merge), Prepare Release, version bumps, CI-gated tagging/publishing, artifacts, reruns, and tag policy. | are cutting a release or need the repo's release policy. |
 | [herdr.md](herdr.md) | How to learn and verify **Herdr** facts (there is no man page): the live sources of truth (`herdr api schema --json`, `herdr <cmd> --help`, `herdr api snapshot`), the Herdr 0.8.0/protocol-19 delta, per-harness integrations, and the exact compatibility gate. | hit a Herdr command/shape that misbehaves, or need to confirm what the installed Herdr actually does. |
 | [testing.md](testing.md) | The testing pyramid in this repo (unit/pure → daemon+CLI integration → TUI snapshots → live E2E), how the provider-free fake Pi/Claude suite works (including the current pane-first scenarios 16/17, whose filenames are historical), and how to write a scenario. The use case ↔ scenario catalog lives in [`../e2e/README.md`](../e2e/README.md). | are adding a feature and need to test it, or are writing/running the live E2E suite. |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ The reference detail behind the [root README](../README.md). Start here to find 
 | Runtime launch | daemon-owned `Spawner`, placement, process/pane handles | [implementation.md](implementation.md) |
 | Config | typed `RootConfig`, one parse, environment overrides after parse | [configuration.md](configuration.md), [design.md](design.md) |
 | Live catalog | scenarios 01–30; provider-free fake/safe harness boundary | [e2e/README.md](../e2e/README.md) |
+| Branches | `dev` integration; `main` production; tags only from green `main` | [releasing.md](releasing.md) |
 
 Keep these links as navigation, not duplicate wire definitions: serde types and migrations are the
 source of truth. The old worktree API is intentionally absent from `board-herdr`; repository
@@ -28,7 +29,7 @@ isolation is an agent prompt concern, not a board space primitive.
 | [protocol.md](protocol.md) | The boardd unix-socket protocol (v1) — transport (NDJSON), auto-start, every method and event, error codes. **The single source of truth** for the daemon⇄client contract; serde types live in `board-core::protocol`. | are writing a client, adding a method, or debugging the wire. |
 | [implementation.md](implementation.md) | The cargo workspace crate layout, crate ownership, shared dependencies, key traits (`BoardClient`, `Spawner`), and the build phases with their tests. | are navigating the codebase or picking up a build task. |
 | [research.md](research.md) | The verified herdr capability map (commands/events/IDs), prior-art survey of agent-kanban tools, and verified harness invocation flags (Pi/Claude/codex/gemini/opencode). | are scoping a feature that touches herdr or a new harness, and want the background that grounded the design. |
-| [releasing.md](releasing.md) | The release contract: Prepare Release, version bumps, CI-gated tagging/publishing, artifacts, reruns, and tag policy. | are cutting a release or need the repo's release policy. |
+| [releasing.md](releasing.md) | The release contract: the `dev`/`main` branch model (feature → dev, promotion to main, hotfix, back-merge), Prepare Release, version bumps, CI-gated tagging/publishing, artifacts, reruns, and tag policy. | are cutting a release or need the repo's release policy. |
 | [herdr.md](herdr.md) | How to learn and verify **Herdr** facts (there is no man page): the live sources of truth (`herdr api schema --json`, `herdr <cmd> --help`, `herdr api snapshot`), the Herdr 0.8.0/protocol-19 delta, per-harness integrations, and the exact compatibility gate. | hit a Herdr command/shape that misbehaves, or need to confirm what the installed Herdr actually does. |
 | [testing.md](testing.md) | The testing pyramid in this repo (unit/pure → daemon+CLI integration → TUI snapshots → live E2E), how the provider-free fake Pi/Claude suite works (including the current pane-first scenarios 16/17, whose filenames are historical), and how to write a scenario. The use case ↔ scenario catalog lives in [`../e2e/README.md`](../e2e/README.md). | are adding a feature and need to test it, or are writing/running the live E2E suite. |
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -83,14 +83,26 @@ disabled for checkout and supplied only to steps that need GitHub API/git access
 The PR must be reviewed and merged into its base. Dispatching CI on the branch is useful proof,
 but it does not authorize publication.
 
-## Promotion to main
+## Promotion to main (action-owned)
 
 For a normal release the release PR merges into `dev`, not `main`. The bump reaches `main` only
-through a `dev -> main` promotion PR merged with a merge commit. CI runs on the merge, and Release
-creates the tag at that exact SHA — "tag and main at the same time" means the tag points to the
-promotion commit. The tag is still created only after CI is green; there is no manual or pre-CI
-tagging anywhere in the flow. A commit on `main` that does not bump the version (back-merge,
-documentation, other branches' merges) is a no-op.
+through the **Promote** workflow, which opens the `dev -> main` PR, waits for its required checks,
+and merges it with a merge commit. CI runs on the merge, and Release creates the tag at that exact
+SHA — "tag and main at the same time" means the tag points to the promotion commit. The tag is
+still created only after CI is green; there is no manual or pre-CI tagging anywhere in the flow.
+A commit on `main` that does not bump the version (back-merge, documentation, other branches'
+merges) is a no-op.
+
+## main protection
+
+`main` is protected by an active branch ruleset: every change must come through a pull request
+merged with a **merge commit** (squash/rebase are not allowed), the six fast CI jobs are required
+status checks with a strict policy, and **signed commits** are required — merge commits created
+by GitHub for a PR merge are GitHub-verified, so every commit on `main` carries a verified
+signature. Direct pushes to `main` are blocked by the pull-request rule; the only writer in
+practice is the automation (`github-actions[bot]`), whose promotion and hotfix merges are
+GitHub-verified. `dev` is protected the same way (PR + merge commit + required checks) but has no
+signature requirement.
 
 ## Release gate
 
@@ -120,6 +132,11 @@ Release state is inspected before mutation:
 Therefore a failure after tag creation, draft creation, or one asset upload can be recovered by
 rerunning the same green `workflow_run`; the per-CI-commit lock serializes retries for that commit. A release with a
 missing tag must be repaired manually and then rerun.
+
+Promotion failures recover the same way: if the promotion PR's checks fail or its merge is
+blocked, rerun the green `dev` CI run — the Promote workflow re-evaluates the same SHA under its
+per-SHA lock, updates the PR, and retries the merge. If a promotion already landed, a rerun is a
+no-op (the dev tip is an ancestor of `main`).
 
 Expected assets:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,16 +1,53 @@
 # Release policy
 
-This repo has two workflows:
+This repo has two long-lived branches and three workflows:
 
-1. **Prepare Release** is manually dispatched with `patch`, `minor`, or `major`. It runs the
-   stdlib-only Python tests, updates the release files, verifies them, runs the Rust gates, and
-   creates or updates `release/vX.Y.Z` plus its PR.
+| Branch | Role |
+|---|---|
+| `dev` | long-lived integration branch; feature and release branches open PRs here |
+| `main` | production, the default branch, and the **only** branch the Release workflow publishes from |
+
+1. **Prepare Release** is manually dispatched with `patch`, `minor`, or `major`, plus a `base`
+   (default `dev`; `main` only for hotfixes). It runs the stdlib-only Python tests, updates the
+   release files, verifies them, runs the Rust gates, and creates or updates `release/vX.Y.Z`
+   plus its PR against the selected base.
 2. **Release** is triggered by a completed **CI workflow run whose event was a push to `main`**.
    It checks the exact green run SHA and publishes only when the workspace version changed in
    `Cargo.toml` versus that commit's first parent.
 
 A normal commit is a successful no-op. The unchanged Release workflow still consumes the existing
 `CI` result; that result now includes the provider-free live E2E job before publication can begin.
+
+## Branch model
+
+| Branch | Opens PRs to | Notes |
+|---|---|---|
+| feature | `dev` | same required checks as `main` |
+| `release/vX.Y.Z` | `dev` (default) or `main` (hotfix) | created/updated by Prepare Release |
+| `dev -> main` promotion | `main` | merge commit; the only way a normal release reaches `main` |
+| `main -> dev` back-merge | `dev` | after promotion, so `dev` keeps the merge history |
+
+Normal release flow:
+
+1. A maintainer starts **Prepare Release** with the bump; the default base is `dev`. The workflow
+   cuts `release/vX.Y.Z` from `dev` and opens (or updates) its PR to `dev`.
+2. The PR is reviewed and merged into `dev` with a merge commit. CI runs on that `dev` push —
+   the full workflow including the dependent live E2E job — but never publishes.
+3. A maintainer opens a `dev -> main` promotion PR (merge commit). CI runs on the merge into
+   `main`.
+4. The **Release** workflow consumes the green `main` CI run, sees the version bump versus the
+   merge's first parent, and creates the tag at that exact promotion SHA. The tag therefore lands
+   on `main` and the release commit at the same time.
+5. `main` is merged back into `dev` so `dev` retains the promotion commit and stays able to serve
+   as the base of the next release.
+
+Hotfix flow: run Prepare Release with `base = main`. The PR targets `main` directly; after the
+merge, Release tags the green main commit as usual. **Always back-merge `main -> dev` after a
+hotfix** before the next normal release, or the next promotion will try to re-land the hotfix
+bump and confuse the version comparison.
+
+Recovery: if the CI of a promotion merge fails, rerun that CI run; Release re-evaluates the same
+green SHA. Any other commit on `main` without a version bump is a no-op.
 
 ## Version and verification contract
 
@@ -36,13 +73,24 @@ The helper uses only Python's standard library.
 
 ## Prepare Release workflow
 
-A maintainer manually starts **Prepare Release** and selects the bump. It computes the target from
-`Cargo.toml`, reuses the same branch/PR on reruns, applies the four release files atomically one
-file at a time, runs Python/Rust tests, then explicitly dispatches CI for the branch. GitHub
-credentials are disabled for checkout and supplied only to steps that need GitHub API/git access.
+A maintainer manually starts **Prepare Release**, selects the bump, and picks the base (`dev` by
+default, `main` for hotfixes). The workflow computes the target from `Cargo.toml`, cuts
+`release/vX.Y.Z` from the selected base, reuses the same branch/PR on reruns (retargeting the PR
+to the current base if it changed), applies the four release files atomically one file at a time,
+runs Python/Rust tests, then explicitly dispatches CI for the branch. GitHub credentials are
+disabled for checkout and supplied only to steps that need GitHub API/git access.
 
-The PR must be reviewed and merged into `main`. Dispatching CI on the branch is useful proof, but
-it does not authorize publication.
+The PR must be reviewed and merged into its base. Dispatching CI on the branch is useful proof,
+but it does not authorize publication.
+
+## Promotion to main
+
+For a normal release the release PR merges into `dev`, not `main`. The bump reaches `main` only
+through a `dev -> main` promotion PR merged with a merge commit. CI runs on the merge, and Release
+creates the tag at that exact SHA — "tag and main at the same time" means the tag points to the
+promotion commit. The tag is still created only after CI is green; there is no manual or pre-CI
+tagging anywhere in the flow. A commit on `main` that does not bump the version (back-merge,
+documentation, other branches' merges) is a no-op.
 
 ## Release gate
 
@@ -84,12 +132,11 @@ The tarball contains the release binary, `herdr-plugin.toml`, `skill/`, packagin
 ## Tag policy
 
 Version tags are owned by the release flow. Maintainers and agents must not create, push, move, or
-delete `v*` tags manually. A maintainer starts **Prepare Release** and merges its PR; after the
-resulting `main` CI succeeds, the **Release** workflow creates the tag at that exact green SHA.
+delete `v*` tags manually. A maintainer starts **Prepare Release** and merges its PRs; after the
+promotion's `main` CI succeeds, the **Release** workflow creates the tag at that exact green SHA.
 If a tag points elsewhere, stop and repair the process rather than retargeting it.
 
-This policy is currently enforced by convention and workflow validation: **no tag ruleset has been
-configured yet**. Because only the repository owner currently has write access, leaving the ruleset
-disabled is an accepted temporary choice. A tag ruleset or dedicated release identity can be added
-later as defense in depth; until then, do not create release tags from a local checkout or the GitHub
-UI.
+This policy is enforced by workflow validation and by a repository tag ruleset protecting `v*`
+against deletion and non-fast-forward updates — the Release workflow's own tag creation is the
+only path that may touch them. Defense in depth: even with the ruleset, never create release tags
+from a local checkout or the GitHub UI.

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -345,6 +345,63 @@ class DocumentationContractTests(unittest.TestCase):
             "re-run the documentation contracts against the bumped tree",
         )
 
+    def test_ci_runs_on_main_and_dev_pushes(self) -> None:
+        """Both long-lived branches run the full CI; dev is integration, main production.
+
+        Feature/release PRs merge into `dev`, so the push gate must cover it —
+        otherwise a broken integration branch ships silently until promotion.
+        """
+        workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        self.assertIn("branches: [main, dev]", workflow)
+
+    def test_release_workflow_never_publishes_from_dev(self) -> None:
+        """A dev push runs CI but must never publish: Release stays bound to main.
+
+        Both the `workflow_run` branch filter and the job's head_branch guard
+        must keep naming `main`, or a dev CI completion would become a release
+        path. This is the gate D4 of the dev-branch rollout exists to protect.
+        """
+        workflow = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
+        self.assertIn(
+            "branches:\n      - main",
+            workflow,
+            "workflow_run trigger must stay filtered to main",
+        )
+        self.assertIn(
+            "github.event.workflow_run.head_branch == 'main'",
+            workflow,
+            "release job must stay gated to green CI runs on main",
+        )
+
+    def test_prepare_release_targets_an_input_base(self) -> None:
+        """Prepare Release defaults to `dev` and supports `main` for hotfixes.
+
+        The checkout and the created/reused PR must both follow the input;
+        a rerun must retarget an existing PR whose base changed.
+        """
+        workflow = (ROOT / ".github/workflows/prepare-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("base:", workflow, "base input is missing")
+        self.assertIn("default: dev", workflow, "dev must be the default base")
+        self.assertIn("- dev", workflow)
+        self.assertIn("- main", workflow)
+        self.assertIn(
+            "ref: ${{ inputs.base }}",
+            workflow,
+            "release branch must be cut from the selected base",
+        )
+        self.assertIn(
+            '--base "${{ inputs.base }}"',
+            workflow,
+            "created/reused PR must target the selected base",
+        )
+        self.assertNotIn(
+            "--base main",
+            workflow,
+            "the PR base must never be hardcoded to main",
+        )
+
     def test_maintained_markdown_links_resolve(self) -> None:
         for document in maintained_markdown():
             for link in re.findall(r"\[[^]]+\]\(([^)]+)\)", document.read_text()):

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -402,6 +402,33 @@ class DocumentationContractTests(unittest.TestCase):
             "the PR base must never be hardcoded to main",
         )
 
+    def test_promote_workflow_merges_dev_but_never_tags(self) -> None:
+        """The action-owned promotion: green dev CI with a pending bump opens
+        and merges `dev -> main`; tagging stays exclusively in Release.
+
+        The promote workflow must be bound to `dev` CI completions, merge
+        through a PR (so the merge commit is GitHub-verified and satisfies the
+        main ruleset), and contain no tag- or release-creation step.
+        """
+        workflow = (ROOT / ".github/workflows/promote.yml").read_text(encoding="utf-8")
+        self.assertIn(
+            "branches:\n      - dev",
+            workflow,
+            "promote trigger must be dev-only",
+        )
+        self.assertIn(
+            "github.event.workflow_run.head_branch == 'dev'",
+            workflow,
+            "promote job must stay gated to dev CI runs",
+        )
+        self.assertIn(
+            "gh pr merge",
+            workflow,
+            "promotion must land via a merged PR",
+        )
+        self.assertNotIn("git tag", workflow, "promote must never create tags")
+        self.assertNotIn("gh release", workflow, "promote must never publish")
+
     def test_maintained_markdown_links_resolve(self) -> None:
         for document in maintained_markdown():
             for link in re.findall(r"\[[^]]+\]\(([^)]+)\)", document.read_text()):


### PR DESCRIPTION
Adopt `dev` as the long-lived integration branch while keeping `main` as production/default and the only publish path. The promotion `dev -> main` is **action-owned**: the new `Promote` workflow merges it, so no maintainer step sits between a green `dev` CI and the Release tag.

**Flow (per `docs/releasing.md`)**
- Feature PRs target `dev`.
- **Prepare Release** gains a `base` input (`dev` default, `main` for hotfixes): the release branch is cut from the selected base and the PR targets/retargets it.
- **CI** runs the full workflow (incl. dependent live E2E) on `main` **and** `dev` pushes.
- **Promote** (new): on a green `dev` push whose version is ahead of `main`, opens + merges the `dev -> main` PR (merge commit) after its required checks pass; never creates tags; no-op when dev is already on main or has no bump.
- **Release** stays bound to green `main` CI only (trigger filter + `head_branch` guard, pinned by tests) and tags the exact promotion SHA.
- Back-merge `main -> dev` after each promotion/hotfix; hotfixes use `base=main` and must back-merge before the next normal release.
- `v*` tags remain Release-owned: no manual create/move/delete anywhere.

**main protection (rollout)**: PR-only (merge commit, no squash/rebase), required status checks (strict), **required signed commits** (all main commits GitHub-verified) — direct pushes blocked. `dev` gets the same ruleset minus signatures. Tag ruleset `v*` blocks deletion/force-update.

**Files**
- `.github/workflows/ci.yml` — push gate covers `main, dev`
- `.github/workflows/prepare-release.yml` — `base` input, checkout/PR base, PR retarget on rerun
- `.github/workflows/promote.yml` — new: automated `dev -> main` promotion
- `.github/workflows/release.yml` — comment only; gate unchanged (D4)
- `scripts/tests/test_docs.py` — RED contracts: CI covers both branches, Release stays main-only, Prepare Release honors `inputs.base`, Promote merges dev but never tags
- `docs/releasing.md`, `docs/README.md`, `CONTRIBUTING.md`, `AGENTS.md` — branch model, action-owned promotion, main protection, hotfix, back-merge, recovery, tag ruleset
- `CHANGELOG.md` — `[Unreleased]` entry

**Gates (local)**: fmt, clippy `-D warnings`, `cargo test --workspace --all-features` (904 pass), Python tier (90 pass), `e2e/test-harness.sh`, `e2e/run-all.sh --require-all` (30/30).

**Note**: pre-existing macOS-only flake `run_focus_rescues_a_configured_harness_that_opts_into_resume` (fails in full-suite runs on `main` too; passes in isolation; ubuntu CI green) — unrelated to this workflow/docs-only change.

**Rollout after merge**: create `dev` from updated `main`, add `dev` branch ruleset (PR + required checks + merge commit), add `required_signatures` to `main` ruleset, create `v*` tag ruleset. Rehearsal (D10) happens on the next real release — **no tag is created by this PR** (no version bump).