### PR TITLE
feat: add managed Codex harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Ownership is strict: edit your crate(s) + append to root `[workspace.dependencie
 source of truth: `docs/protocol.md` + `docs/design.md`. Docs live in `docs/` (index: `docs/README.md`);
 `schema.sql` is the fresh-schema source of truth and `board-core::db` owns upgrades. Final compatibility
 is board protocol v1, SQLite schema v13, and exactly Herdr 0.8.0 / socket protocol 19. The complete
-live catalog is `e2e/README.md` (scenarios 01–30); `e2e/test-harness.sh` is the provider-free static
+live catalog is `e2e/README.md` (scenarios 01–31); `e2e/test-harness.sh` is the provider-free static
 safety gate.
 
 ## Build / test gates (keep green)
@@ -35,7 +35,7 @@ The gate list has one maintained copy: **[`docs/README.md` → Test gates](docs/
 
 - `#[ignore]`'d tests hit a live herdr (run only when `HERDR_SOCK`/`HERDR_SOCKET_PATH` exists).
 - End-to-end: `e2e/run-all.sh` (compat: `scripts/e2e.sh`) drives a REAL Herdr; checked-in fake
-  Pi/Claude executables keep the standard suite (scenarios 01–30) provider-free and zero-cost.
+  Pi/Claude/Codex executables keep the standard suite (scenarios 01–31) provider-free and zero-cost.
   **Hard rules an agent must never violate:** run only against the scenario's own **ephemeral**
   `hb-e2e-<slug>-<pid>-<random64>` session and **disposable** workspaces it created — never a user
   session, workspace, or tab — and prefix every Herdr mutation with `HERDR MUTATION:`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+- [#TBD](https://github.com/nelsonPires5/herdr-board/pull/TBD) Add the managed Codex harness with live cached model/effort discovery, native access presets, self-minted thread capture, resume/fork/reuse/rescue, and provider-free E2E coverage.
+
 - [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): adopt `dev` as the long-lived integration branch — feature/release PRs target `dev`, Prepare Release defaults to `base=dev` (`main` only for hotfixes), the Promote workflow automatically merges `dev -> main` after green dev CI, and the Release workflow tags the exact green promotion commit; `main` stays production/default with PR-only, merge-commit and signed-commit protection, and `v*` tags remain Release-owned only.
 
 ## [0.12.0] - 2026-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-- [#TBD](https://github.com/nelsonPires5/herdr-board/pull/TBD) Add the managed Codex harness with live cached model/effort discovery, native access presets, self-minted thread capture, resume/fork/reuse/rescue, and provider-free E2E coverage.
+- [#63](https://github.com/nelsonPires5/herdr-board/pull/63) Add the managed Codex harness with live cached model/effort discovery, native access presets, self-minted thread capture, resume/fork/reuse/rescue, and provider-free E2E coverage.
 
 - [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): adopt `dev` as the long-lived integration branch — feature/release PRs target `dev`, Prepare Release defaults to `base=dev` (`main` only for hotfixes), the Promote workflow automatically merges `dev -> main` after green dev CI, and the Release workflow tags the exact green promotion commit; `main` stays production/default with PR-only, merge-commit and signed-commit protection, and `v*` tags remain Release-owned only.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ agent skill, and named-session notes, see [`docs/install.md`](docs/install.md).
 2. On an empty board press `T` to apply the example pipeline, or `N` to create your own columns.
 3. Press `n` to create a card. Pi is selected by default. Leave model at `(default)` to use Pi's
    configured default, choose thinking effort if needed, then select the session and workspace.
-   Permission appears only for harnesses that support it (Pi does not).
+   Permission appears only for harnesses that support it (Pi does not; Codex offers
+   `untrusted|on-request|never`).
 4. Move the card into an automatic column with `m`, `H` / `L`, or drag-and-drop.
 5. Watch the agent appear in its stable `card-<id>` workspace tab. Follow progress with `Enter`
    for card detail; the agent comments and calls `board done` when its stage finishes.
@@ -95,7 +96,13 @@ board move <new-card-id> Execute
 `pi` is the default built-in harness. An omitted model lets Pi use its current configured default;
 an explicit model uses Pi's `provider/model` form. Board effort maps to Pi `--thinking`. Pi has no
 board permission mode and rejects `--permission`. Claude remains available explicitly with
-`--harness claude` and keeps its model/effort/permission behavior.
+`--harness claude` and keeps its model/effort/permission behavior. Codex is the third built-in:
+`--harness codex` keeps free-form model entry and also discovers visible models plus per-model
+efforts from `$CODEX_HOME/models_cache.json`. Board effort `off` becomes Codex
+`model_reasoning_effort=none`. Its permission selector mirrors Codex: `ask-for-approval`
+(workspace-write + on-request), `approve-for-me` (automatic reviewer), or `full-access` (no sandbox
+or approvals). Codex mints its own thread id — the board never invents one — and captures the
+integration-reported id after launch so later stages can `resume`/`fork` the same conversation.
 
 ## How it works
 
@@ -127,8 +134,8 @@ The daemon creates one stable `card-<id>` tab per new card. For a workspace the 
 just created (`new_workspace`), that workspace's own initial tab is adopted as the card tab —
 renamed to `card-<id>` — so no unused initial tab is left behind. The tab's root is reserved as a
 labeled `card-<id>-anchor` shell and every run is split into a child from it. A successful
-**managed** (Pi/Claude) launch then closes the anchor, leaving exactly the harness pane visible;
-**configured** harnesses keep the anchor because their child exits with the run. Ownership is
+**managed** (Pi/Claude/Codex) launch then closes the anchor, leaving exactly the harness pane
+visible; **configured** harnesses keep the anchor because their child exits with the run. Ownership is
 proven from durable pane identity, never from a matching label, so a user tab is never adopted.
 The full placement and recovery rules are in [`docs/design.md`](docs/design.md).
 
@@ -298,8 +305,8 @@ typed `board_core::client::BoardClient`; only boardd touches SQLite.
 - `scripts/` — `build.sh` (release build used by plugin installation), `install-cli.sh` (managed
   CLI copy), `install.sh` (local-development setup), `open-board.sh` (open-or-focus plugin
   action), and `board-rpc.py` (raw daemon protocol client);
-- `e2e/` — scenarios 01–30 against disposable Herdr sessions/workspaces; checked-in fake Pi,
-  Claude, and configured harnesses keep the standard suite provider-free. `e2e/test-harness.sh`
+- `e2e/` — scenarios 01–31 against disposable Herdr sessions/workspaces; checked-in fake Pi,
+  Claude, Codex, and configured harnesses keep the standard suite provider-free. `e2e/test-harness.sh`
   performs static ownership/safety checks without starting Herdr; the live suite is a separate
   gate. The catalog is [`e2e/README.md`](e2e/README.md).
 

--- a/crates/board-cli/src/helpers.rs
+++ b/crates/board-cli/src/helpers.rs
@@ -45,6 +45,7 @@ pub(crate) fn env_card_id() -> Result<i64> {
 
 pub(crate) fn actor_run_id() -> Result<Option<i64>> {
     match std::env::var("BOARD_RUN_ID") {
+        Ok(value) if value.is_empty() => Ok(None),
         Ok(value) => Ok(Some(value.parse::<i64>().map_err(|_| {
             anyhow!("invalid $BOARD_RUN_ID '{value}': expected an integer")
         })?)),

--- a/crates/board-cli/tests/integration/comments.rs
+++ b/crates/board-cli/tests/integration/comments.rs
@@ -129,6 +129,19 @@ fn comment_mutations_enforce_agent_run_ownership_and_reject_system_comments() {
     let td = TestDaemon::start(&[]);
     let card_id = old_card(&td, "comment authorization");
 
+    let human = json_output(&td.board_with_env(
+        &[
+            "card",
+            "comment",
+            "add",
+            &card_id.to_string(),
+            "rescued human comment",
+            "--json",
+        ],
+        &[("BOARD_RUN_ID", "")],
+    ));
+    assert_eq!(human["author"], "user");
+
     let own = json_output(&td.board_with_env(
         &[
             "card",

--- a/crates/board-cli/tests/integration/harness.rs
+++ b/crates/board-cli/tests/integration/harness.rs
@@ -1,4 +1,5 @@
 use board_core::client::BoardClient;
+use serde_json::Value;
 
 use super::{fake_card, json_output, todo_id, TestDaemon};
 
@@ -41,17 +42,17 @@ fn harness_models_claude_json_and_human() {
 #[test]
 fn harness_list_builtins_and_config_defined() {
     let td = TestDaemon::start(&[]);
-    // human: one harness per line, built-ins first (pi, claude) then config.
+    // human: one harness per line, built-ins first (pi, claude, codex) then config.
     let out = td.board(&["harness", "list"]);
     assert!(out.status.success(), "harness list should succeed");
     let text = String::from_utf8_lossy(&out.stdout);
     let names: Vec<&str> = text.lines().filter(|l| !l.is_empty()).collect();
-    assert_eq!(names, vec!["pi", "claude", "fake"], "got:\n{text}");
+    assert_eq!(names, vec!["pi", "claude", "codex", "fake"], "got:\n{text}");
 
     // --json: the same names, default-first, as a JSON array.
     let out = td.board(&["harness", "list", "--json"]);
     let names: Vec<String> = serde_json::from_value(json_output(&out)).unwrap();
-    assert_eq!(names, vec!["pi", "claude", "fake"]);
+    assert_eq!(names, vec!["pi", "claude", "codex", "fake"]);
 }
 
 #[test]
@@ -80,7 +81,7 @@ fn harness_models_unknown_harness_errors() {
     let err = String::from_utf8_lossy(&out.stderr);
     assert_eq!(
         err.trim_end(),
-        "board: boardd error 2: not found: unknown harness 'ghost'; known: pi, claude, fake",
+        "board: boardd error 2: not found: unknown harness 'ghost'; known: pi, claude, codex, fake",
         "unknown harness names the harness and the known set"
     );
 
@@ -93,7 +94,131 @@ fn harness_models_unknown_harness_errors() {
     assert_eq!(error["error"]["code"], 2);
     assert_eq!(
         error["error"]["message"],
-        "not found: unknown harness 'ghost'; known: pi, claude, fake"
+        "not found: unknown harness 'ghost'; known: pi, claude, codex, fake"
+    );
+}
+
+#[test]
+fn harness_codex_models_efforts_and_permissions() {
+    let td = TestDaemon::start(&[]);
+
+    // --json: full HarnessCapabilities — no model aliases (models are
+    // free-form), the full effort ladder with `off` first (mapped to codex
+    // `none` only at argv time), and the three user-facing approval presets.
+    let out = td.board(&["harness", "models", "codex", "--json"]);
+    let caps: board_core::capability::HarnessCapabilities =
+        serde_json::from_value(json_output(&out)).expect("parse HarnessCapabilities");
+    assert_eq!(caps.harness, "codex");
+    assert!(
+        caps.models.is_empty(),
+        "codex models are free-form, not aliased"
+    );
+    assert!(caps.model_freeform);
+    let efforts: Vec<&str> = caps.default_efforts.iter().map(|e| e.as_str()).collect();
+    assert_eq!(
+        efforts,
+        vec!["off", "minimal", "low", "medium", "high", "xhigh", "max"],
+        "the full board ladder; off maps to codex `none` only while building argv"
+    );
+    assert_eq!(
+        caps.permission_modes,
+        vec!["ask-for-approval", "approve-for-me", "full-access"],
+        "the three user-facing approval presets; sandbox stays a separate dimension"
+    );
+
+    // human: notes the free-form catalog (there is no model table to render).
+    let out = td.board(&["harness", "models", "codex"]);
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("any model string accepted"),
+        "human output notes model_freeform; got:\n{text}"
+    );
+
+    // efforts: every model string is accepted (known:false) with all 7 levels.
+    let out = td.board(&[
+        "harness",
+        "efforts",
+        "codex",
+        "--model",
+        "gpt-5.2-codex",
+        "--json",
+    ]);
+    let v = json_output(&out);
+    assert_eq!(v["model"], "gpt-5.2-codex");
+    assert_eq!(v["known"], false);
+    let efforts: Vec<&str> = v["efforts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        efforts,
+        vec!["off", "minimal", "low", "medium", "high", "xhigh", "max"]
+    );
+
+    // permissions: exactly the three approval presets, JSON and one-per-line.
+    let out = td.board(&["harness", "permissions", "codex", "--json"]);
+    let modes: Vec<String> = serde_json::from_value(json_output(&out)).unwrap();
+    assert_eq!(
+        modes,
+        vec!["ask-for-approval", "approve-for-me", "full-access"]
+    );
+    let out = td.board(&["harness", "permissions", "codex"]);
+    assert!(out.status.success());
+    let text = String::from_utf8_lossy(&out.stdout);
+    for mode in ["ask-for-approval", "approve-for-me", "full-access"] {
+        assert!(
+            text.lines().any(|l| l == mode),
+            "missing permission line {mode}; got:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn harness_codex_models_overlay_live_catalog_from_codex_home() {
+    // A CODEX_HOME with models_cache.json → the daemon overlays the visible
+    // model slugs and their per-model supported_reasoning_levels (efforts
+    // filtered to the board ladder: `none`→off, `ultra` dropped).
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("models_cache.json"),
+        r#"{"models": [
+          {"slug": "gpt-5.6-sol", "visibility": "list",
+           "supported_reasoning_levels": [
+             {"effort": "none"}, {"effort": "low"}, {"effort": "high"},
+             {"effort": "ultra"}]},
+          {"slug": "gpt-5.6-sol-wm", "visibility": "hide",
+           "supported_reasoning_levels": [{"effort": "low"}]}
+        ]}"#,
+    )
+    .unwrap();
+    let td = TestDaemon::start(&[("CODEX_HOME", dir.path().to_str().unwrap())]);
+
+    let out = td.board(&["harness", "models", "codex", "--json"]);
+    let caps: board_core::capability::HarnessCapabilities =
+        serde_json::from_value(json_output(&out)).expect("parse HarnessCapabilities");
+    let ids: Vec<&str> = caps.models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["gpt-5.6-sol"], "visible slugs only");
+    assert_eq!(caps.models[0].id, "gpt-5.6-sol");
+    let efforts: Vec<&str> = caps.models[0].efforts.iter().map(|e| e.as_str()).collect();
+    assert_eq!(
+        efforts,
+        vec!["off", "low", "high"],
+        "none maps to off; ultra is filtered out of the wire protocol"
+    );
+    assert!(caps.model_freeform);
+
+    // The static catalog is the fallback when CODEX_HOME has no cache.
+    let empty = tempfile::tempdir().unwrap();
+    let td = TestDaemon::start(&[("CODEX_HOME", empty.path().to_str().unwrap())]);
+    let out = td.board(&["harness", "models", "codex", "--json"]);
+    let caps: board_core::capability::HarnessCapabilities =
+        serde_json::from_value(json_output(&out)).unwrap();
+    assert!(
+        caps.models.is_empty(),
+        "missing cache keeps the static catalog"
     );
 }
 
@@ -258,6 +383,192 @@ fn card_new_rejects_pi_permission_mode() {
     ]);
     assert!(!out.status.success());
     assert!(String::from_utf8_lossy(&out.stderr).contains("pi does not support permission modes"));
+}
+
+#[test]
+fn card_new_codex_effort_and_approval_persist() {
+    let td = TestDaemon::start(&[]);
+
+    // A codex card: free-form model, the `off` effort (spelled `none` for the
+    // codex CLI only at launch time), and an explicit approval preset.
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        "codex task",
+        "--harness",
+        "codex",
+        "--model",
+        "gpt-5.2-codex",
+        "--effort",
+        "off",
+        "--permission",
+        "full-access",
+        "--json",
+    ]);
+    let card = json_output(&out);
+    assert_eq!(card["harness"], "codex");
+    assert_eq!(card["model"], "gpt-5.2-codex");
+    assert_eq!(card["effort"], "off");
+    assert_eq!(card["permission_mode"], "full-access");
+    let id = card["id"].as_i64().expect("card id");
+
+    // Edit flips to the other end of the ladder and a different approval preset.
+    let edited = json_output(&td.board(&[
+        "card",
+        "edit",
+        &id.to_string(),
+        "--effort",
+        "max",
+        "--permission",
+        "ask-for-approval",
+        "--json",
+    ]));
+    assert_eq!(edited["effort"], "max");
+    assert_eq!(edited["permission_mode"], "ask-for-approval");
+    assert_eq!(edited["harness"], "codex");
+}
+
+#[test]
+fn card_new_rejects_codex_out_of_catalog_values() {
+    let td = TestDaemon::start(&[]);
+
+    // `ultra` is deliberately not in this version's codex ladder — the CLI
+    // rejects it up front, listing the exact canonical board efforts.
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        "bad effort",
+        "--harness",
+        "codex",
+        "--effort",
+        "ultra",
+    ]);
+    assert!(!out.status.success(), "ultra must be rejected for codex");
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        err.trim_end(),
+        "board: invalid effort 'ultra' (expected: off, minimal, low, medium, high, xhigh, max)",
+        "the CLI's effort vocabulary is the full board ladder, off first; no ultra"
+    );
+
+    // A Claude-only permission mode is not a codex approval preset.
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        "bad perm",
+        "--harness",
+        "codex",
+        "--permission",
+        "acceptEdits",
+    ]);
+    assert!(
+        !out.status.success(),
+        "claude modes must be rejected for codex"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("permission mode 'acceptEdits' is not accepted"),
+        "names the rejected permission; got: {err}"
+    );
+
+    // The old codex-internal approval ids are gone: the board-facing
+    // vocabulary is the three presets, so `untrusted` is rejected up front.
+    let out = td.board(&[
+        "card",
+        "new",
+        "--title",
+        "legacy perm",
+        "--harness",
+        "codex",
+        "--permission",
+        "untrusted",
+    ]);
+    assert!(
+        !out.status.success(),
+        "untrusted is a codex-internal id, not a board-facing preset"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("permission mode 'untrusted' is not accepted"),
+        "names the rejected permission; got: {err}"
+    );
+}
+
+#[test]
+fn column_create_codex_overrides_persist_and_clear() {
+    let td = TestDaemon::start(&[]);
+
+    let created = json_output(&td.board(&[
+        "column",
+        "create",
+        "--name",
+        "Codex stage",
+        "--harness",
+        "codex",
+        "--model",
+        "gpt-5.2-codex",
+        "--effort",
+        "minimal",
+        "--permission",
+        "ask-for-approval",
+        "--json",
+    ]));
+    let id = created["id"].as_i64().expect("created column id");
+    assert_eq!(created["harness_override"], "codex");
+    assert_eq!(created["model_override"], "gpt-5.2-codex");
+    assert_eq!(created["effort_override"], "minimal");
+    assert_eq!(created["permission_override"], "ask-for-approval");
+
+    let edited = json_output(&td.board(&[
+        "column",
+        "edit",
+        &id.to_string(),
+        "--effort",
+        "off",
+        "--permission",
+        "full-access",
+        "--json",
+    ]));
+    assert_eq!(edited["effort_override"], "off");
+    assert_eq!(edited["permission_override"], "full-access");
+    assert_eq!(edited["harness_override"], "codex");
+
+    let cleared = json_output(&td.board(&[
+        "column",
+        "edit",
+        &id.to_string(),
+        "--clear-harness",
+        "--clear-model",
+        "--clear-effort",
+        "--clear-permission",
+        "--json",
+    ]));
+    assert_eq!(cleared["harness_override"], Value::Null);
+    assert_eq!(cleared["model_override"], Value::Null);
+    assert_eq!(cleared["effort_override"], Value::Null);
+    assert_eq!(cleared["permission_override"], Value::Null);
+
+    // The per-card-only opt-in stays rejected at the column boundary for
+    // codex too (the catalog is never consulted for it).
+    let out = td.board(&[
+        "column",
+        "create",
+        "--name",
+        "Bad",
+        "--harness",
+        "codex",
+        "--permission",
+        "bypassPermissions",
+    ]);
+    assert!(
+        !out.status.success(),
+        "bypassPermissions is never a column override"
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(err.contains("bypassPermissions"), "got: {err}");
 }
 
 #[test]

--- a/crates/board-core/src/capability.rs
+++ b/crates/board-core/src/capability.rs
@@ -2,7 +2,8 @@
 //!
 //! Built-in harness catalogs are intentionally small and static. Pi models stay
 //! free-form because they depend on provider/auth/user configuration; Claude's
-//! aliases are field-verified against Claude CLI 2.1.209. Config-defined
+//! aliases are field-verified against Claude CLI 2.1.209; codex is free-form
+//! with the full effort ladder and a fixed approval-mode enum. Config-defined
 //! harnesses declare capabilities in `[harness.NAME]`.
 
 use serde::{Deserialize, Serialize};
@@ -185,7 +186,6 @@ const CLAUDE_PERMISSION_MODES: [&str; 6] = [
 /// and therefore free-form; thinking is valid for omitted and explicit model
 /// ids; Pi has no board-level tool permission mode.
 pub struct Pi;
-
 impl HarnessMeta for Pi {
     fn id(&self) -> &str {
         "pi"
@@ -260,6 +260,55 @@ impl HarnessMeta for Claude {
     }
 }
 
+/// Codex reasoning efforts, ascending — the full board ladder. `off` maps to
+/// codex's `none` only while building argv ([`crate::harness::codex`]).
+const CODEX_EFFORTS: [Effort; 7] = [
+    Effort::Off,
+    Effort::Minimal,
+    Effort::Low,
+    Effort::Medium,
+    Effort::High,
+    Effort::Xhigh,
+    Effort::Max,
+];
+
+/// The codex CLI approval presets (board-facing ids). Each maps to an exact
+/// codex CLI spelling while building argv (see [`crate::harness::codex`]):
+/// `ask-for-approval`, `approve-for-me`, `full-access`. Sandbox stays a
+/// separate dimension and never hides inside this list.
+const CODEX_PERMISSION_MODES: [&str; 3] = ["ask-for-approval", "approve-for-me", "full-access"];
+
+/// Built-in `codex` harness adapter (zero-sized). Models are free-form (no
+/// alias catalog); every effort level is accepted for any model; approval is
+/// the fixed enum above; resume/fork are conversation-id subcommands.
+pub struct Codex;
+
+impl HarnessMeta for Codex {
+    fn id(&self) -> &str {
+        "codex"
+    }
+    fn models(&self) -> Vec<ModelInfo> {
+        Vec::new()
+    }
+    fn efforts(&self, _model: Option<&str>) -> Vec<Effort> {
+        CODEX_EFFORTS.to_vec()
+    }
+    fn permissions(&self) -> Vec<String> {
+        CODEX_PERMISSION_MODES
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+    fn model_freeform(&self) -> bool {
+        true
+    }
+    fn resume(&self) -> ResumeSupport {
+        // `codex resume <id>` re-opens a recorded thread (verified against the
+        // fixture harness in `e2e/fake-bin/codex`).
+        ResumeSupport::ByConversationId
+    }
+}
+
 /// Owning adapter for a config-defined harness (`[harness.NAME]`).
 pub struct ConfigHarness {
     name: String,
@@ -325,6 +374,7 @@ pub fn meta_for(harness: &str, config: &Config) -> Option<Box<dyn HarnessMeta>> 
     match harness {
         "pi" => Some(Box::new(Pi)),
         "claude" => Some(Box::new(Claude)),
+        "codex" => Some(Box::new(Codex)),
         _ => config.harness.get(harness).map(|def| {
             Box::new(ConfigHarness {
                 name: harness.to_string(),
@@ -366,6 +416,11 @@ pub fn pi_capabilities() -> HarnessCapabilities {
     HarnessCapabilities::from_meta(&Pi)
 }
 
+/// Built-in codex capabilities.
+pub fn codex_capabilities() -> HarnessCapabilities {
+    HarnessCapabilities::from_meta(&Codex)
+}
+
 /// Resolve capabilities for a built-in or config-defined harness via its
 /// [`HarnessMeta`] adapter. Unknown harness → `None`.
 pub fn capabilities_for(harness: &str, config: &Config) -> Option<HarnessCapabilities> {
@@ -389,6 +444,7 @@ pub fn default_capabilities(harness: &str) -> HarnessCapabilities {
     match harness {
         "pi" => pi_capabilities(),
         "claude" => claude_capabilities(),
+        "codex" => codex_capabilities(),
         _ => HarnessCapabilities {
             harness: harness.to_string(),
             models: Vec::new(),

--- a/crates/board-core/src/codex_catalog.rs
+++ b/crates/board-core/src/codex_catalog.rs
@@ -1,0 +1,190 @@
+//! Live Codex model catalog: populate real codex models + per-model efforts.
+//!
+//! The codex CLI ships a built-in capability catalog with `models: []`
+//! (free-form), but the CLI's own catalog is discoverable on disk: the
+//! integration writes `$CODEX_HOME/models_cache.json` (default
+//! `~/.codex/models_cache.json`) with every model the CLI knows and the
+//! reasoning levels each accepts. Unlike Pi there is no auth step — the cache
+//! is the catalog, and a per-model `visibility` marks which slugs the CLI
+//! actually offers the user.
+//!
+//! So the daemon's live codex catalog is:
+//!   1. read `models_cache.json` from the codex home;
+//!   2. keep the **visible** model slugs (`visibility` missing or `"list"`),
+//!      mapping each `supported_reasoning_levels` into the board `Effort`
+//!      ladder — codex's `none` becomes the board's `off`, and levels the
+//!      board does not know (e.g. `ultra`) are filtered out rather than
+//!      growing the protocol enum;
+//!   3. fall back to the static free-form catalog (`models: []`) when the
+//!      file is missing, malformed, empty, or from a newer CLI whose shape
+//!      this parser does not recognize.
+//!
+//! The modern shape is `{"models": [{"slug", "visibility", ...,
+//! "supported_reasoning_levels": [{"effort", "description"}]}]}`; the legacy
+//! map shape (`{slug: {supported_reasoning_levels: [...]}}`) and plain-string
+//! levels are also accepted. Everything here is pure file reading; nothing
+//! mutates state. `auth.json` is deliberately never read.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::capability::ModelInfo;
+use crate::protocol::Effort;
+
+/// Resolve the codex home: `$CODEX_HOME` else `~/.codex`. Mirrors the codex
+/// CLI's own default. Returns `None` when no home dir is known.
+pub fn default_codex_home() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("CODEX_HOME") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|h| !h.is_empty())
+        .map(|h| PathBuf::from(h).join(".codex"))
+}
+
+/// The board's canonical ascending effort order (also the order codex's
+/// cache uses, minus `none` which maps onto [`Effort::Off`]).
+const EFFORT_ORDER: [Effort; 7] = [
+    Effort::Off,
+    Effort::Minimal,
+    Effort::Low,
+    Effort::Medium,
+    Effort::High,
+    Effort::Xhigh,
+    Effort::Max,
+];
+
+/// Map one codex reasoning level onto the board ladder. Codex spells the
+/// lowest level `none` where the board says `off`; any level the board does
+/// not know (e.g. `ultra`) maps to `None` and is filtered out — the `Effort`
+/// enum is protocol and never grows from a cache.
+fn effort_from_level(level: &str) -> Option<Effort> {
+    if level == "none" {
+        return Some(Effort::Off);
+    }
+    Effort::parse_str(level)
+}
+
+/// Collect a model's `supported_reasoning_levels` (objects with an `effort`
+/// field, or plain strings) into the canonical ascending board ladder, with
+/// unknown levels filtered and duplicates removed. Empty result means the
+/// model cannot express any board effort and must be dropped.
+fn efforts_of(levels: Option<&Value>) -> Vec<Effort> {
+    let mut supported: Vec<Effort> = Vec::new();
+    if let Some(Value::Array(items)) = levels {
+        for item in items {
+            let level = match item {
+                Value::String(s) => Some(s.as_str()),
+                Value::Object(map) => map.get("effort").and_then(Value::as_str),
+                _ => None,
+            };
+            if let Some(level) = level {
+                if let Some(effort) = effort_from_level(level) {
+                    if !supported.contains(&effort) {
+                        supported.push(effort);
+                    }
+                }
+            }
+        }
+    }
+    EFFORT_ORDER
+        .iter()
+        .copied()
+        .filter(|effort| supported.contains(effort))
+        .collect()
+}
+
+/// Whether the cache marks this entry as offered to the user. `visibility`
+/// missing (legacy entries) or `"list"` means visible; anything else
+/// (`"hide"` — e.g. `codex-auto-review`) is dropped.
+fn is_visible(entry: &Value) -> bool {
+    matches!(
+        entry.get("visibility").and_then(Value::as_str),
+        None | Some("list")
+    )
+}
+
+/// The model slug of one cache entry: its `slug`/`id` field, or the map key
+/// the entry sits under.
+fn slug_of(entry: &Value, map_key: Option<&str>) -> Option<String> {
+    entry
+        .get("slug")
+        .or_else(|| entry.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| map_key.map(str::to_string))
+}
+
+/// Load the live codex model catalog from `codex_home`'s `models_cache.json`.
+/// Returns `None` when the file is missing/unreadable/malformed or yields no
+/// usable models (the caller falls back to the static free-form catalog).
+pub fn load_from_files(codex_home: &Path) -> Option<Vec<ModelInfo>> {
+    let raw = std::fs::read_to_string(codex_home.join("models_cache.json")).ok()?;
+    let root: Value = serde_json::from_str(&raw).ok()?;
+
+    // Candidate `(slug, entry)` pairs: the modern `models` array, a
+    // `models`-as-map middle shape, or a legacy top-level slug map.
+    let mut pairs: Vec<(String, Value)> = Vec::new();
+    match root.get("models") {
+        Some(Value::Array(entries)) => {
+            for entry in entries {
+                if let Some(slug) = slug_of(entry, None) {
+                    pairs.push((slug, entry.clone()));
+                }
+            }
+        }
+        Some(Value::Object(map)) => {
+            for (slug, entry) in map {
+                pairs.push((slug.clone(), entry.clone()));
+            }
+        }
+        _ => match &root {
+            Value::Object(map) if !map.is_empty() => {
+                for (slug, entry) in map {
+                    pairs.push((slug.clone(), entry.clone()));
+                }
+            }
+            _ => return None,
+        },
+    }
+
+    let mut out: Vec<ModelInfo> = Vec::new();
+    for (slug, entry) in pairs {
+        // A bare string entry (slug only) carries no level information.
+        let Value::Object(_) = &entry else { continue };
+        if !is_visible(&entry) {
+            continue;
+        }
+        let efforts = efforts_of(entry.get("supported_reasoning_levels"));
+        if efforts.is_empty() {
+            // Every level got filtered (or none were declared): the board
+            // cannot express this model at any effort, so it stays out of the
+            // catalog — the model is still accepted free-form with the
+            // default ladder.
+            continue;
+        }
+        out.push(ModelInfo { id: slug, efforts });
+    }
+    if out.is_empty() {
+        return None;
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out.dedup_by(|a, b| a.id == b.id);
+    Some(out)
+}
+
+/// The live codex model catalog: on-disk cache first, else empty (the caller
+/// keeps the static free-form catalog).
+///
+/// Live discovery is **disabled** when `codex_home` is `None` — the daemon
+/// only sets it at startup; tests leave it unset and get the static catalog.
+pub fn live_models(codex_home: Option<&Path>) -> Vec<ModelInfo> {
+    let Some(home) = codex_home else {
+        return Vec::new();
+    };
+    load_from_files(home).unwrap_or_default()
+}

--- a/crates/board-core/src/config.rs
+++ b/crates/board-core/src/config.rs
@@ -81,6 +81,12 @@ pub struct Config {
     /// daemon fills this in at startup; tests leave it `None` to stay hermetic.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pi_agent_dir: Option<PathBuf>,
+    /// Codex home to read the live model catalog from (`models_cache.json`).
+    /// `None` disables live codex model discovery → the `codex` harness
+    /// reports the static free-form catalog (`models: []`). The daemon fills
+    /// this in at startup; tests leave it `None` to stay hermetic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_home: Option<PathBuf>,
 }
 
 /// A config-defined harness: an argv template plus an optional capability
@@ -121,6 +127,7 @@ impl Default for Config {
             idle_grace_seconds: default_idle_grace_seconds(),
             harness: HashMap::new(),
             pi_agent_dir: None,
+            codex_home: None,
         }
     }
 }

--- a/crates/board-core/src/db/mod.rs
+++ b/crates/board-core/src/db/mod.rs
@@ -25,6 +25,10 @@ pub enum LifecycleFaultPoint {
     EnqueueAfterRunInsert,
     PromoteAfterRunUpdate,
     FinalizeAfterRunUpdate,
+    /// After the run row of a captured-session promotion is written, before
+    /// the card row: the daemon can die between the two, and the unit of work
+    /// must still roll back as one.
+    CaptureAfterRunUpdate,
 }
 
 /// All values needed to insert one queued run. Prompt building and external I/O

--- a/crates/board-core/src/db/runs.rs
+++ b/crates/board-core/src/db/runs.rs
@@ -66,12 +66,21 @@ impl Db {
             pane_id,
             None,
             timeout_deadline_at_ms,
+            None,
         )
     }
 
     /// Atomically promote an exact queued run and persist the runtime card-tab
     /// anchor alongside its child pane. Legacy callers use
     /// [`Self::promote_run_uow`] and retain a NULL anchor.
+    ///
+    /// `captured_session_id` is the harness-reported conversation/thread id of
+    /// a self-minting integration (codex): when present it is written to the
+    /// run **and** the card in this same transaction, so the promotion and the
+    /// session identity can never be half-committed (a cancel-during-spawn
+    /// that ended the run fails the promotion before either row is touched).
+    /// `None` keeps the enqueue-time id — a fork whose new thread id was not
+    /// captured degrades to the recorded source id instead of wiping it.
     pub fn promote_run_with_anchor_uow(
         &self,
         run_id: i64,
@@ -79,6 +88,7 @@ impl Db {
         pane_id: Option<&str>,
         anchor_pane_id: Option<&str>,
         timeout_deadline_at_ms: Option<i64>,
+        captured_session_id: Option<&str>,
     ) -> Result<Run> {
         let tx = self.conn.unchecked_transaction()?;
         let card_id: i64 = tx
@@ -94,13 +104,68 @@ impl Db {
                 other => Error::Sqlite(other),
             })?;
         tx.execute(
-            "UPDATE runs SET started_at=datetime('now'),herdr_workspace_id=?1,herdr_pane_id=?2,herdr_anchor_pane_id=?3,timeout_deadline_at_ms=?5,timeout_paused_at_ms=NULL WHERE id=?4",
-            params![workspace_id,pane_id,anchor_pane_id,run_id,timeout_deadline_at_ms],
+            "UPDATE runs SET started_at=datetime('now'),herdr_workspace_id=?1,herdr_pane_id=?2,herdr_anchor_pane_id=?3,timeout_deadline_at_ms=?5,timeout_paused_at_ms=NULL,session_id=COALESCE(?6,session_id) WHERE id=?4",
+            params![workspace_id,pane_id,anchor_pane_id,run_id,timeout_deadline_at_ms,captured_session_id],
         )?;
         self.lifecycle_fault(LifecycleFaultPoint::PromoteAfterRunUpdate)?;
+        // The captured-session write is part of the same promotion: a crash or
+        // injected fault between the two updates must roll back the run row
+        // too, exactly like the card-status update below.
+        if captured_session_id.is_some() {
+            self.lifecycle_fault(LifecycleFaultPoint::CaptureAfterRunUpdate)?;
+        }
         tx.execute(
-            "UPDATE cards SET status='running',awaiting_reason=NULL,updated_at=datetime('now') WHERE id=?1",
-            params![card_id],
+            "UPDATE cards SET status='running',awaiting_reason=NULL,session_id=COALESCE(?2,session_id),updated_at=datetime('now') WHERE id=?1",
+            params![card_id, captured_session_id],
+        )?;
+        tx.commit()?;
+        self.get_run(run_id)
+    }
+
+    /// Atomically persist a harness-captured session id on the exact open run
+    /// **and** its card, in one transaction.
+    ///
+    /// The daemon's launch path persists a captured id through
+    /// [`Self::promote_run_with_anchor_uow`] instead (promotion + session in
+    /// one commit). This primitive remains the single-row owner for captures
+    /// written outside promotion — e.g. a capture that races promotion while
+    /// the run is still queued — and pins the same atomicity contract: the
+    /// run and its card must never disagree about the conversation id a
+    /// resume/fork would re-attach to.
+    ///
+    /// The run must still be open (`ended_at IS NULL`): a cancel-during-spawn
+    /// that ended the run while the capture was in flight makes the write fail
+    /// closed instead of resurrecting identity on a dead run. A blank id is
+    /// rejected the same way. Replacing an id (e.g. a fork whose NEW thread id
+    /// supersedes the source id recorded at enqueue) is the intended use;
+    /// schema stays v13 — this only writes the existing columns.
+    pub fn promote_captured_session_uow(&self, run_id: i64, session_id: &str) -> Result<Run> {
+        if session_id.trim().is_empty() {
+            return Err(Error::BadRequest(
+                "captured session id must not be empty".into(),
+            ));
+        }
+        let tx = self.conn.unchecked_transaction()?;
+        let card_id: i64 = tx
+            .query_row(
+                "SELECT card_id FROM runs WHERE id=?1 AND ended_at IS NULL",
+                params![run_id],
+                |r| r.get(0),
+            )
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    Error::InvalidState(format!("run {run_id} is not open"))
+                }
+                other => Error::Sqlite(other),
+            })?;
+        tx.execute(
+            "UPDATE runs SET session_id=?1 WHERE id=?2",
+            params![session_id, run_id],
+        )?;
+        self.lifecycle_fault(LifecycleFaultPoint::CaptureAfterRunUpdate)?;
+        tx.execute(
+            "UPDATE cards SET session_id=?1,updated_at=datetime('now') WHERE id=?2",
+            params![session_id, card_id],
         )?;
         tx.commit()?;
         self.get_run(run_id)

--- a/crates/board-core/src/harness/codex.rs
+++ b/crates/board-core/src/harness/codex.rs
@@ -1,0 +1,158 @@
+//! Built-in `codex` harness adapter (C7): argv, session syntax, and prompt
+//! transport for the Codex CLI as a Herdr managed agent (kind `"codex"`).
+//!
+//! Field-verified facts (the Codex harness plan + `docs/research.md`):
+//! - codex mints its own thread/session UUID; there is **no public
+//!   `--session-id` for Mint**, so the board never invents one: a codex Mint
+//!   carries no session flag and reports `resulting_session_id: None`, which
+//!   is the daemon's signal to persist `NULL`. The thread id arrives only
+//!   after launch via `agent.get.agent_session` and is promoted atomically
+//!   onto run+card (`Db::promote_captured_session_uow`);
+//! - resume and fork are **subcommands**: `codex resume <id>` / `codex fork
+//!   <id>`, appended last to the startup argv like every other harness's
+//!   session flags;
+//! - the model is free-form via `--model`;
+//! - reasoning effort rides `-c model_reasoning_effort=<value>`; codex spells
+//!   the lowest level `none` where the board says `off`. The mapping happens
+//!   only here, while building argv — the `Effort` enum is unchanged;
+//! - approval rides board-facing presets — `ask-for-approval` →
+//!   `--sandbox workspace-write --ask-for-approval on-request`,
+//!   `approve-for-me` → `--approve-for-me` (which routes through the
+//!   workspace-write sandbox per the CLI's own help), `full-access` →
+//!   `--dangerously-bypass-approvals-and-sandbox`. Sandbox is a separate
+//!   dimension and is only ever spelled explicitly for the first preset;
+//! - codex has no system-prompt-file equivalent: the managed prompt channels
+//!   (`initial_prompt` / `system_prompt`) are the only prompt transport, so
+//!   startup argv carries neither task nor system text.
+
+use crate::harness::{protocol_system_prompt, HarnessError, HarnessInvocation, SessionPlan};
+use crate::prompt::EffectiveSettings;
+use crate::protocol::Effort;
+
+/// The `model_reasoning_effort` value codex expects for each board effort.
+/// The board's lowest effort is `off`; codex calls it `none`. Every other
+/// level keeps its canonical spelling (no `ultra` in this version).
+pub(super) fn effort_value(effort: Effort) -> &'static str {
+    match effort {
+        Effort::Off => "none",
+        Effort::Minimal => "minimal",
+        Effort::Low => "low",
+        Effort::Medium => "medium",
+        Effort::High => "high",
+        Effort::Xhigh => "xhigh",
+        Effort::Max => "max",
+    }
+}
+
+/// The exact startup flags each board-facing approval preset maps to.
+/// Verified against the installed codex CLI's help:
+/// - `ask-for-approval` → `--sandbox workspace-write --ask-for-approval
+///   on-request` (the explicit sandbox keeps the pair self-contained);
+/// - `approve-for-me` → `--approve-for-me` alone — the CLI's own help routes
+///   it through the workspace-write sandbox, so no `--sandbox` is needed;
+/// - `full-access` → `--dangerously-bypass-approvals-and-sandbox` alone.
+///
+/// Unknown values pass through as `--ask-for-approval <value>` for forward
+/// compatibility; the engine's capability validation gates card/column
+/// permission values to the catalog before any launch, so only the three
+/// presets reach argv in practice.
+pub(super) fn approval_argv(permission: &str) -> Vec<String> {
+    match permission {
+        "ask-for-approval" => vec![
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "--ask-for-approval".to_string(),
+            "on-request".to_string(),
+        ],
+        "approve-for-me" => vec!["--approve-for-me".to_string()],
+        "full-access" => vec!["--dangerously-bypass-approvals-and-sandbox".to_string()],
+        other => vec!["--ask-for-approval".to_string(), other.to_string()],
+    }
+}
+
+/// The exact startup flags codex uses to express a [`SessionPlan`], plus the
+/// harness conversation id the run should persist.
+///
+/// Mint takes no session flag at all: codex mints its own thread id, and the
+/// offered `target_uuid` is deliberately ignored — a board-invented uuid must
+/// never surface in argv or persist. Resume and fork are subcommands carrying
+/// the real recorded id; the fork's NEW thread id replaces it atomically at
+/// promotion once the integration reports it.
+pub(super) fn session_argv(
+    session: &SessionPlan,
+    _target_uuid: Option<&str>,
+) -> Result<(Vec<String>, Option<String>), HarnessError> {
+    Ok(match session {
+        SessionPlan::Mint => (Vec::new(), None),
+        SessionPlan::Resume(id) => (vec!["resume".to_string(), id.clone()], Some(id.clone())),
+        SessionPlan::Fork(id) => (vec!["fork".to_string(), id.clone()], Some(id.clone())),
+    })
+}
+
+/// Session-carrying argv tokens for re-threading a *persisted* codex argv:
+/// `resume <id>` / `fork <id>` are subcommand + value pairs, so
+/// [`crate::harness::strip_session_flags`] treats each as a two-token unit.
+pub(super) const SESSION_FLAGS: &[(&str, bool)] = &[("resume", true), ("fork", true)];
+
+/// Section delimiter naming the system-instructions half of the codex Mint
+/// prompt block (see [`mint_prompt`]).
+pub const MINT_SYSTEM_DELIMITER: &str = "## herdr-board system instructions";
+/// Section delimiter naming the card-task half of the codex Mint prompt block
+/// (see [`mint_prompt`]).
+pub const MINT_TASK_DELIMITER: &str = "## herdr-board card task";
+
+/// Compose the single `agent.prompt` block a codex **Mint** receives: the
+/// system instructions first, then the card task, each under its own clearly
+/// delimited heading.
+///
+/// Codex has no system-prompt file equivalent and no prompt in startup argv,
+/// so this block is the *only* prompt transport for a fresh conversation: the
+/// integration reads the system instructions and the task from one prompt,
+/// with the delimiters making the boundary explicit (and byte-assertable).
+/// Resume, fork and same-pane reuse deliver the task alone; a rescue delivers
+/// neither.
+pub fn mint_prompt(system_prompt: &str, task: &str) -> String {
+    format!("{MINT_SYSTEM_DELIMITER}\n{system_prompt}\n\n{MINT_TASK_DELIMITER}\n{task}")
+}
+
+/// Build a managed Herdr codex launch: `codex [--model M]
+/// [-c model_reasoning_effort=E] [permission preset flags] [resume|fork <id>]`.
+///
+/// Both prompt channels ride outside argv — `initial_prompt` carries the card
+/// task, `system_prompt` the column instructions plus the protocol trailer —
+/// and the daemon submits them only after the agent is interactive (Mint:
+/// `system_prompt + task` delimited block; Resume/Fork/reuse: task only;
+/// rescue re-sends neither). Startup argv therefore contains no prompt text
+/// and no `--` delimiter.
+pub fn managed_codex_invocation(
+    settings: &EffectiveSettings,
+    session: &SessionPlan,
+    minted_uuid: Option<&str>,
+    prompt: &str,
+) -> Result<HarnessInvocation, HarnessError> {
+    let mut argv = vec!["codex".to_string()];
+    if let Some(model) = &settings.model {
+        argv.extend(["--model".to_string(), model.clone()]);
+    }
+    if let Some(effort) = settings.effort {
+        argv.extend([
+            "-c".to_string(),
+            format!("model_reasoning_effort={}", effort_value(effort)),
+        ]);
+    }
+    if let Some(permission) = &settings.permission_mode {
+        argv.extend(approval_argv(permission));
+    }
+
+    let (session_flags, resulting_session_id) = session_argv(session, minted_uuid)?;
+    argv.extend(session_flags);
+
+    Ok(HarnessInvocation {
+        agent_kind: Some("codex".to_string()),
+        initial_prompt: Some(prompt.to_string()),
+        system_prompt: Some(protocol_system_prompt(settings.system_prompt.as_deref())),
+        argv,
+        env: Vec::new(),
+        resulting_session_id,
+    })
+}

--- a/crates/board-core/src/harness/mod.rs
+++ b/crates/board-core/src/harness/mod.rs
@@ -1,9 +1,12 @@
 //! Harness adapters: turn resolved settings + a prompt into `(argv, env)`.
 //!
-//! Two kinds:
-//! - built-ins `pi` and `claude` — flags exactly per `docs/protocol.md`;
+//! Three kinds:
+//! - built-ins `pi`, `claude` and `codex` — flags exactly per
+//!   `docs/protocol.md` (the codex adapter lives in [`codex`]);
 //! - config-defined harnesses — an argv template with `{model}`/`{effort}`/
 //!   `{permission_mode}` placeholders; prompt via `BOARD_PROMPT` env.
+
+pub mod codex;
 
 use crate::capability::ResumeSupport;
 use crate::config::Config;
@@ -13,7 +16,7 @@ use crate::prompt::EffectiveSettings;
 /// Harness stored on newly-created cards when the caller omits one.
 pub const DEFAULT_HARNESS: &str = "pi";
 /// Built-ins routed without config-defined argv/env reconstruction.
-pub const BUILTIN_HARNESSES: [&str; 2] = ["pi", "claude"];
+pub const BUILTIN_HARNESSES: [&str; 3] = ["pi", "claude", "codex"];
 
 pub fn is_builtin_harness(name: &str) -> bool {
     BUILTIN_HARNESSES.contains(&name)
@@ -160,6 +163,7 @@ pub fn session_argv(
                 Some(id.clone()),
             )),
         },
+        "codex" => codex::session_argv(session, target_uuid),
         other => Err(HarnessError::UnknownHarness(other.to_string())),
     }
 }
@@ -176,12 +180,24 @@ fn session_flags(harness_name: &str) -> &'static [(&'static str, bool)] {
             ("--resume", true),
             ("--fork-session", false),
         ],
+        "codex" => codex::SESSION_FLAGS,
         _ => &[],
     }
 }
 
 /// Drop every session-carrying flag (and its value) from a persisted argv.
 fn strip_session_flags(harness_name: &str, argv: &[String]) -> Vec<String> {
+    // Codex session syntax is a trailing bare-word subcommand. Its model is
+    // free-form, so `--model resume`/`--model fork` must not be mistaken for
+    // session syntax; only the adapter-owned final pair is removable.
+    if harness_name == "codex" {
+        return if argv.len() >= 2 && matches!(argv[argv.len() - 2].as_str(), "resume" | "fork") {
+            argv[..argv.len() - 2].to_vec()
+        } else {
+            argv.to_vec()
+        };
+    }
+
     let flags = session_flags(harness_name);
     let mut out = Vec::with_capacity(argv.len());
     let mut index = 0;
@@ -409,6 +425,9 @@ pub fn build_invocation(
     }
     if harness_name == "claude" {
         return managed_claude_invocation(settings, session, minted_uuid, prompt);
+    }
+    if harness_name == "codex" {
+        return codex::managed_codex_invocation(settings, session, minted_uuid, prompt);
     }
 
     let def = config

--- a/crates/board-core/src/lib.rs
+++ b/crates/board-core/src/lib.rs
@@ -7,7 +7,8 @@
 //! - [`db`]: rusqlite store, migrations, CRUD, position management, queries.
 //! - [`engine`]: pure column-engine transition/entry/validation decisions.
 //! - [`prompt`]: prompt assembly and effective-settings resolution.
-//! - [`harness`]: argv/env builders for built-in Pi/Claude and config harnesses.
+//! - [`harness`]: argv/env builders for the built-in Pi/Claude/Codex and config
+//!   harnesses.
 //! - [`config`]: `~/.config/herdr-board/config.toml` loader.
 //! - [`paths`]: db/socket/log/config path resolution.
 //! - [`client`]: blocking NDJSON `BoardClient` (+ `FakeBoardClient` behind a feature).
@@ -15,6 +16,7 @@
 
 pub mod capability;
 pub mod client;
+pub mod codex_catalog;
 pub mod config;
 pub mod db;
 pub mod engine;

--- a/crates/board-core/tests/capability.rs
+++ b/crates/board-core/tests/capability.rs
@@ -277,18 +277,18 @@ argv = ["z"]
 argv = ["a"]
 "#;
     let cfg = Config::from_toml(toml).unwrap();
-    // Built-ins first in their default order (pi before claude), then config
-    // keys sorted and de-duplicated.
+    // Built-ins first in their default order (pi before claude, codex slotting
+    // in right after claude), then config keys sorted and de-duplicated.
     assert_eq!(
         available_harnesses(&cfg),
-        vec!["pi", "claude", "alpha", "zeta"]
+        vec!["pi", "claude", "codex", "alpha", "zeta"]
     );
 }
 
 #[test]
 fn capabilities_match_trait_snapshot() {
     // The wire snapshot and the trait agree for every built-in.
-    for h in ["pi", "claude"] {
+    for h in ["pi", "claude", "codex"] {
         let cfg = Config::default();
         let via_fn = capabilities_for(h, &cfg).unwrap();
         let via_trait = {

--- a/crates/board-core/tests/codex_catalog.rs
+++ b/crates/board-core/tests/codex_catalog.rs
@@ -1,0 +1,174 @@
+//! Live Codex model catalog discovery (`CODEX_HOME/models_cache.json`).
+//!
+//! Codex keeps a models cache at `$CODEX_HOME/models_cache.json` (default
+//! `~/.codex/models_cache.json`). It lists every model the CLI knows, with a
+//! per-model `supported_reasoning_levels` array — the same vocabulary the
+//! board needs for `ModelInfo.efforts`. Unlike Pi there is no auth step: the
+//! cache is the catalog, and `visibility: "list"` marks the models the CLI
+//! actually offers the user.
+//!
+//! Contracts pinned here (the daemon overlays these onto the codex
+//! capabilities exactly like `pi_catalog`):
+//! - the modern shape: `{"models": [{"slug", "visibility", ...,
+//!   "supported_reasoning_levels": [{"effort", "description"}]}]}`;
+//! - visible models only (`visibility` missing or `"list"`; `"hide"` models
+//!   are dropped — `codex-auto-review`-style entries never reach the board);
+//! - codex's `none` level maps to the board's `off`; every other level keeps
+//!   its canonical spelling; levels the board does not know (e.g. `ultra`)
+//!   are filtered out, never added to the `Effort` enum;
+//! - a model whose levels all get filtered is dropped (it stays reachable
+//!   free-form with the default ladder);
+//! - a missing/malformed/empty cache yields `None` → the caller keeps the
+//!   static free-form catalog (`models: []`), so the board never breaks when
+//!   the cache is absent or from a newer CLI;
+//! - the legacy map shape (`{slug: {supported_reasoning_levels: [...]}}`)
+//!   parses too, so an older cache stays usable.
+
+use std::fs;
+
+use board_core::codex_catalog::{live_models, load_from_files};
+use board_core::protocol::Effort;
+
+/// A modern-format cache: top-level `models` array with slugs, visibility and
+/// per-model reasoning levels (mirror of the real codex cache shape, verified
+/// against an installed CLI).
+const MODERN_CACHE: &str = r#"{
+  "fetched_at": "2026-01-01T00:00:00Z",
+  "etag": "abc",
+  "client_version": "0.59.0",
+  "models": [
+    {
+      "slug": "gpt-5.6-sol",
+      "visibility": "list",
+      "supported_reasoning_levels": [
+        {"effort": "low", "description": "fast"},
+        {"effort": "medium", "description": "balanced"},
+        {"effort": "high", "description": "deep"},
+        {"effort": "xhigh", "description": "deeper"},
+        {"effort": "max", "description": "deepest"},
+        {"effort": "ultra", "description": "auto-delegating"}
+      ]
+    },
+    {
+      "slug": "gpt-5.4",
+      "visibility": "list",
+      "supported_reasoning_levels": [
+        {"effort": "none", "description": "no reasoning"},
+        {"effort": "low", "description": "fast"},
+        {"effort": "medium", "description": "balanced"}
+      ]
+    },
+    {
+      "slug": "gpt-5.6-sol-wm",
+      "visibility": "hide",
+      "supported_reasoning_levels": [
+        {"effort": "low", "description": "hidden"}
+      ]
+    },
+    {
+      "slug": "codex-auto-review",
+      "visibility": "hide",
+      "supported_reasoning_levels": [
+        {"effort": "low", "description": "internal"}
+      ]
+    },
+    {
+      "slug": "ultra-only",
+      "visibility": "list",
+      "supported_reasoning_levels": [
+        {"effort": "ultra", "description": "only ultra"}
+      ]
+    }
+  ]
+}"#;
+
+fn fixture_cache(contents: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("models_cache.json"), contents).unwrap();
+    dir
+}
+
+#[test]
+fn maps_visible_slugs_and_reasoning_levels_into_model_info() {
+    let dir = fixture_cache(MODERN_CACHE);
+    let models = load_from_files(dir.path()).unwrap();
+
+    // `hide` models are dropped; `ultra-only` is dropped because every level
+    // got filtered. The two visible models remain, sorted by slug.
+    let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["gpt-5.4", "gpt-5.6-sol"]);
+
+    // Codex `none` maps to board `off`; `ultra` is filtered out; the rest
+    // keep their canonical spellings in ascending order.
+    let sol = models.iter().find(|m| m.id == "gpt-5.6-sol").unwrap();
+    assert_eq!(
+        sol.efforts,
+        vec![
+            Effort::Low,
+            Effort::Medium,
+            Effort::High,
+            Effort::Xhigh,
+            Effort::Max,
+        ],
+        "ultra must be filtered, never added to the Effort enum"
+    );
+    let gpt54 = models.iter().find(|m| m.id == "gpt-5.4").unwrap();
+    assert_eq!(
+        gpt54.efforts,
+        vec![Effort::Off, Effort::Low, Effort::Medium],
+        "codex `none` maps to the board's lowest effort `off`"
+    );
+    let mut deduped = gpt54.efforts.clone();
+    deduped.dedup();
+    assert_eq!(gpt54.efforts, deduped, "no duplicate efforts");
+}
+
+#[test]
+fn legacy_map_shape_with_plain_string_levels_parses() {
+    // Older caches map slug -> model object (some with plain-string levels).
+    let dir = fixture_cache(
+        r#"{
+          "o3": {"supported_reasoning_levels": ["none", "low", "high"]},
+          "gpt-5-mini": {"supported_reasoning_levels": ["minimal", "max", "ultra"]}
+        }"#,
+    );
+    let models = load_from_files(dir.path()).unwrap();
+    let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+    assert_eq!(ids, vec!["gpt-5-mini", "o3"]);
+    let o3 = models.iter().find(|m| m.id == "o3").unwrap();
+    assert_eq!(o3.efforts, vec![Effort::Off, Effort::Low, Effort::High]);
+    let mini = models.iter().find(|m| m.id == "gpt-5-mini").unwrap();
+    assert_eq!(mini.efforts, vec![Effort::Minimal, Effort::Max]);
+}
+
+#[test]
+fn missing_cache_yields_none() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(load_from_files(dir.path()).is_none());
+}
+
+#[test]
+fn malformed_cache_yields_none() {
+    let dir = fixture_cache("not json at all {");
+    assert!(load_from_files(dir.path()).is_none());
+}
+
+#[test]
+fn empty_or_shapeless_cache_yields_none() {
+    // Valid JSON but no models list → nothing to offer.
+    let dir = fixture_cache(r#"{"fetched_at": "x"}"#);
+    assert!(load_from_files(dir.path()).is_none());
+}
+
+#[test]
+fn no_home_disables_live_discovery() {
+    // `live_models(None)` is the daemon's no-configured-home path: empty,
+    // so the caller keeps the static free-form catalog.
+    assert!(live_models(None).is_empty());
+}
+
+#[test]
+fn live_models_falls_back_to_static_on_missing_cache() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(live_models(Some(dir.path())).is_empty());
+}

--- a/crates/board-core/tests/db/atomic.rs
+++ b/crates/board-core/tests/db/atomic.rs
@@ -488,3 +488,129 @@ fn delete_column_rolls_back_card_migration_and_both_position_compactions() {
         source.id
     );
 }
+
+#[test]
+fn captured_session_promotion_rolls_back_when_card_write_fails() {
+    let (_dir, path, card) = create_file_db("capture atomic");
+    let db = Db::open(&path).unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue(card.id, card.column_id))
+        .unwrap();
+    drop(db);
+    let before = reopened_state(&path, card.id);
+    let db = Db::open(&path).unwrap();
+    arm_fault(
+        &path,
+        "CREATE TRIGGER abort_capture BEFORE UPDATE OF session_id ON cards
+         BEGIN SELECT RAISE(ABORT,'fault: capture'); END;",
+    );
+
+    assert!(db
+        .promote_captured_session_uow(run.id, "thread-abc")
+        .is_err());
+    drop(db);
+
+    assert_eq!(
+        reopened_state(&path, card.id),
+        before,
+        "a failed capture must leave the run AND the card exactly as found"
+    );
+}
+
+#[test]
+fn integrated_capture_promotion_rolls_back_when_card_write_fails() {
+    // The daemon's launch path persists the captured id inside the promotion
+    // UOW: a card-side failure must roll back the run promotion AND the
+    // session id together — never a started run without its identity.
+    let (_dir, path, card) = create_file_db("capture promotion atomic");
+    let db = Db::open(&path).unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue(card.id, card.column_id))
+        .unwrap();
+    drop(db);
+    let before = reopened_state(&path, card.id);
+    let db = Db::open(&path).unwrap();
+    arm_fault(
+        &path,
+        "CREATE TRIGGER abort_capture_promotion BEFORE UPDATE OF session_id ON cards
+         BEGIN SELECT RAISE(ABORT,'fault: capture promotion'); END;",
+    );
+
+    assert!(db
+        .promote_run_with_anchor_uow(
+            run.id,
+            Some("workspace"),
+            Some("pane"),
+            None,
+            None,
+            Some("thread-captured"),
+        )
+        .is_err());
+    drop(db);
+
+    assert_eq!(
+        reopened_state(&path, card.id),
+        before,
+        "a failed capture promotion must leave the run queued, the card queued, and no session id anywhere"
+    );
+}
+
+#[test]
+fn capture_crash_fault_hook_child() {
+    if std::env::var_os(CRASH_CHILD_ENV).is_none() {
+        return;
+    }
+    let path = std::path::PathBuf::from(std::env::var_os("DB_PATH").unwrap());
+    let run_id: i64 = std::env::var("RUN_ID").unwrap().parse().unwrap();
+    let effect_path = std::path::PathBuf::from(std::env::var_os("EFFECT_PATH").unwrap());
+    let event_path = std::path::PathBuf::from(std::env::var_os("EVENT_PATH").unwrap());
+    let db = Db::open_with_lifecycle_fault_hook(&path, |point| {
+        if point == LifecycleFaultPoint::CaptureAfterRunUpdate {
+            std::process::exit(87);
+        }
+        Ok(())
+    })
+    .unwrap();
+    let run = db
+        .promote_captured_session_uow(run_id, "thread-crash")
+        .unwrap();
+    fs::write(effect_path, format!("{:?}", run)).unwrap();
+    fs::write(event_path, "captured").unwrap();
+}
+
+#[test]
+fn subprocess_crash_before_capture_commit_reopens_exact_prior_state() {
+    if std::env::var_os(CRASH_CHILD_ENV).is_some() {
+        return;
+    }
+    let (_dir, path, card) = create_file_db("capture crash atomic");
+    let db = Db::open(&path).unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue(card.id, card.column_id))
+        .unwrap();
+    drop(db);
+    let before = reopened_state(&path, card.id);
+    let effect_path = path.with_extension("effects");
+    let event_path = path.with_extension("events");
+    fs::File::create(&effect_path).unwrap();
+    fs::File::create(&event_path).unwrap();
+
+    let output = Command::new(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "atomic::capture_crash_fault_hook_child",
+            "--nocapture",
+        ])
+        .env(CRASH_CHILD_ENV, "1")
+        .env("DB_PATH", &path)
+        .env("RUN_ID", run.id.to_string())
+        .env("EFFECT_PATH", &effect_path)
+        .env("EVENT_PATH", &event_path)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(87), "{output:?}");
+
+    assert_eq!(reopened_state(&path, card.id), before);
+    assert_eq!(fs::read(&effect_path).unwrap(), b"");
+    assert_eq!(fs::read(&event_path).unwrap(), b"");
+}

--- a/crates/board-core/tests/db/runs.rs
+++ b/crates/board-core/tests/db/runs.rs
@@ -485,3 +485,278 @@ fn run_for_card_requires_the_exact_owning_card() {
     let unknown = db.run_for_card(4242, first.id).unwrap_err();
     assert_eq!(unknown.to_string(), "not found: card 4242");
 }
+
+// ---------------------------------------------------------------------------
+// Captured-session promotion (C4 core): a self-minting harness like codex
+// reports its thread/conversation id only after launch, so the daemon persists
+// it atomically on BOTH the run and the card — never half-promoted.
+// ---------------------------------------------------------------------------
+
+/// Enqueue a codex-shaped run: Mint persists `session_id: NULL` (the board
+/// never invents a uuid for codex; the captured thread id replaces it).
+fn enqueue_codex<'a>(card_id: i64, column_id: i64, session_id: Option<&'a str>) -> EnqueueRun<'a> {
+    EnqueueRun {
+        card_id,
+        column_id,
+        harness: "codex",
+        argv_json: r#"["codex","--model","m"]"#,
+        prompt_snapshot: "Card task:\nwork",
+        system_prompt_snapshot: Some("s"),
+        launch_spec_json: None,
+        session_id,
+        session: None,
+    }
+}
+
+#[test]
+fn captured_session_promotion_writes_run_and_card_in_one_transaction() {
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex mint".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, None))
+        .unwrap();
+    // Mint persisted NULL — never a board-invented uuid.
+    assert_eq!(run.session_id, None);
+    assert_eq!(db.get_card(card.id).unwrap().unwrap().session_id, None);
+
+    // Capture while still queued (post-launch capture can race promotion).
+    let promoted = db
+        .promote_captured_session_uow(run.id, "thread-abc")
+        .unwrap();
+    assert_eq!(promoted.session_id.as_deref(), Some("thread-abc"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-abc")
+    );
+
+    // A later capture on the same open run replaces the id (fork: the NEW
+    // thread id supersedes the source id recorded at enqueue).
+    let replaced = db
+        .promote_captured_session_uow(run.id, "thread-forked")
+        .unwrap();
+    assert_eq!(replaced.session_id.as_deref(), Some("thread-forked"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-forked")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integrated promotion (C4 daemon path): the captured id is persisted in the
+// SAME transaction as the run promotion + card running/session update.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn promotion_with_captured_session_commits_run_card_and_identity_together() {
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex capture promote".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, None))
+        .unwrap();
+    assert_eq!(run.session_id, None);
+
+    // One UOW: run started + workspace/pane + session id on the run AND the
+    // card's running state + session id — no intermediate state is visible.
+    let promoted = db
+        .promote_run_with_anchor_uow(
+            run.id,
+            Some("workspace"),
+            Some("pane"),
+            Some("anchor"),
+            Some(1_000),
+            Some("thread-captured"),
+        )
+        .unwrap();
+    assert!(promoted.started_at.is_some());
+    assert_eq!(promoted.herdr_workspace_id.as_deref(), Some("workspace"));
+    assert_eq!(promoted.herdr_pane_id.as_deref(), Some("pane"));
+    assert_eq!(promoted.herdr_anchor_pane_id.as_deref(), Some("anchor"));
+    assert_eq!(
+        promoted.session_id.as_deref(),
+        Some("thread-captured"),
+        "the captured id replaces the mint NULL on the run"
+    );
+    let card = db.get_card(card.id).unwrap().unwrap();
+    assert_eq!(card.status, CardStatus::Running);
+    assert_eq!(
+        card.session_id.as_deref(),
+        Some("thread-captured"),
+        "run and card must never disagree about the conversation id"
+    );
+}
+
+#[test]
+fn promotion_without_capture_keeps_the_enqueue_time_session_id() {
+    // A fork whose NEW thread id was never captured degrades to the recorded
+    // source id: COALESCE keeps it instead of wiping identity.
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex fork no capture".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, Some("thread-1")))
+        .unwrap();
+    let promoted = db
+        .promote_run_with_anchor_uow(run.id, None, None, None, None, None)
+        .unwrap();
+    assert_eq!(promoted.session_id.as_deref(), Some("thread-1"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-1")
+    );
+}
+
+#[test]
+fn promotion_with_captured_session_replaces_a_prior_enqueue_id_on_both_rows() {
+    // Fork with a captured NEW thread id: the source id must survive nowhere.
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex fork captured".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, Some("thread-1")))
+        .unwrap();
+    let promoted = db
+        .promote_run_with_anchor_uow(run.id, None, None, None, None, Some("thread-new"))
+        .unwrap();
+    assert_eq!(promoted.session_id.as_deref(), Some("thread-new"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-new")
+    );
+    assert!(!db
+        .get_run(run.id)
+        .unwrap()
+        .session_id
+        .as_deref()
+        .is_some_and(|id| id == "thread-1"));
+}
+
+#[test]
+fn captured_session_promotion_works_after_run_started() {
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex started".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, None))
+        .unwrap();
+    db.promote_run_uow(run.id, Some("workspace"), Some("pane"), None)
+        .unwrap();
+    let promoted = db
+        .promote_captured_session_uow(run.id, "thread-late")
+        .unwrap();
+    assert_eq!(promoted.session_id.as_deref(), Some("thread-late"));
+    assert_eq!(promoted.herdr_pane_id.as_deref(), Some("pane"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-late")
+    );
+}
+
+#[test]
+fn captured_session_promotion_rejects_ended_run_without_touching_identity() {
+    // The cancel-during-spawn race: the run ended while the capture was in
+    // flight, so persisting the captured id on a dead run must fail closed and
+    // leave both rows untouched.
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex cancelled".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, None))
+        .unwrap();
+    db.finalize_run_uow(&FinalizeRun {
+        run_id: run.id,
+        outcome: RunOutcome::Cancelled,
+        summary: None,
+        comments: &[],
+        target_column_id: None,
+        final_status: CardStatus::Idle,
+        final_awaiting_reason: None,
+        next: None,
+    })
+    .unwrap();
+
+    let err = db
+        .promote_captured_session_uow(run.id, "thread-late")
+        .unwrap_err();
+    assert!(err.to_string().contains("not open"), "message: {err}");
+    assert_eq!(db.get_run(run.id).unwrap().session_id, None);
+    assert_eq!(db.get_card(card.id).unwrap().unwrap().session_id, None);
+    assert!(db.get_run(run.id).unwrap().ended_at.is_some());
+}
+
+#[test]
+fn captured_session_promotion_rejects_blank_session_id() {
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex blank".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, None))
+        .unwrap();
+    for blank in ["", "   "] {
+        assert!(db.promote_captured_session_uow(run.id, blank).is_err());
+    }
+    assert_eq!(db.get_run(run.id).unwrap().session_id, None);
+    assert_eq!(db.get_card(card.id).unwrap().unwrap().session_id, None);
+}
+
+#[test]
+fn captured_session_promotion_replaces_a_prior_resume_id_on_both_rows() {
+    // Fork enqueues the source id; the fork's NEW thread id replaces it on
+    // run and card atomically once the integration reports it.
+    let db = mem();
+    let card = db
+        .create_card(&CardCreateParams {
+            title: "codex fork".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let run = db
+        .enqueue_run_uow(&enqueue_codex(card.id, card.column_id, Some("thread-1")))
+        .unwrap();
+    assert_eq!(run.session_id.as_deref(), Some("thread-1"));
+
+    let promoted = db
+        .promote_captured_session_uow(run.id, "thread-new")
+        .unwrap();
+    assert_eq!(promoted.session_id.as_deref(), Some("thread-new"));
+    assert_eq!(
+        db.get_card(card.id).unwrap().unwrap().session_id.as_deref(),
+        Some("thread-new")
+    );
+    // The prior id survives nowhere.
+    assert!(!db
+        .get_run(run.id)
+        .unwrap()
+        .session_id
+        .as_deref()
+        .is_some_and(|id| id == "thread-1"));
+}

--- a/crates/board-core/tests/harness_codex.rs
+++ b/crates/board-core/tests/harness_codex.rs
@@ -1,0 +1,667 @@
+//! Codex harness RED contracts (C3 session policy + C6 adapter).
+//!
+//! These tests pin the codex built-in contracts *before* the adapter exists.
+//! They are intentionally RED today: every `session_argv("codex", …)`,
+//! `build_invocation("codex", …)`, capability-catalog and rescue-rethreading
+//! assertion below fails with `UnknownHarness` or a behavior mismatch until C7
+//! implements the built-in adapter.
+//!
+//! Verified facts (the Codex harness plan + `docs/research.md`):
+//! - codex mints its own thread/session UUID; there is **no public
+//!   `--session-id` for Mint**, so the board must never invent one;
+//! - resume and fork are **subcommands**: `codex resume <id>` / `codex fork
+//!   <id>`, appended last to the startup argv like every other harness's
+//!   session flags;
+//! - reasoning effort rides `-c model_reasoning_effort=<value>`, and codex
+//!   spells the lowest level `none` where the board says `off`;
+//! - approval rides user-facing presets: `ask-for-approval` →
+//!   `--sandbox workspace-write --ask-for-approval on-request`,
+//!   `approve-for-me` → `--approve-for-me`, `full-access` →
+//!   `--dangerously-bypass-approvals-and-sandbox`;
+//! - sandbox is a separate dimension and is only spelled explicitly for the
+//!   `ask-for-approval` preset (the approve-for-me preset already routes
+//!   through the workspace-write sandbox per the CLI's own help);
+//! - codex has no system-prompt file equivalent: the managed prompt channels
+//!   (`initial_prompt` / `system_prompt`) are the only prompt transport, and
+//!   startup argv carries neither task nor system text.
+//!
+//! What cannot be pinned here (daemon-owned, C4/C5 REDs live in
+//! `board-daemon`):
+//! - `prepare_enqueue_values` must persist **NULL** for a codex Mint instead
+//!   of its synthetic `target_session` fallback — the adapter side (this
+//!   file) reports `resulting_session_id: None` so the daemon has a signal;
+//! - the Mint prompt submission (`system_prompt + task` delimited block) and
+//!   the post-launch `agent.get.agent_session` thread-id capture/promotion.
+
+use board_core::capability::{
+    available_harnesses, capabilities_for, default_capabilities, meta_for, resume_support_for,
+    HarnessCapabilities, ResumeSupport,
+};
+use board_core::config::{Config, HarnessDef};
+use board_core::harness::{
+    build_invocation, is_builtin_harness, plan_session, resume_invocation, session_argv,
+    HarnessError, SessionPlan, BOARD_PROTOCOL_TRAILER, BOARD_RESCUE, BUILTIN_HARNESSES,
+};
+use board_core::launch::ExecutionSpec;
+use board_core::prompt::EffectiveSettings;
+use board_core::protocol::Effort;
+
+fn codex_settings() -> EffectiveSettings {
+    EffectiveSettings {
+        harness: "codex".into(),
+        model: Some("gpt-5.6".into()),
+        effort: Some(Effort::Low),
+        permission_mode: Some("ask-for-approval".into()),
+        system_prompt: Some("PLAN stage".into()),
+        fresh_session: false,
+        timeout_minutes: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// C3 — session policy: Mint has no synthetic id; Resume/Fork use the real id
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codex_session_argv_contract() {
+    // Mint: no session flag at all; the board never supplies a synthetic id.
+    assert_eq!(
+        session_argv("codex", &SessionPlan::Mint, None).unwrap(),
+        (vec![], None)
+    );
+    assert_eq!(
+        session_argv("codex", &SessionPlan::Mint, Some("synthetic-uuid")).unwrap(),
+        (vec![], None),
+        "codex mints its own thread id; a board-invented uuid must never surface"
+    );
+    // Resume: `codex resume <id>` with the real id persisted.
+    assert_eq!(
+        session_argv("codex", &SessionPlan::Resume("thread-1".into()), None).unwrap(),
+        (
+            vec!["resume".to_string(), "thread-1".to_string()],
+            Some("thread-1".to_string())
+        )
+    );
+    // Fork: `codex fork <id>` keeps the real source id at enqueue; the fork's
+    // NEW thread id is only known once the integration reports it, and
+    // replaces it atomically at promotion (C4).
+    assert_eq!(
+        session_argv("codex", &SessionPlan::Fork("thread-1".into()), None).unwrap(),
+        (
+            vec!["fork".to_string(), "thread-1".to_string()],
+            Some("thread-1".to_string())
+        )
+    );
+    assert_eq!(
+        session_argv(
+            "codex",
+            &SessionPlan::Fork("thread-1".into()),
+            Some("synthetic-uuid")
+        )
+        .unwrap(),
+        (
+            vec!["fork".to_string(), "thread-1".to_string()],
+            Some("thread-1".to_string())
+        )
+    );
+}
+
+#[test]
+fn codex_enqueue_policy_never_invents_an_id() {
+    // The full policy chain: whatever plan_session decides, a codex launch
+    // persists exactly the real id — never a board-minted uuid. The daemon's
+    // `prepare_enqueue_values` Mint fallback (`target_session`) must be
+    // suppressed for codex; the adapter side pinned here reports None so the
+    // daemon has an unambiguous signal to persist NULL.
+    let cases = [
+        (None, false, false, SessionPlan::Mint),
+        (
+            Some("thread-1"),
+            false,
+            false,
+            SessionPlan::Resume("thread-1".into()),
+        ),
+        (
+            Some("thread-1"),
+            false,
+            true,
+            SessionPlan::Fork("thread-1".into()),
+        ),
+        (Some("thread-1"), true, false, SessionPlan::Mint),
+    ];
+    for (existing, fresh, retry, expected) in cases {
+        let plan = plan_session(existing, fresh, retry);
+        assert_eq!(plan, expected);
+        let inv = build_invocation(
+            "codex",
+            &Config::default(),
+            &codex_settings(),
+            &plan,
+            Some("synthetic-uuid"),
+            "task",
+        )
+        .unwrap();
+        match plan {
+            SessionPlan::Mint => {
+                assert_eq!(
+                    inv.resulting_session_id, None,
+                    "codex Mint must persist NULL, never a board-invented uuid"
+                );
+                assert!(
+                    !inv.argv.iter().any(|a| a.contains("synthetic-uuid")),
+                    "the offered minted uuid must not leak into codex argv"
+                );
+            }
+            SessionPlan::Resume(id) | SessionPlan::Fork(id) => {
+                assert_eq!(
+                    inv.resulting_session_id.as_deref(),
+                    Some(id.as_str()),
+                    "resume/fork keep the real thread id"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn configured_harnesses_keep_their_synthetic_mint_fallback() {
+    // The no-invented-uuid policy is codex-specific. A config-defined harness
+    // keeps the current contract: build_invocation reports no resulting
+    // session id, and the daemon's Mint fallback persists the synthetic uuid.
+    let mut config = Config::default();
+    config.harness.insert(
+        "fake".into(),
+        HarnessDef {
+            argv: vec!["run".into()],
+            ..Default::default()
+        },
+    );
+    let inv = build_invocation(
+        "fake",
+        &config,
+        &codex_settings(),
+        &SessionPlan::Mint,
+        Some("synthetic-uuid"),
+        "p",
+    )
+    .unwrap();
+    assert_eq!(inv.resulting_session_id, None);
+    assert_eq!(inv.argv, vec!["run"]);
+}
+
+// ---------------------------------------------------------------------------
+// C6 — adapter argv: mint/resume/fork, effort + approval mapping, prompt
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codex_is_registered_builtin_after_claude() {
+    assert!(is_builtin_harness("codex"));
+    assert_eq!(BUILTIN_HARNESSES.to_vec(), vec!["pi", "claude", "codex"]);
+    let list = available_harnesses(&Config::default());
+    assert_eq!(
+        list.iter().position(|h| h.as_str() == "codex"),
+        Some(2),
+        "codex slots into the built-in list right after claude"
+    );
+}
+
+#[test]
+fn codex_mint_argv_exact_spelling() {
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &codex_settings(),
+        &SessionPlan::Mint,
+        None,
+        "implement the widget",
+    )
+    .unwrap();
+    assert_eq!(inv.agent_kind.as_deref(), Some("codex"));
+    assert_eq!(
+        inv.argv,
+        vec![
+            "codex".to_string(),
+            "--model".into(),
+            "gpt-5.6".into(),
+            "-c".into(),
+            "model_reasoning_effort=low".into(),
+            "--sandbox".into(),
+            "workspace-write".into(),
+            "--ask-for-approval".into(),
+            "on-request".into(),
+        ],
+        "codex mint argv: free-form --model, effort via -c, the ask-for-approval preset, no session flag"
+    );
+    // Managed prompt transport: both channels ride outside argv.
+    assert_eq!(inv.initial_prompt.as_deref(), Some("implement the widget"));
+    let expected_system = format!("PLAN stage\n\n{BOARD_PROTOCOL_TRAILER}");
+    assert_eq!(inv.system_prompt.as_deref(), Some(expected_system.as_str()));
+    assert!(inv.env.is_empty());
+}
+
+#[test]
+fn codex_resume_and_fork_argv_are_subcommands_with_the_real_id() {
+    // Resume re-attaches to the recorded thread id.
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &codex_settings(),
+        &SessionPlan::Resume("thread-7".into()),
+        None,
+        "task",
+    )
+    .unwrap();
+    assert_eq!(inv.resulting_session_id.as_deref(), Some("thread-7"));
+    assert!(inv
+        .argv
+        .ends_with(&["resume".to_string(), "thread-7".to_string()]));
+
+    // Fork keeps the real source id at enqueue (the NEW thread id replaces it
+    // at promotion once the integration reports it).
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &codex_settings(),
+        &SessionPlan::Fork("thread-7".into()),
+        None,
+        "task",
+    )
+    .unwrap();
+    assert_eq!(inv.resulting_session_id.as_deref(), Some("thread-7"));
+    assert!(inv
+        .argv
+        .ends_with(&["fork".to_string(), "thread-7".to_string()]));
+    // Never a board-invented uuid, even when one is offered.
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &codex_settings(),
+        &SessionPlan::Fork("thread-7".into()),
+        Some("synthetic-uuid"),
+        "task",
+    )
+    .unwrap();
+    assert_eq!(inv.resulting_session_id.as_deref(), Some("thread-7"));
+}
+
+#[test]
+fn codex_maps_off_effort_to_none_and_preserves_other_spellings() {
+    let mut s = codex_settings();
+    // The board's lowest effort is `off`; codex calls it `none`. The mapping
+    // happens only while building argv — the enum stays unchanged.
+    s.effort = Some(Effort::Off);
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &s,
+        &SessionPlan::Mint,
+        None,
+        "t",
+    )
+    .unwrap();
+    assert!(inv
+        .argv
+        .windows(2)
+        .any(|w| w[0] == "-c" && w[1] == "model_reasoning_effort=none"));
+
+    // Every other level keeps its canonical spelling (no `ultra` in this
+    // version).
+    for (effort, spelling) in [
+        (Effort::Minimal, "minimal"),
+        (Effort::Low, "low"),
+        (Effort::Medium, "medium"),
+        (Effort::High, "high"),
+        (Effort::Xhigh, "xhigh"),
+        (Effort::Max, "max"),
+    ] {
+        s.effort = Some(effort);
+        let inv = build_invocation(
+            "codex",
+            &Config::default(),
+            &s,
+            &SessionPlan::Mint,
+            None,
+            "t",
+        )
+        .unwrap();
+        assert!(
+            inv.argv
+                .windows(2)
+                .any(|w| { w[0] == "-c" && w[1] == format!("model_reasoning_effort={spelling}") }),
+            "effort {effort:?} must keep its spelling"
+        );
+    }
+
+    // No effort → no `-c` at all.
+    s.effort = None;
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &s,
+        &SessionPlan::Mint,
+        None,
+        "t",
+    )
+    .unwrap();
+    assert!(!inv.argv.iter().any(|a| a == "-c"));
+}
+
+#[test]
+fn codex_maps_permission_presets_to_exact_argv() {
+    // The board-facing codex approval vocabulary is three user-facing presets;
+    // each maps to an exact verified codex CLI spelling (checked against the
+    // installed CLI's help):
+    //   ask-for-approval → --sandbox workspace-write --ask-for-approval on-request
+    //   approve-for-me   → --approve-for-me          (routes through the
+    //                       workspace-write sandbox per the CLI's own help)
+    //   full-access      → --dangerously-bypass-approvals-and-sandbox
+    let mut s = codex_settings();
+    let cases = [
+        (
+            "ask-for-approval",
+            vec![
+                "--sandbox",
+                "workspace-write",
+                "--ask-for-approval",
+                "on-request",
+            ],
+        ),
+        ("approve-for-me", vec!["--approve-for-me"]),
+        (
+            "full-access",
+            vec!["--dangerously-bypass-approvals-and-sandbox"],
+        ),
+    ];
+    for (preset, expected) in cases {
+        s.permission_mode = Some(preset.into());
+        let inv = build_invocation(
+            "codex",
+            &Config::default(),
+            &s,
+            &SessionPlan::Mint,
+            None,
+            "t",
+        )
+        .unwrap();
+        assert!(
+            inv.argv.windows(expected.len()).any(|w| w == expected),
+            "preset {preset} must map to {expected:?}; got {:?}",
+            inv.argv
+        );
+    }
+    s.permission_mode = None;
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &s,
+        &SessionPlan::Mint,
+        None,
+        "t",
+    )
+    .unwrap();
+    assert!(!inv.argv.iter().any(|a| a == "--ask-for-approval"));
+    assert!(!inv.argv.iter().any(|a| a == "--sandbox"));
+    assert!(!inv.argv.iter().any(|a| a == "--approve-for-me"));
+}
+
+#[test]
+fn codex_permission_preset_applies_before_resume_fork_subcommand() {
+    // The preset flags sit with the other launch flags; resume/fork remain
+    // the LAST two argv entries (the adapter-owned session syntax).
+    let mut s = codex_settings();
+    s.permission_mode = Some("full-access".into());
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &s,
+        &SessionPlan::Resume("thread-7".into()),
+        None,
+        "t",
+    )
+    .unwrap();
+    assert!(inv
+        .argv
+        .contains(&"--dangerously-bypass-approvals-and-sandbox".to_string()));
+    assert!(inv
+        .argv
+        .ends_with(&["resume".to_string(), "thread-7".to_string()]));
+}
+
+#[test]
+fn codex_startup_argv_contains_no_prompt_or_system_prompt() {
+    let prompt = "implement the widget\nand respect --flags";
+    let inv = build_invocation(
+        "codex",
+        &Config::default(),
+        &codex_settings(),
+        &SessionPlan::Mint,
+        None,
+        prompt,
+    )
+    .unwrap();
+    for arg in &inv.argv {
+        assert!(
+            !arg.contains("implement the widget"),
+            "startup argv must not embed the task text: {arg:?}"
+        );
+        assert!(
+            !arg.contains("PLAN stage"),
+            "startup argv must not embed the column system prompt: {arg:?}"
+        );
+        assert!(
+            !arg.contains("herdr-board protocol"),
+            "startup argv must not embed the protocol trailer: {arg:?}"
+        );
+        assert!(
+            !arg.contains("instructions="),
+            "the prompt must never ride -c instructions: {arg:?}"
+        );
+    }
+    assert!(!inv.argv.iter().any(|a| a == "--"));
+    assert!(!inv
+        .argv
+        .iter()
+        .any(|a| a.starts_with("--append-system-prompt")));
+    // Both managed prompt channels stay out of argv and are delivered by the
+    // daemon after the agent is interactive (Mint: system_prompt + task).
+    assert_eq!(inv.initial_prompt.as_deref(), Some(prompt));
+    let expected_system = format!("PLAN stage\n\n{BOARD_PROTOCOL_TRAILER}");
+    assert_eq!(inv.system_prompt.as_deref(), Some(expected_system.as_str()));
+    assert!(inv.env.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// C6 — capability catalog (adapter registration, C7 green target)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codex_capability_catalog_shape() {
+    let caps = default_capabilities("codex");
+    assert_eq!(caps.harness, "codex");
+    assert!(caps.models.is_empty());
+    assert!(caps.model_freeform);
+    assert_eq!(
+        caps.default_efforts,
+        vec![
+            Effort::Off,
+            Effort::Minimal,
+            Effort::Low,
+            Effort::Medium,
+            Effort::High,
+            Effort::Xhigh,
+            Effort::Max,
+        ]
+    );
+    assert_eq!(
+        caps.permission_modes,
+        vec!["ask-for-approval", "approve-for-me", "full-access"]
+    );
+    assert_eq!(caps.resume, ResumeSupport::ByConversationId);
+    // The old approval-mode ids are gone: they were codex-internal spellings,
+    // not board-facing presets. Sandbox vocabulary never hides inside the
+    // permission field either.
+    for word in [
+        "untrusted",
+        "on-request",
+        "never",
+        "read-only",
+        "workspace-write",
+    ] {
+        assert!(
+            !caps.permission_modes.iter().any(|p| p == word),
+            "{word} must not appear as a board-facing preset"
+        );
+    }
+}
+
+#[test]
+fn codex_resolves_through_meta_and_resume_support() {
+    let cfg = Config::default();
+    let meta = meta_for("codex", &cfg).unwrap();
+    assert_eq!(meta.id(), "codex");
+    assert!(meta.models().is_empty());
+    assert!(meta.model_freeform());
+    assert_eq!(
+        meta.permissions(),
+        vec!["ask-for-approval", "approve-for-me", "full-access"]
+    );
+    assert_eq!(meta.resume(), ResumeSupport::ByConversationId);
+    // The trait answer and the wire snapshot never disagree.
+    let caps = capabilities_for("codex", &cfg).unwrap();
+    assert_eq!(caps, HarnessCapabilities::from_meta(meta.as_ref()));
+    assert_eq!(
+        resume_support_for("codex", &cfg),
+        ResumeSupport::ByConversationId
+    );
+}
+
+// ---------------------------------------------------------------------------
+// C6 — rescue re-threading (dead-pane rescue never re-sends the task)
+// ---------------------------------------------------------------------------
+
+/// The startup-only argv form a codex mint persists (after C7): no session
+/// tokens, no prompt text.
+fn persisted_codex_mint() -> ExecutionSpec {
+    ExecutionSpec {
+        argv: vec![
+            "codex".into(),
+            "--model".into(),
+            "recorded-model".into(),
+            "-c".into(),
+            "model_reasoning_effort=low".into(),
+            "--sandbox".into(),
+            "workspace-write".into(),
+            "--ask-for-approval".into(),
+            "on-request".into(),
+        ],
+        env: vec![("RECORDED_ENV".into(), "recorded-value".into())],
+        agent_kind: Some("codex".into()),
+        initial_prompt: Some("the original task".into()),
+        system_prompt: Some("recorded system prompt".into()),
+    }
+}
+
+#[test]
+fn codex_mint_prompt_block_is_a_single_delimited_system_then_task_block() {
+    use board_core::harness::codex::{mint_prompt, MINT_SYSTEM_DELIMITER, MINT_TASK_DELIMITER};
+
+    let system = "PLAN stage rules\nsecond line";
+    let task = "implement the widget\nwith --flags";
+    let block = mint_prompt(system, task);
+    // One block, system first, task second, each under its own delimiter.
+    let expected = format!("{MINT_SYSTEM_DELIMITER}\n{system}\n\n{MINT_TASK_DELIMITER}\n{task}");
+    assert_eq!(block, expected);
+    assert!(block.starts_with(MINT_SYSTEM_DELIMITER));
+    let task_at = block.find(MINT_TASK_DELIMITER).unwrap();
+    assert!(task_at > MINT_SYSTEM_DELIMITER.len());
+    assert!(block[..task_at].contains(system));
+    assert!(block[task_at..].contains(task));
+    // The task text is never quoted or re-delimited inside the system half.
+    assert!(!block[..task_at].contains("implement the widget"));
+}
+
+#[test]
+fn codex_resume_invocation_rethreads_mint_argv_to_resume_subcommand() {
+    let spec = resume_invocation(
+        "codex",
+        ResumeSupport::ByConversationId,
+        &persisted_codex_mint(),
+        "thread-9",
+    )
+    .unwrap();
+    assert_eq!(
+        spec.argv,
+        vec![
+            "codex",
+            "--model",
+            "recorded-model",
+            "-c",
+            "model_reasoning_effort=low",
+            "--sandbox",
+            "workspace-write",
+            "--ask-for-approval",
+            "on-request",
+            "resume",
+            "thread-9",
+        ]
+    );
+    // Rescue never re-sends the task, and never re-runs it.
+    assert_eq!(spec.initial_prompt, None);
+    assert!(!spec.env.iter().any(|(k, _)| k == "BOARD_PROMPT"));
+    assert!(!spec.argv.iter().any(|a| a.contains("the original task")));
+    // The rest of the recorded execution environment is preserved verbatim.
+    assert!(spec
+        .env
+        .contains(&("RECORDED_ENV".to_string(), "recorded-value".to_string())));
+    assert_eq!(
+        spec.system_prompt.as_deref(),
+        Some("recorded system prompt")
+    );
+    assert_eq!(spec.agent_kind.as_deref(), Some("codex"));
+    assert!(spec
+        .env
+        .contains(&(BOARD_RESCUE.to_string(), "1".to_string())));
+}
+
+#[test]
+fn codex_resume_invocation_preserves_freeform_model_named_resume_or_fork() {
+    for model in ["resume", "fork"] {
+        let mut spec = persisted_codex_mint();
+        spec.argv[2] = model.to_string();
+        spec.argv.extend(["fork".into(), "thread-1".into()]);
+
+        let resumed =
+            resume_invocation("codex", ResumeSupport::ByConversationId, &spec, "thread-9").unwrap();
+
+        assert_eq!(resumed.argv[1..3], ["--model", model]);
+        assert!(resumed.argv.contains(&"-c".to_string()));
+        assert!(resumed
+            .argv
+            .ends_with(&["resume".to_string(), "thread-9".to_string()]));
+    }
+}
+
+#[test]
+fn codex_resume_invocation_rethreads_fork_argv_to_plain_resume() {
+    let mut spec = persisted_codex_mint();
+    spec.argv.extend(["fork".into(), "thread-1".into()]);
+    let resumed =
+        resume_invocation("codex", ResumeSupport::ByConversationId, &spec, "thread-9").unwrap();
+    // The persisted fork subcommand is stripped, not duplicated.
+    assert!(!resumed.argv.contains(&"thread-1".to_string()));
+    assert!(resumed
+        .argv
+        .ends_with(&["resume".to_string(), "thread-9".to_string()]));
+}
+
+#[test]
+fn codex_resume_invocation_refuses_legacy_all_in_one_argv() {
+    // A `--` delimiter means the persisted argv embeds the task text, so
+    // appending `resume <id>` would re-send it. Refuse instead of guessing.
+    let mut spec = persisted_codex_mint();
+    spec.argv.extend(["--".into(), "the original task".into()]);
+    assert!(spec.argv.contains(&"--".to_string()));
+    let err =
+        resume_invocation("codex", ResumeSupport::ByConversationId, &spec, "thread-9").unwrap_err();
+    assert_eq!(err, HarnessError::ResumeLegacyArgv("codex".into()));
+}

--- a/crates/board-daemon/src/dispatch/enqueue.rs
+++ b/crates/board-daemon/src/dispatch/enqueue.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use board_core::db::Db;
 use board_core::engine::{decide_resumability, validate_effective_settings, ResumabilityDecision};
-use board_core::harness::{build_invocation, plan_session, SessionPlan};
+use board_core::harness::{build_invocation, is_builtin_harness, plan_session, SessionPlan};
 use board_core::launch::{ExecutionSpec, RunLaunchSpec};
 use board_core::model::{Card, Run};
 use board_core::prompt::{assemble_prompt, effective_settings};
@@ -89,8 +89,18 @@ pub(crate) fn prepare_enqueue_values(
         .resulting_session_id
         .clone()
         .or_else(|| match &plan {
-            SessionPlan::Mint => target_session.clone(),
-            SessionPlan::Resume(id) | SessionPlan::Fork(id) => Some(id.clone()),
+            // The synthetic mint fallback exists only for config-defined
+            // harnesses. Built-ins either report a real resulting id (pi/claude
+            // mint, every resume/fork) or self-mint their own thread id (codex
+            // Mint reports `None`), so a codex Mint must persist NULL — the
+            // board never invents a uuid for a harness that mints its own.
+            SessionPlan::Mint if !is_builtin_harness(&settings.harness) => target_session.clone(),
+            SessionPlan::Resume(id) | SessionPlan::Fork(id)
+                if !is_builtin_harness(&settings.harness) =>
+            {
+                Some(id.clone())
+            }
+            _ => None,
         });
     Ok(PreparedEnqueue {
         card_id: card.id,

--- a/crates/board-daemon/src/dispatch/launch_plan.rs
+++ b/crates/board-daemon/src/dispatch/launch_plan.rs
@@ -191,6 +191,14 @@ pub(super) async fn spawn_one(d: &Arc<Daemon>, run: &Run, card: &Card) -> Result
         // current queued run has no pane yet, so it cannot be its own match).
         let self_run_id = run.id;
         let self_session_id = run.session_id.clone();
+        // A Fork (retry) hop must NEVER re-prompt the prior live pane: the
+        // fork's whole point is a fresh conversation from the source, and
+        // re-prompting the old pane would keep the old conversation so the
+        // queued `fork <id>` argv never executes. The run's `session_id`
+        // still records the SOURCE id (the fork's new thread id arrives
+        // only at promotion), so the id alone cannot tell a retry-fork
+        // from a resume — the exact launch argv can.
+        let hop_is_fork = argv_is_fork(&run.harness, &req.argv);
         let resolved = tokio::task::spawn_blocking(move || {
             let mut client = HerdrClient::connect(&socket)
                 .map_err(|e| anyhow::anyhow!("herdr unavailable: {e}"))?;
@@ -231,23 +239,28 @@ pub(super) async fn spawn_one(d: &Arc<Daemon>, run: &Run, card: &Card) -> Result
             // Reuse the prior run's pane iff this hop resumes the SAME harness
             // conversation: a non-fresh resume keeps the card's `session_id`,
             // so a prior durable run in this session/workspace that recorded
-            // that id is the source pane to re-prompt. Mint (fresh column) and
-            // Fork (retry) mint a new id and therefore find no match.
-            let reuse_pane_id = self_session_id.as_deref().and_then(|sid| {
-                prior_runs
-                    .iter()
-                    .filter(|r| {
-                        r.id != self_run_id
-                            && r.ended_at.is_some()
-                            && r.launch_spec.is_some()
-                            && r.session.as_deref() == session
-                            && r.herdr_workspace_id.as_deref() == Some(workspace_id.as_str())
-                            && r.session_id.as_deref() == Some(sid)
-                    })
-                    .max_by_key(|r| r.id)
-                    .and_then(|r| r.herdr_pane_id.clone())
-                    .filter(|pane| !pane.is_empty())
-            });
+            // that id is the source pane to re-prompt. Mint (fresh column)
+            // mints a new id and finds no match; Fork (retry) is excluded
+            // outright above — it must launch fresh so the fork actually runs.
+            let reuse_pane_id = if hop_is_fork {
+                None
+            } else {
+                self_session_id.as_deref().and_then(|sid| {
+                    prior_runs
+                        .iter()
+                        .filter(|r| {
+                            r.id != self_run_id
+                                && r.ended_at.is_some()
+                                && r.launch_spec.is_some()
+                                && r.session.as_deref() == session
+                                && r.herdr_workspace_id.as_deref() == Some(workspace_id.as_str())
+                                && r.session_id.as_deref() == Some(sid)
+                        })
+                        .max_by_key(|r| r.id)
+                        .and_then(|r| r.herdr_pane_id.clone())
+                        .filter(|pane| !pane.is_empty())
+                })
+            };
             Ok::<_, anyhow::Error>((
                 workspace_id,
                 cwd,
@@ -384,6 +397,13 @@ pub(crate) fn register_spawned_run(
             spawned.pane_id.as_deref(),
             spawned.anchor_pane_id.as_deref(),
             timeout_deadline_at_ms,
+            // The harness-captured conversation id (codex self-mints its
+            // thread id) is persisted in the SAME transaction as the run
+            // promotion and the card running/session update — the capture
+            // travels through this cancellation critical section, so a cancel
+            // that ended the run while the spawn was in flight discards the
+            // captured id together with the handle.
+            spawned.captured_session_id.as_deref(),
         )?;
         let registered_handle = handle.take().ok_or_else(|| {
             Error::InvalidState(format!(
@@ -420,6 +440,33 @@ pub(crate) fn register_spawned_run(
             }
             other
         }
+    }
+}
+
+/// Whether a queued run's hop is a Fork (retry) rather than a Resume, read
+/// from the exact launch argv that will be spawned.
+///
+/// The per-harness spellings mirror `board_core::harness::session_argv`, the
+/// single source of truth for how a
+/// [`SessionPlan`](board_core::harness::SessionPlan) is spelled in argv:
+/// - pi fork: `--fork <source> --session-id <target>` (a bare `--session-id`
+///   is the mint/resume shape);
+/// - claude fork: `--resume <id> --fork-session` (a plain `--resume` resumes
+///   in place);
+/// - codex fork/resume are trailing subcommands: `fork <id>` vs `resume <id>`.
+///
+/// A Fork records the SOURCE conversation id on the run — the fork's new
+/// thread id replaces it only at promotion — so `run.session_id` cannot tell
+/// a retry-fork from a resume; the argv can. Fork hops must never re-prompt
+/// the prior live same-session pane: re-prompting keeps the old conversation
+/// and the queued `fork <id>` subcommand would never execute.
+fn argv_is_fork(harness: &str, argv: &[String]) -> bool {
+    match harness {
+        "pi" => argv.iter().any(|arg| arg == "--fork"),
+        "claude" => argv.iter().any(|arg| arg == "--fork-session"),
+        // Same tail check the spawner uses to detect codex session flags.
+        "codex" => argv.len() >= 2 && argv[argv.len() - 2] == "fork",
+        _ => false,
     }
 }
 

--- a/crates/board-daemon/src/dispatch/tests/enqueue.rs
+++ b/crates/board-daemon/src/dispatch/tests/enqueue.rs
@@ -91,6 +91,115 @@ fn pi_fork_persists_the_new_target_session_id() {
 }
 
 #[test]
+fn codex_mint_enqueue_persists_null_session_without_a_synthetic_uuid() {
+    // C3 daemon contract: codex mints its own thread id, so a codex Mint
+    // enqueue persists NULL — the board never invents a uuid for it — and the
+    // startup argv carries no session token and no prompt text.
+    let d = test_daemon(Arc::new(MissingPiSpawner));
+    let (card_id, column_id) = {
+        let db = d.store.lock();
+        let column = db
+            .create_column(&ColumnCreateParams {
+                name: "Codex".into(),
+                system_prompt: Some("col instructions".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let card = db
+            .create_card(&CardCreateParams {
+                column_id: Some(column.id),
+                title: "codex mint".into(),
+                harness: Some("codex".into()),
+                description: Some("build the widget".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        (card.id, card.column_id)
+    };
+
+    let run = enqueue_run(&d, card_id, column_id, false).unwrap();
+    let card = d.store.lock().get_card(card_id).unwrap().unwrap();
+    assert_eq!(
+        run.session_id, None,
+        "codex Mint must persist NULL, never a board-invented uuid"
+    );
+    assert_eq!(card.session_id, None);
+
+    let argv: Vec<String> = serde_json::from_str(&run.argv_json).unwrap();
+    assert_eq!(argv.first().map(String::as_str), Some("codex"));
+    assert!(
+        !argv.iter().any(|a| a.len() == 36 && a.contains('-')),
+        "no synthetic uuid may leak into the persisted argv: {argv:?}"
+    );
+    assert!(!argv.iter().any(|a| a == "resume" || a == "fork"));
+    assert!(!argv.iter().any(|a| a == "--"));
+    assert!(!argv.iter().any(|a| a.starts_with("--append-system-prompt")));
+
+    // The managed prompt channels ride outside argv exactly like the adapter
+    // produced them at enqueue time.
+    let spec = run.launch_spec.as_ref().unwrap().execution();
+    assert_eq!(spec.agent_kind.as_deref(), Some("codex"));
+    let prompt = assemble_prompt("build the widget", &[]);
+    assert_eq!(spec.initial_prompt.as_deref(), Some(prompt.as_str()));
+    assert_eq!(
+        spec.system_prompt.as_deref(),
+        Some(board_core::harness::protocol_system_prompt(Some("col instructions")).as_str())
+    );
+}
+
+#[test]
+fn codex_resume_enqueue_keeps_the_real_recorded_thread_id() {
+    // Resume must persist the real recorded id — never a fresh minted uuid.
+    let d = test_daemon(Arc::new(MissingPiSpawner));
+    let (card_id, column_id, old_session) = {
+        let db = d.store.lock();
+        let card = db
+            .create_card(&CardCreateParams {
+                title: "codex resume".into(),
+                harness: Some("codex".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let old_session = "thread-1";
+        db.set_card_session(card.id, old_session).unwrap();
+        let prior = db
+            .enqueue_run_uow(&EnqueueRun {
+                card_id: card.id,
+                column_id: card.column_id,
+                harness: "codex",
+                argv_json: "[]",
+                prompt_snapshot: "prior",
+                system_prompt_snapshot: Some("system"),
+                launch_spec_json: None,
+                session_id: Some(old_session),
+                session: None,
+            })
+            .unwrap();
+        db.promote_run_uow(prior.id, None, None, None).unwrap();
+        db.finalize_run_uow(&FinalizeRun {
+            run_id: prior.id,
+            outcome: RunOutcome::Ok,
+            summary: None,
+            comments: &[(&format!("agent:{}", prior.id), "done")],
+            target_column_id: None,
+            final_status: CardStatus::Done,
+            final_awaiting_reason: None,
+            next: None,
+        })
+        .unwrap();
+        (card.id, card.column_id, old_session.to_string())
+    };
+
+    let run = enqueue_run(&d, card_id, column_id, false).unwrap();
+    assert_eq!(run.session_id.as_deref(), Some(old_session.as_str()));
+    let argv: Vec<String> = serde_json::from_str(&run.argv_json).unwrap();
+    assert!(
+        argv.ends_with(&["resume".to_string(), old_session.clone()]),
+        "codex resume is the `resume <id>` subcommand appended last: {argv:?}"
+    );
+}
+
+#[test]
 fn enqueue_run_final_guard_prevents_duplicate_open_runs() {
     let d = test_daemon(Arc::new(MissingPiSpawner));
     let (card_id, column_id) = {

--- a/crates/board-daemon/src/dispatch/tests/mod.rs
+++ b/crates/board-daemon/src/dispatch/tests/mod.rs
@@ -291,5 +291,6 @@ mod concurrency;
 mod enqueue;
 mod finalize;
 mod ownership;
+mod pane_reuse;
 mod registration;
 mod space;

--- a/crates/board-daemon/src/dispatch/tests/pane_reuse.rs
+++ b/crates/board-daemon/src/dispatch/tests/pane_reuse.rs
@@ -1,0 +1,219 @@
+//! Dispatch-side pane-reuse decision: which queued hop may re-prompt the
+//! prior run's still-live pane.
+//!
+//! The spawner tests cover what a *reuse request* does to herdr; this module
+//! covers when dispatch is allowed to make one. A Resume hop keeps the same
+//! harness conversation and reuses the exact prior pane. A Fork (retry) hop
+//! must never re-prompt it — the queued `fork <source-id>` argv needs a fresh
+//! pane, and re-prompting the live pane would keep the old conversation so
+//! the fork never executes. A Mint hop mints a new id and finds no match.
+
+use super::*;
+use board_core::launch::{ExecutionSpec, RunLaunchSpec};
+use serde_json::json;
+
+const SOURCE_SESSION: &str = "thread-7";
+const PRIOR_PANE: &str = "w1:p-prior";
+
+/// Serve exactly the herdr calls `spawn_one` makes for a durable v11 launch:
+/// the protocol gate, workspace discovery, and the two live snapshots (cwd
+/// proof, then card-tab reconstruction from the prior durable pane).
+fn reuse_decision_server() -> FakeHerdr {
+    let snapshot = json!({
+        "panes": [{
+            "pane_id": PRIOR_PANE, "terminal_id": "term-1",
+            "workspace_id": "w1", "tab_id": "w1:t1",
+            "cwd": "/repo", "focused": false, "revision": 1
+        }]
+    });
+    testkit::herdr_server()
+        .take(5)
+        .on("workspace.list", |req| {
+            testkit::reply(
+                req,
+                json!({"workspaces": [{
+                    "workspace_id": "w1", "label": "Feature", "number": 1,
+                    "focused": false, "active_tab_id": "", "agent_status": "idle"
+                }]}),
+            )
+        })
+        .on("session.snapshot", move |req| {
+            testkit::reply(req, json!({"snapshot": snapshot}))
+        })
+        .serve()
+}
+
+/// A codex card whose prior durable run ended in `w1:p-prior` — the pane
+/// stays open in herdr (finished panes remain visible by design). When
+/// `source` is set, the prior run captured that conversation id and the card
+/// keeps it, so the next hop carries the same `session_id` whether it
+/// resumes or forks.
+fn codex_card_with_ended_prior_run(d: &Arc<Daemon>, source: Option<&str>) -> (i64, i64) {
+    let db = d.store.lock();
+    let column = db
+        .create_column(&ColumnCreateParams {
+            name: "Codex".into(),
+            trigger: Some(Trigger::Auto),
+            ..Default::default()
+        })
+        .unwrap();
+    let card = db
+        .create_card(&CardCreateParams {
+            column_id: Some(column.id),
+            title: "codex retry".into(),
+            harness: Some("codex".into()),
+            description: Some("build the widget".into()),
+            space_kind: Some(SpaceKind::NewWorkspace),
+            space_ref: Some("Feature".into()),
+            space_cwd: Some("/repo".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    if let Some(source) = source {
+        db.set_card_session(card.id, source).unwrap();
+    }
+    let spec = RunLaunchSpec::v1(ExecutionSpec {
+        argv: vec!["codex".into()],
+        env: Vec::new(),
+        agent_kind: Some("codex".into()),
+        initial_prompt: Some("prior".into()),
+        system_prompt: Some("system".into()),
+    });
+    let prior = db
+        .enqueue_run_uow(&EnqueueRun {
+            card_id: card.id,
+            column_id: card.column_id,
+            harness: "codex",
+            argv_json: &serde_json::to_string(&spec.execution().argv).unwrap(),
+            prompt_snapshot: "prior",
+            system_prompt_snapshot: Some("system"),
+            launch_spec_json: Some(&serde_json::to_string(&spec).unwrap()),
+            session_id: source,
+            session: None,
+        })
+        .unwrap();
+    db.promote_run_uow(prior.id, Some("w1"), Some(PRIOR_PANE), None)
+        .unwrap();
+    db.finalize_run_uow(&FinalizeRun {
+        run_id: prior.id,
+        outcome: RunOutcome::Ok,
+        summary: None,
+        comments: &[(&format!("agent:{}", prior.id), "done")],
+        target_column_id: None,
+        final_status: CardStatus::Done,
+        final_awaiting_reason: None,
+        next: None,
+    })
+    .unwrap();
+    (card.id, card.column_id)
+}
+
+/// A daemon whose default herdr session is the fake server, with a recording
+/// spawner — the full launch path through `spawn_one` runs for real.
+fn reuse_decision_daemon(spawner: Arc<CapturingSpawner>, herdr: &FakeHerdr) -> Arc<Daemon> {
+    testkit::daemon()
+        .spawner(spawner)
+        .registry(Some(crate::session::SessionRegistry::with_entries(
+            herdr.socket.clone(),
+            Vec::new(),
+        )))
+        .build_daemon()
+}
+
+/// A codex retry records the SOURCE conversation id (the fork's new thread id
+/// arrives only at promotion) and its argv ends `fork <source-id>`. With a
+/// live prior pane holding that same id, the reuse candidate resolves — but
+/// re-prompting it would keep the old conversation and the fork would never
+/// execute. The retry must launch fresh with `reuse_pane_id: None`.
+#[tokio::test]
+async fn codex_fork_retry_never_reuses_the_prior_live_pane() {
+    let spawner = Arc::new(CapturingSpawner::default());
+    let herdr = reuse_decision_server();
+    let d = reuse_decision_daemon(spawner.clone(), &herdr);
+    let (card_id, column_id) = codex_card_with_ended_prior_run(&d, Some(SOURCE_SESSION));
+
+    let retry = enqueue_run(&d, card_id, column_id, true).unwrap();
+    let argv: Vec<String> = serde_json::from_str(&retry.argv_json).unwrap();
+    assert_eq!(argv, ["codex", "fork", SOURCE_SESSION]);
+    assert_eq!(retry.session_id.as_deref(), Some(SOURCE_SESSION));
+
+    dispatch_pass(&d).await;
+
+    let requests = spawner.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1, "exactly one launch request");
+    let req = &requests[0];
+    assert_eq!(req.argv, ["codex", "fork", SOURCE_SESSION]);
+    assert_eq!(
+        req.reuse_pane_id, None,
+        "a codex retry (`fork <source-id>`) must never re-prompt the prior \
+         live same-session pane — it must launch fresh so codex actually forks"
+    );
+    // Nothing was re-prompted or re-spawned against herdr: the launch made
+    // only the resolution calls.
+    assert_eq!(
+        herdr.methods(),
+        [
+            "ping",
+            "workspace.list",
+            "session.snapshot",
+            "session.snapshot"
+        ]
+    );
+    assert!(
+        herdr.requests_for("agent.prompt").is_empty(),
+        "a fork launch must not prompt any pane"
+    );
+    // The fresh launch registered as a running run.
+    let run = d.store.lock().get_run(retry.id).unwrap();
+    assert!(run.started_at.is_some());
+}
+
+/// A non-fresh hop (resume) still reuses the exact same conversation pane:
+/// the prior live pane holding the recorded id is re-prompted in place.
+#[tokio::test]
+async fn codex_resume_hop_reuses_the_exact_prior_pane() {
+    let spawner = Arc::new(CapturingSpawner::default());
+    let herdr = reuse_decision_server();
+    let d = reuse_decision_daemon(spawner.clone(), &herdr);
+    let (card_id, column_id) = codex_card_with_ended_prior_run(&d, Some(SOURCE_SESSION));
+
+    let resume = enqueue_run(&d, card_id, column_id, false).unwrap();
+    let argv: Vec<String> = serde_json::from_str(&resume.argv_json).unwrap();
+    assert_eq!(argv, ["codex", "resume", SOURCE_SESSION]);
+
+    dispatch_pass(&d).await;
+
+    let requests = spawner.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1, "exactly one launch request");
+    assert_eq!(requests[0].argv, ["codex", "resume", SOURCE_SESSION]);
+    assert_eq!(
+        requests[0].reuse_pane_id.as_deref(),
+        Some(PRIOR_PANE),
+        "a resume hop re-prompts the exact prior conversation pane"
+    );
+}
+
+/// A mint hop mints a new (or self-minted) conversation and finds no reuse
+/// match: no recorded source id, no reuse.
+#[tokio::test]
+async fn codex_mint_hop_finds_no_reuse_match() {
+    let spawner = Arc::new(CapturingSpawner::default());
+    let herdr = reuse_decision_server();
+    let d = reuse_decision_daemon(spawner.clone(), &herdr);
+    let (card_id, column_id) = codex_card_with_ended_prior_run(&d, None);
+
+    let mint = enqueue_run(&d, card_id, column_id, false).unwrap();
+    let argv: Vec<String> = serde_json::from_str(&mint.argv_json).unwrap();
+    assert_eq!(argv, ["codex"]);
+    assert_eq!(mint.session_id, None);
+
+    dispatch_pass(&d).await;
+
+    let requests = spawner.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1, "exactly one launch request");
+    assert_eq!(requests[0].argv, ["codex"]);
+    assert_eq!(
+        requests[0].reuse_pane_id, None,
+        "a mint hop has no source conversation to reuse"
+    );
+}

--- a/crates/board-daemon/src/dispatch/tests/registration.rs
+++ b/crates/board-daemon/src/dispatch/tests/registration.rs
@@ -124,6 +124,156 @@ fn spawned_run_registration_kills_handle_when_row_was_cancelled() {
     assert_eq!(spawner.kills.load(Ordering::SeqCst), 1);
 }
 
+#[test]
+fn spawned_run_registration_persists_captured_session_atomically_with_promotion() {
+    // A codex-shaped run: enqueue persisted NULL, the spawner captured the
+    // thread id after launch, and registration must persist it in the SAME
+    // transaction as the run promotion + card running/session update.
+    let spawner = Arc::new(RecordingSpawner::default());
+    let d = test_daemon(spawner.clone());
+    let (card_id, run_id) = {
+        let db = d.store.lock();
+        let card = db
+            .create_card(&CardCreateParams {
+                title: "register captured session".into(),
+                harness: Some("codex".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let run = db
+            .enqueue_run_uow(&EnqueueRun {
+                card_id: card.id,
+                column_id: card.column_id,
+                harness: "codex",
+                argv_json: r#"["codex","--model","m"]"#,
+                prompt_snapshot: "p",
+                system_prompt_snapshot: Some("system"),
+                launch_spec_json: None,
+                session_id: None,
+                session: None,
+            })
+            .unwrap();
+        assert_eq!(run.session_id, None, "codex mint enqueued NULL");
+        (card.id, run.id)
+    };
+    let started = Instant::now();
+
+    assert!(register_spawned_run(
+        &d,
+        run_id,
+        RuntimeHandle {
+            pid: Some(41),
+            anchor_pane_id: Some("anchor-41".into()),
+            captured_session_id: Some("thread-captured".into()),
+            ..Default::default()
+        },
+        started,
+        None,
+        None,
+    )
+    .unwrap());
+
+    let sched = d.sched.lock().unwrap();
+    let db = d.store.lock();
+    let promoted = db.get_run(run_id).unwrap();
+    assert!(promoted.started_at.is_some());
+    assert_eq!(promoted.herdr_anchor_pane_id.as_deref(), Some("anchor-41"));
+    assert_eq!(
+        promoted.session_id.as_deref(),
+        Some("thread-captured"),
+        "the captured id is persisted with the promotion"
+    );
+    let card = db.get_card(card_id).unwrap().unwrap();
+    assert_eq!(card.status, CardStatus::Running);
+    assert_eq!(
+        card.session_id.as_deref(),
+        Some("thread-captured"),
+        "run and card must never disagree about the conversation id"
+    );
+    assert_eq!(sched.active.get(&run_id).unwrap().handle.pid, Some(41));
+    assert_eq!(spawner.kills.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn spawned_run_registration_discards_captured_session_when_run_was_cancelled() {
+    // The cancel-during-spawn race: the spawner captured a thread id, but the
+    // run ended while the launch was in flight. Registration must fail closed
+    // — kill the handle and leave the captured id nowhere, not resurrect
+    // identity on a dead run.
+    let spawner = Arc::new(RecordingSpawner::default());
+    let d = test_daemon(spawner.clone());
+    let (card_id, run_id) = {
+        let db = d.store.lock();
+        let card = db
+            .create_card(&CardCreateParams {
+                title: "capture cancelled during spawn".into(),
+                harness: Some("codex".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let run = db
+            .enqueue_run_uow(&EnqueueRun {
+                card_id: card.id,
+                column_id: card.column_id,
+                harness: "codex",
+                argv_json: "[]",
+                prompt_snapshot: "p",
+                system_prompt_snapshot: Some("system"),
+                launch_spec_json: None,
+                session_id: None,
+                session: None,
+            })
+            .unwrap();
+        db.finalize_run_uow(&FinalizeRun {
+            run_id: run.id,
+            outcome: RunOutcome::Cancelled,
+            summary: Some("cancelled"),
+            comments: &[],
+            target_column_id: None,
+            final_status: CardStatus::Failed,
+            final_awaiting_reason: None,
+            next: None,
+        })
+        .unwrap();
+        (card.id, run.id)
+    };
+
+    assert!(!register_spawned_run(
+        &d,
+        run_id,
+        RuntimeHandle {
+            pid: Some(42),
+            captured_session_id: Some("thread-late".into()),
+            ..Default::default()
+        },
+        Instant::now(),
+        None,
+        None,
+    )
+    .unwrap());
+
+    let db = d.store.lock();
+    let run = db.get_run(run_id).unwrap();
+    assert!(run.started_at.is_none());
+    assert_eq!(
+        run.session_id, None,
+        "the captured id must be discarded with the cancelled run"
+    );
+    assert_eq!(run.outcome, Some(RunOutcome::Cancelled));
+    assert_eq!(
+        db.get_card(card_id).unwrap().unwrap().status,
+        CardStatus::Failed
+    );
+    assert_eq!(
+        db.get_card(card_id).unwrap().unwrap().session_id,
+        None,
+        "the cancelled card keeps its enqueue-time identity (NULL)"
+    );
+    drop(db);
+    assert!(!d.sched.lock().unwrap().active.contains_key(&run_id));
+    assert_eq!(spawner.kills.load(Ordering::SeqCst), 1);
+}
+
 #[tokio::test]
 async fn spawn_failure_for_missing_pi_marks_run_failed_with_system_comment() {
     let d = test_daemon(Arc::new(MissingPiSpawner));

--- a/crates/board-daemon/src/herdr_snapshot/tests.rs
+++ b/crates/board-daemon/src/herdr_snapshot/tests.rs
@@ -69,6 +69,7 @@ fn agent_status_overrides_pane_fallback() {
         revision: 1,
         interactive_ready: true,
         launch_pending: false,
+        agent_session: None,
     }];
     let mut snap = empty_snapshot();
     snap.panes = panes;
@@ -97,6 +98,7 @@ fn agent_on_nonexistent_pane_is_ignored() {
         revision: 1,
         interactive_ready: true,
         launch_pending: false,
+        agent_session: None,
     }];
     let mut snap = empty_snapshot();
     snap.panes = panes;

--- a/crates/board-daemon/src/lib.rs
+++ b/crates/board-daemon/src/lib.rs
@@ -89,6 +89,12 @@ async fn async_main(db_path: PathBuf, socket_path: PathBuf) -> anyhow::Result<()
     if config.pi_agent_dir.is_none() {
         config.pi_agent_dir = board_core::pi_catalog::default_agent_dir();
     }
+    // Same for the codex home: `$CODEX_HOME` else `~/.codex` (mirror of the
+    // codex CLI's own default). Tests leave `codex_home` None and get the
+    // static free-form catalog.
+    if config.codex_home.is_none() {
+        config.codex_home = board_core::codex_catalog::default_codex_home();
+    }
     tracing::info!(
         "spawner={:?} max_concurrent={}",
         settings.spawner,

--- a/crates/board-daemon/src/ops/discovery.rs
+++ b/crates/board-daemon/src/ops/discovery.rs
@@ -1,6 +1,6 @@
 use super::*;
 use board_core::capability::{available_harnesses, capabilities_for};
-use board_core::pi_catalog;
+use board_core::{codex_catalog, pi_catalog};
 pub(super) fn harness_capabilities(d: &Arc<Daemon>, p: HarnessCapabilitiesParams) -> Result<Value> {
     match capabilities_for(&p.harness, &d.config) {
         Some(mut caps) => {
@@ -9,6 +9,16 @@ pub(super) fn harness_capabilities(d: &Arc<Daemon>, p: HarnessCapabilitiesParams
             // leave `pi_agent_dir` unset, so this stays the static catalog.
             if p.harness == "pi" {
                 let models = pi_catalog::live_models(d.config.pi_agent_dir.as_deref(), "pi");
+                if !models.is_empty() {
+                    caps.models = models;
+                }
+            }
+            // Codex mirrors Pi: the static catalog is free-form; overlay the
+            // live models read from the codex home's models_cache.json when
+            // one is configured. Tests leave `codex_home` unset, so this
+            // stays the static catalog.
+            if p.harness == "codex" {
+                let models = codex_catalog::live_models(d.config.codex_home.as_deref());
                 if !models.is_empty() {
                     caps.models = models;
                 }

--- a/crates/board-daemon/src/ops/tests/cards.rs
+++ b/crates/board-daemon/src/ops/tests/cards.rs
@@ -300,20 +300,16 @@ fn card_move_blocked_by_incompatible_target_harness() {
 
 #[test]
 fn card_move_blocked_when_session_cannot_resolve() {
-    // A fake `herdr` that reports no sessions. A card pinned to a named session
-    // ("ghost") then cannot resolve, so the blocking pre-check rejects the
-    // move; the default-session card (session: null) is still allowed.
-    let dir = tempfile::tempdir().unwrap();
-    let script = dir.path().join("herdr");
-    std::fs::write(&script, "#!/bin/sh\necho '{\"sessions\":[]}'\n").unwrap();
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
-    }
-    std::env::set_var("HERDR_BIN_PATH", &script);
-
-    let registry = Some(SessionRegistry::new(PathBuf::from("/tmp/board-test.sock")));
+    // A registry that knows NO sessions (seeded, so no `herdr` binary is ever
+    // invoked — deliberately NOT a global `HERDR_BIN_PATH` env mutation, which
+    // would race every parallel test that shells out to the configured-harness
+    // runner). A card pinned to a named session ("ghost") then cannot resolve,
+    // so the blocking pre-check rejects the move; the default-session card
+    // (session: null) is still allowed.
+    let registry = Some(SessionRegistry::with_entries(
+        PathBuf::from("/tmp/board-test.sock"),
+        Vec::new(),
+    ));
     let d = test_daemon_with_registry(Config::default(), registry);
     let alpha = scoped_board(&d, "/alpha");
     let beta = scoped_board(&d, "/beta");
@@ -353,8 +349,6 @@ fn card_move_blocked_when_session_cannot_resolve() {
         Some(alpha),
         "blocked move must not move the card"
     );
-
-    std::env::remove_var("HERDR_BIN_PATH");
 }
 
 #[test]

--- a/crates/board-daemon/src/ops/tests/discovery.rs
+++ b/crates/board-daemon/src/ops/tests/discovery.rs
@@ -288,9 +288,10 @@ fn run_focus_rescue_gives_the_new_pane_the_board_env_but_never_the_run_credentia
     // `board comment`/`done`/`__pane-exited`. A rescued pane belongs to no run
     // and must not be able to write to the immutable historical row, so it is
     // withheld; the id travels as an inert label instead.
-    assert!(
-        !env.contains_key("BOARD_RUN_ID"),
-        "a rescued pane must not receive the run credential: {env:?}"
+    assert_eq!(
+        env.get("BOARD_RUN_ID"),
+        Some(&String::new()),
+        "a rescued pane must explicitly clear an inherited run credential: {env:?}"
     );
     assert_eq!(env.get("BOARD_RESCUED_RUN_ID"), Some(&run_id.to_string()));
 }
@@ -605,7 +606,10 @@ fn harness_list_builtin_only() {
     let d = test_daemon(Config::default());
     let v = handle_request(&d, "harness.list", json!({})).unwrap();
     let names: Vec<String> = serde_json::from_value(v["harnesses"].clone()).unwrap();
-    assert_eq!(names, vec!["pi".to_string(), "claude".to_string()]);
+    assert_eq!(
+        names,
+        vec!["pi".to_string(), "claude".to_string(), "codex".to_string()]
+    );
 }
 
 #[test]
@@ -621,7 +625,7 @@ fn harness_list_includes_config_defined() {
     let d = test_daemon(config);
     let v = handle_request(&d, "harness.list", json!({})).unwrap();
     let names: Vec<String> = serde_json::from_value(v["harnesses"].clone()).unwrap();
-    assert_eq!(names, vec!["pi", "claude", "fake"]);
+    assert_eq!(names, vec!["pi", "claude", "codex", "fake"]);
 }
 
 #[test]
@@ -699,6 +703,99 @@ fn harness_capabilities_pi_falls_back_to_static_without_agent_dir() {
     // No pi_agent_dir (tests) → static free-form catalog (models: []).
     let d = test_daemon(Config::default());
     let v = handle_request(&d, "harness.capabilities", json!({ "harness": "pi" })).unwrap();
+    assert!(v["models"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn harness_capabilities_codex_overlays_live_catalog_from_codex_home() {
+    // A CODEX_HOME with models_cache.json → the daemon overlays the visible
+    // model slugs (per-model supported_reasoning_levels) onto the codex
+    // catalog, exactly like the pi overlay. `hide` models and levels the
+    // board does not know (`ultra`) never reach the wire.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("models_cache.json"),
+        r#"{"models": [
+          {"slug": "gpt-5.6-sol", "visibility": "list",
+           "supported_reasoning_levels": [
+             {"effort": "low"}, {"effort": "medium"}, {"effort": "high"},
+             {"effort": "xhigh"}, {"effort": "max"}, {"effort": "ultra"}]},
+          {"slug": "gpt-5.4", "visibility": "list",
+           "supported_reasoning_levels": [{"effort": "none"}, {"effort": "low"}]},
+          {"slug": "codex-auto-review", "visibility": "hide",
+           "supported_reasoning_levels": [{"effort": "low"}]}
+        ]}"#,
+    )
+    .unwrap();
+    let config = Config {
+        codex_home: Some(dir.path().to_path_buf()),
+        ..Config::default()
+    };
+    let d = test_daemon(config);
+
+    let v = handle_request(&d, "harness.capabilities", json!({ "harness": "codex" })).unwrap();
+    let models = v["models"].as_array().unwrap();
+    let ids: Vec<&str> = models.iter().map(|m| m["id"].as_str().unwrap()).collect();
+    assert_eq!(ids, vec!["gpt-5.4", "gpt-5.6-sol"]);
+    let sol = models.iter().find(|m| m["id"] == "gpt-5.6-sol").unwrap();
+    let efforts: Vec<&str> = sol["efforts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        efforts,
+        vec!["low", "medium", "high", "xhigh", "max"],
+        "ultra is filtered, not added to the protocol"
+    );
+    let gpt54 = models.iter().find(|m| m["id"] == "gpt-5.4").unwrap();
+    let efforts: Vec<&str> = gpt54["efforts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        efforts,
+        vec!["off", "low"],
+        "codex `none` maps to board `off`"
+    );
+    // model_freeform stays true: arbitrary model strings are still accepted.
+    assert_eq!(v["model_freeform"], true);
+    // The preset approval vocabulary is untouched by the overlay.
+    let presets: Vec<&str> = v["permission_modes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        presets,
+        vec!["ask-for-approval", "approve-for-me", "full-access"]
+    );
+}
+
+#[test]
+fn harness_capabilities_codex_falls_back_to_static_without_codex_home() {
+    // No codex_home (tests) → static free-form catalog (models: []).
+    let d = test_daemon(Config::default());
+    let v = handle_request(&d, "harness.capabilities", json!({ "harness": "codex" })).unwrap();
+    assert!(v["models"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn harness_capabilities_codex_falls_back_to_static_on_malformed_cache() {
+    // A malformed models_cache.json must not break codex capabilities: the
+    // daemon keeps the static free-form catalog.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("models_cache.json"), "{not json").unwrap();
+    let config = Config {
+        codex_home: Some(dir.path().to_path_buf()),
+        ..Config::default()
+    };
+    let d = test_daemon(config);
+    let v = handle_request(&d, "harness.capabilities", json!({ "harness": "codex" })).unwrap();
     assert!(v["models"].as_array().unwrap().is_empty());
 }
 

--- a/crates/board-daemon/src/ops/tests/mod.rs
+++ b/crates/board-daemon/src/ops/tests/mod.rs
@@ -221,8 +221,15 @@ fn add_rescuable_run(
             session: None,
         })
         .unwrap();
-    db.promote_run_with_anchor_uow(run.id, Some("w1"), Some("w1:p9"), Some("w1:anchor"), None)
-        .unwrap();
+    db.promote_run_with_anchor_uow(
+        run.id,
+        Some("w1"),
+        Some("w1:p9"),
+        Some("w1:anchor"),
+        None,
+        None,
+    )
+    .unwrap();
     // A rescue must work on a *finished* run: the row below is exactly what the
     // tests then assert stays untouched.
     db.finalize_run_uow(&FinalizeRun {

--- a/crates/board-daemon/src/recovery.rs
+++ b/crates/board-daemon/src/recovery.rs
@@ -71,6 +71,7 @@ async fn adopt_runs(d: &Arc<Daemon>) {
             anchor_pane_id: run.herdr_anchor_pane_id.clone(),
             pid: None,
             herdr_socket,
+            captured_session_id: run.session_id.clone(),
         };
         let alive = if handle.pane_id.is_some() {
             let spawner = d.spawner.clone();

--- a/crates/board-daemon/src/rescue.rs
+++ b/crates/board-daemon/src/rescue.rs
@@ -214,7 +214,7 @@ fn rescue_identity(
 /// the two rescue variables, and any harness that reads the board env — the
 /// checked-in fixtures do, under `set -u` — would exit immediately.
 ///
-/// **`BOARD_RUN_ID` is deliberately absent.** It is not documentation, it is the
+/// **`BOARD_RUN_ID` is deliberately empty.** It is not documentation, it is the
 /// *actor credential*: `board comment` authenticates as `agent:$BOARD_RUN_ID`,
 /// `board done` forwards it as the run to finalize, and the configured-harness
 /// wrapper passes it to `run.pane_exited`. A rescued pane belongs to no run, and
@@ -226,13 +226,14 @@ fn rescue_identity(
 ///   unwatched, unowned pane finalize that run — racing the liveness watcher for
 ///   the right to write the run's outcome.
 ///
-/// Omitting it fails closed instead: `board comment` degrades to an ordinary
-/// human comment on the card (still useful, and the card is the durable place for
-/// a rescued conversation to report), `board done` answers "no active run" or is
-/// rejected on run-id mismatch, and the configured wrapper's `__pane-exited` call
-/// fails argument parsing and is swallowed by its own `|| :`. The run id is still
-/// carried, for humans and fixtures, as `BOARD_RESCUED_RUN_ID` — a plain label
-/// that no board command consumes.
+/// An explicit empty value, rather than omission, also overrides a stale value a
+/// shell pane may inherit; the CLI treats empty as unset. Thus `board comment`
+/// degrades to an ordinary human comment on the card (still useful, and the card
+/// is the durable place for a rescued conversation to report), `board done`
+/// answers "no active run" or is rejected on run-id mismatch, and the configured
+/// wrapper's `__pane-exited` call fails argument parsing and is swallowed by its
+/// own `|| :`. The run id is still carried, for humans and fixtures, as
+/// `BOARD_RESCUED_RUN_ID` — a plain label that no board command consumes.
 fn rescue_board_env(
     d: &Arc<Daemon>,
     run: &Run,
@@ -247,8 +248,12 @@ fn rescue_board_env(
         execution.env.retain(|(existing, _)| existing != &key);
         execution.env.push((key, value));
     }
-    // Belt and braces: the actor credential must not survive from any source.
+    // Belt and braces: explicitly clear an actor credential inherited by a
+    // live shell; omission cannot override an existing pane environment.
     execution.env.retain(|(key, _)| key != "BOARD_RUN_ID");
+    execution
+        .env
+        .push(("BOARD_RUN_ID".to_string(), String::new()));
     Ok(())
 }
 

--- a/crates/board-daemon/src/spawner/herdr/managed.rs
+++ b/crates/board-daemon/src/spawner/herdr/managed.rs
@@ -1,5 +1,7 @@
 //! Managed Herdr launch: `agent.start` on a board-owned pane, with the
-//! name/busy retry taxonomy and the wait for the agent to become interactive.
+//! name/busy retry taxonomy, the wait for the agent to become interactive,
+//! and — for self-minting harnesses like codex — the bounded post-launch
+//! capture of the integration-reported conversation/thread id.
 
 use std::fs;
 use std::io::Write;
@@ -16,7 +18,8 @@ use board_herdr::{
 use super::super::placement::{RetryablePlacementRace, ERR_PANE_NOT_FOUND};
 use super::super::{
     HerdrLaunchPlan, AGENT_START_BUSY_BACKOFF, AGENT_START_BUSY_RETRIES, AGENT_START_TIMEOUT_MS,
-    IMMEDIATE_READINESS_PROBES, READINESS_BACKOFF, READINESS_TIMEOUT,
+    IMMEDIATE_READINESS_PROBES, READINESS_BACKOFF, READINESS_TIMEOUT, SESSION_CAPTURE_PROBES,
+    SESSION_CAPTURE_TIMEOUT,
 };
 
 const ERR_AGENT_NAME_TAKEN: &str = "agent_name_taken";
@@ -28,6 +31,15 @@ pub(crate) type DelayFn = dyn Fn(Duration) + Send + Sync;
 /// `HerdrSpawner` (the run-pane rescue) that have no injected clock of their own.
 pub(crate) const DEFAULT_AGENT_START_DELAY: &DelayFn = &(thread::sleep as fn(Duration));
 
+/// Launch one managed agent and return the harness-captured conversation id
+/// (self-minting harnesses like codex), or `None` when no capture applies
+/// (pi/claude, same-pane reuse) or none validated.
+///
+/// The capture travels through the spawn handle so the daemon persists it
+/// atomically with run promotion inside [`crate::dispatch::launch_plan::
+/// register_spawned_run`]'s cancellation critical section — a cancel that
+/// ended the run while the launch was in flight discards the captured id
+/// together with the handle.
 pub(crate) fn launch_managed(
     client: &mut HerdrClient,
     req: &HerdrLaunchPlan,
@@ -35,7 +47,7 @@ pub(crate) fn launch_managed(
     pane_id: &str,
     reuse: bool,
     delay: &DelayFn,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<String>> {
     // A same-conversation resume hop reuses the prior run's agent pane. The
     // conversation + agent are already live there, so there is nothing to
     // `agent.start`: the pane name is exclusive while open (re-starting would
@@ -43,7 +55,9 @@ pub(crate) fn launch_managed(
     // by the original start, and the persisted `--resume`/`--session-id` argv
     // is irrelevant (the conversation is in-process). Just wait for the agent
     // to finish the previous stage's turn (it may still be Working right after
-    // `board done`) and deliver the new stage's prompt.
+    // `board done`) and deliver the new stage's prompt — task only, never a
+    // system block, and nothing to capture (the conversation id is already
+    // persisted on the card).
     if reuse {
         await_reuse_ready(client, pane_id)?;
         if let Some(text) = &req.initial_prompt {
@@ -55,9 +69,172 @@ pub(crate) fn launch_managed(
                 })
                 .with_context(|| format!("herdr agent.prompt (reuse) for {}", req.name))?;
         }
-        return Ok(());
+        return Ok(None);
     }
 
+    match kind {
+        // Codex mints its own thread id and has no system-prompt file: startup
+        // argv carries no prompt text, and the reported id is captured after
+        // readiness through the same gated connection (C5/C7).
+        "codex" => launch_managed_codex(client, req, pane_id, delay),
+        // Pi/Claude keep the authoritative 0600 startup system-prompt file.
+        "pi" | "claude" => {
+            launch_managed_prompt_file(client, req, kind, pane_id, delay)?;
+            Ok(None)
+        }
+        other => bail!("unsupported managed harness kind: {other}"),
+    }
+}
+
+/// A codex launch: `agent.start` with the startup-only argv (no prompt file,
+/// no `--` delimiter), readiness polling, the bounded session capture, and
+/// then the prompt — Mint receives one delimited `system + task` block,
+/// resume/fork receive the task alone, a rescue sends nothing.
+fn launch_managed_codex(
+    client: &mut HerdrClient,
+    req: &HerdrLaunchPlan,
+    pane_id: &str,
+    delay: &DelayFn,
+) -> anyhow::Result<Option<String>> {
+    let (_, startup_tail) = req
+        .argv
+        .split_first()
+        .ok_or_else(|| anyhow!("managed codex invocation has empty startup argv"))?;
+    let params = AgentStartParams {
+        name: req.name.clone(),
+        kind: "codex".to_string(),
+        pane_id: pane_id.to_string(),
+        args: startup_tail.to_vec(),
+        timeout_ms: Some(AGENT_START_TIMEOUT_MS),
+    };
+    let started = agent_start_retry_name(client, &params, req.name_fallback.as_deref(), delay)
+        .map_err(|error| map_start_error(req, error))?;
+    await_interactive_ready(client, &started)?;
+
+    // Post-launch capture: the minted thread id is reported only once the
+    // integration is up. Bounded poll on the SAME gated connection; a
+    // missing/mismatched report degrades to None with a warning and the
+    // launch stays successful (enqueue-time identity is kept as-is).
+    let captured_session_id = capture_codex_session(client, pane_id, delay);
+
+    if let Some(text) = codex_prompt_text(req) {
+        client
+            .agent_prompt(&AgentPromptParams {
+                target: pane_id.to_string(),
+                text,
+                wait: None,
+            })
+            .with_context(|| format!("herdr agent.prompt for {}", req.name))?;
+    }
+    Ok(captured_session_id)
+}
+
+/// The `agent.prompt` text for a codex launch: Mint receives one clearly
+/// delimited block with the system instructions first, then the card task;
+/// resume/fork (fresh pane) receive the task alone; a rescue sends nothing
+/// (`initial_prompt` was cleared by `resume_invocation`). Same-pane reuse is
+/// handled by [`launch_managed`] before this point and delivers the task
+/// alone.
+fn codex_prompt_text(req: &HerdrLaunchPlan) -> Option<String> {
+    let task = req.initial_prompt.as_deref()?;
+    if is_codex_mint(&req.argv) {
+        let system = req.system_prompt.as_deref().unwrap_or_default();
+        Some(board_core::harness::codex::mint_prompt(system, task))
+    } else {
+        Some(task.to_string())
+    }
+}
+
+/// Whether a board-built codex argv is a Mint. The codex session adapter
+/// appends `resume <id>` / `fork <id>` as the LAST two tokens for
+/// resume/fork; a Mint argv carries no session tokens at all. Only the tail
+/// is inspected because the model value after `--model` could itself be
+/// spelled `resume` or `fork`.
+fn is_codex_mint(argv: &[String]) -> bool {
+    !(argv.len() >= 2 && matches!(argv[argv.len() - 2].as_str(), "resume" | "fork"))
+}
+
+/// Bounded post-launch capture of the integration-reported thread id for a
+/// codex pane, over the launch's already-gated connection.
+///
+/// The report rides `AgentInfo.agent_session` (`AgentSessionInfo` in the
+/// protocol-19 schema): `{agent, kind, source, value}`. Only an `id`-kind
+/// reference owned by the codex agent (`agent == "codex"`) with a non-empty
+/// value is a usable conversation id; a wrong agent, a `path` kind or a blank
+/// value means the pane's identity is not board-resumable, so the capture
+/// degrades to `None` with a warning. `source` is deliberately not
+/// constrained — its exact spelling is integration-internal and undocumented,
+/// and the plan's rule is to not overfit it. The poll is bounded by
+/// [`SESSION_CAPTURE_PROBES`] and [`SESSION_CAPTURE_TIMEOUT`]; a session that
+/// never appears degrades the same way and the launch continues.
+fn capture_codex_session(
+    client: &mut HerdrClient,
+    pane_id: &str,
+    delay: &DelayFn,
+) -> Option<String> {
+    let deadline = Instant::now() + SESSION_CAPTURE_TIMEOUT;
+    let mut probes = 0_usize;
+    loop {
+        match client.agent_get(pane_id) {
+            Ok(agent) => {
+                if let Some(session) = agent.agent_session {
+                    let agent_ok = session.agent == "codex";
+                    let kind_ok = session.kind == "id";
+                    let value_ok = !session.value.trim().is_empty();
+                    if agent_ok && kind_ok && value_ok {
+                        tracing::info!(
+                            pane_id,
+                            thread_id = %session.value,
+                            "captured codex thread id"
+                        );
+                        return Some(session.value);
+                    }
+                    tracing::warn!(
+                        pane_id,
+                        agent = %session.agent,
+                        kind = %session.kind,
+                        has_value = value_ok,
+                        error_category = "harness",
+                        "codex reported an unusable agent_session; run continues without a captured thread id"
+                    );
+                    return None;
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    pane_id,
+                    error = %format!("{error:#}"),
+                    error_category = "herdr",
+                    "agent.get failed while capturing the codex thread id; run continues without it"
+                );
+                return None;
+            }
+        }
+        probes += 1;
+        if probes >= SESSION_CAPTURE_PROBES || Instant::now() >= deadline {
+            tracing::warn!(
+                pane_id,
+                probes,
+                error_category = "harness",
+                "codex did not report an agent_session within the capture bound; run continues without a captured thread id"
+            );
+            return None;
+        }
+        if probes > IMMEDIATE_READINESS_PROBES {
+            delay(READINESS_BACKOFF.min(deadline.saturating_duration_since(Instant::now())));
+        }
+    }
+}
+
+/// Pi/Claude fresh launch: startup argv plus the authoritative 0600
+/// system-prompt file, readiness polling, then the card prompt.
+fn launch_managed_prompt_file(
+    client: &mut HerdrClient,
+    req: &HerdrLaunchPlan,
+    kind: &str,
+    pane_id: &str,
+    delay: &DelayFn,
+) -> anyhow::Result<()> {
     let flag = match kind {
         "pi" => "--append-system-prompt",
         "claude" => "--append-system-prompt-file",
@@ -102,18 +279,7 @@ pub(crate) fn launch_managed(
 
     let operation = (|| -> anyhow::Result<()> {
         let started = agent_start_retry_name(client, &params, req.name_fallback.as_deref(), delay)
-            .map_err(|error| {
-                let message = error.to_string();
-                let typed = if matches!(
-                    &error,
-                    HerdrError::Protocol { code, .. } if code == ERR_PANE_NOT_FOUND
-                ) {
-                    anyhow::Error::new(RetryablePlacementRace(error))
-                } else {
-                    anyhow::Error::new(error)
-                };
-                typed.context(format!("herdr agent.start for {}: {message}", req.name))
-            })?;
+            .map_err(|error| map_start_error(req, error))?;
         await_interactive_ready(client, &started)?;
         if let Some(text) = &req.initial_prompt {
             client
@@ -138,6 +304,21 @@ pub(crate) fn launch_managed(
             "additionally failed to remove system-prompt file: {remove_error:#}"
         ))),
     }
+}
+
+/// Wrap an `agent.start` failure, classifying the owned-pane race exactly as
+/// placement does so the caller can retry the whole allocation.
+fn map_start_error(req: &HerdrLaunchPlan, error: HerdrError) -> anyhow::Error {
+    let message = error.to_string();
+    let typed = if matches!(
+        &error,
+        HerdrError::Protocol { code, .. } if code == ERR_PANE_NOT_FOUND
+    ) {
+        anyhow::Error::new(RetryablePlacementRace(error))
+    } else {
+        anyhow::Error::new(error)
+    };
+    typed.context(format!("herdr agent.start for {}: {message}", req.name))
 }
 
 fn agent_start_retry_name(

--- a/crates/board-daemon/src/spawner/herdr/mod.rs
+++ b/crates/board-daemon/src/spawner/herdr/mod.rs
@@ -205,7 +205,7 @@ impl HerdrSpawner {
             // `agent.start` and only re-prompts the live agent.
             let reused = req.reuse_pane_id.as_deref() == Some(owned.pane_id.as_str());
 
-            let launch_result = match req.agent_kind.as_deref() {
+            let launch_result: anyhow::Result<Option<String>> = match req.agent_kind.as_deref() {
                 Some(kind) => launch_managed(
                     &mut client,
                     req,
@@ -220,11 +220,12 @@ impl HerdrSpawner {
                     &selected_socket,
                     req,
                     &owned.pane_id,
-                ),
+                )
+                .map(|()| None),
             };
 
             match launch_result {
-                Ok(()) => {
+                Ok(captured_session_id) => {
                     // Managed card tabs converge to exactly one harness pane:
                     // once the fresh launch (or the reuse re-prompt) succeeded,
                     // close the anchor so no shell strip is left beside the
@@ -260,6 +261,10 @@ impl HerdrSpawner {
                         anchor_pane_id,
                         pid: None,
                         herdr_socket: req.herdr_socket.clone(),
+                        // The launch captured the integration-reported
+                        // conversation id (codex self-mints its thread id);
+                        // dispatch persists it atomically with the promotion.
+                        captured_session_id,
                     });
                 }
                 Err(error) if attempt == 0 && is_retryable_placement_race(&error) => {

--- a/crates/board-daemon/src/spawner/mod.rs
+++ b/crates/board-daemon/src/spawner/mod.rs
@@ -98,6 +98,12 @@ pub struct RuntimeHandle {
     /// herdr socket this pane lives on (its session), so kill/liveness target
     /// the right session after a daemon restart. `None` = default socket.
     pub herdr_socket: Option<PathBuf>,
+    /// Harness-reported conversation/thread id captured after launch
+    /// (self-minting integrations like codex report it only once the agent is
+    /// up, via `agent.get.agent_session`). The daemon persists it atomically
+    /// with run promotion + card running/session update; `None` means no
+    /// capture was attempted (pi/claude, reuse) or none validated.
+    pub captured_session_id: Option<String>,
 }
 
 /// Launch, kill, and liveness-check agent processes.
@@ -125,3 +131,10 @@ pub(crate) const AGENT_START_BUSY_BACKOFF: Duration = Duration::from_millis(100)
 pub(crate) const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const READINESS_BACKOFF: Duration = Duration::from_millis(100);
 pub(crate) const IMMEDIATE_READINESS_PROBES: usize = 3;
+/// Total `agent.get` probes of the post-launch session capture (self-minting
+/// harnesses like codex). After the immediate probes the capture backs off
+/// with [`READINESS_BACKOFF`], and [`SESSION_CAPTURE_TIMEOUT`] is the hard
+/// wall-clock cap — the capture is bounded and degrades to `None` instead of
+/// polling forever, so a late or missing thread report never stalls launch.
+pub(crate) const SESSION_CAPTURE_PROBES: usize = 5;
+pub(crate) const SESSION_CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);

--- a/crates/board-daemon/src/spawner/rescue.rs
+++ b/crates/board-daemon/src/spawner/rescue.rs
@@ -383,7 +383,13 @@ fn launch_rescue(
             pane_id,
             false,
             DEFAULT_AGENT_START_DELAY,
-        ),
+        )
+        .map(|_captured| {
+            // A rescue persists nothing: the captured id (when the resumed
+            // integration reports one) is deliberately dropped here — the
+            // historical run row stays immutable, so there is nowhere to
+            // promote it to.
+        }),
         None => {
             let runner = HerdrCliPaneRunner;
             launch_configured(

--- a/crates/board-daemon/src/spawner/tests/managed.rs
+++ b/crates/board-daemon/src/spawner/tests/managed.rs
@@ -3,6 +3,8 @@
 //! file, readiness polling before the card prompt, and the bounded
 //! `agent_pane_busy` / name-collision retry budget.
 
+use std::time::Duration;
+
 use super::*;
 use serde_json::json;
 
@@ -559,5 +561,379 @@ fn managed_composed_name_taken_then_busy_has_one_global_busy_budget() {
             "card-42-execute-r7",
             "card-42-execute-r7",
         ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Codex (C5 capture + C7 no-file prompt semantics): the self-minting harness
+// has no system-prompt file and no prompt in startup argv; after readiness the
+// daemon bounded-polls `agent.get.agent_session` on the gated connection,
+// validates `{agent: codex, kind: id, value non-empty}`, and delivers the
+// prompt — Mint gets one delimited system+task block, resume/fork the task
+// alone, reuse the task alone, rescue nothing. The captured thread id rides
+// the handle for atomic promotion.
+// ---------------------------------------------------------------------------
+
+/// An `agent.get` reply carrying a protocol-19 `AgentSessionInfo`.
+/// A reused codex pane that is already interactive and quiescent (mirror of
+/// `pane_reuse::reuse_agent_ready`, kept local so this module owns its fixture).
+fn codex_reuse_agent_ready(req: &Value, pane_id: &str, status: &str) -> Value {
+    reply(
+        req,
+        json!({"type":"agent_info","agent":{
+            "pane_id": pane_id, "agent": "codex", "agent_status": status,
+            "interactive_ready": true, "launch_pending": false,
+            "focused": false, "revision": 2
+        }}),
+    )
+}
+
+/// An `agent.get` reply carrying a protocol-19 `AgentSessionInfo`.
+fn agent_get_with_session(req: &Value, pane_id: &str, session: Value) -> Value {
+    reply(
+        req,
+        json!({
+            "type": "agent_info",
+            "agent": {
+                "pane_id": pane_id,
+                "agent": "codex",
+                "agent_status": "idle",
+                "interactive_ready": true,
+                "launch_pending": false,
+                "focused": false,
+                "revision": 2,
+                "agent_session": session
+            }
+        }),
+    )
+}
+
+fn codex_session(thread_id: &str) -> Value {
+    json!({"agent": "codex", "kind": "id", "source": "session", "value": thread_id})
+}
+
+/// The exact startup tail `board_core::harness::codex` produces for
+/// `codex_req`: no prompt file flag, no `--`, no task text.
+const CODEX_STARTUP_TAIL: &[&str] = &["--model", "gpt-5.6", "-c", "model_reasoning_effort=low"];
+
+#[test]
+fn managed_codex_mint_has_no_prompt_file_captures_session_then_prompts_delimited_block() {
+    use board_core::harness::codex::{mint_prompt, MINT_SYSTEM_DELIMITER, MINT_TASK_DELIMITER};
+
+    let prompts = Arc::new(Mutex::new(Vec::<String>::new()));
+    let prompts_for_server = Arc::clone(&prompts);
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => {
+            // C7: no system-prompt file and no argv prompt for codex.
+            let args: Vec<&str> = req["params"]["args"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert_eq!(
+                args, CODEX_STARTUP_TAIL,
+                "codex startup argv must be exactly the startup tail"
+            );
+            assert_eq!(req["params"]["kind"], "codex");
+            agent_started(req, "w1:p2", false, true)
+        }
+        "agent.get" => {
+            assert_eq!(req["params"], json!({"target": "w1:p2"}));
+            agent_get_with_session(req, "w1:p2", codex_session("thread-1"))
+        }
+        "agent.prompt" => {
+            prompts_for_server
+                .lock()
+                .unwrap()
+                .push(req["params"]["text"].as_str().unwrap().to_string());
+            agent_prompted(req, "w1:p2", "card-42-execute")
+        }
+        method => panic!("unexpected codex-mint method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+
+    let handle = spawner
+        .spawn(&codex_req(&[], Some("build the widget")))
+        .unwrap();
+    assert_eq!(handle.pane_id.as_deref(), Some("w1:p2"));
+    assert_eq!(
+        handle.captured_session_id.as_deref(),
+        Some("thread-1"),
+        "the captured thread id must ride the handle for atomic promotion"
+    );
+
+    let requests = fake.requests.lock().unwrap();
+    let methods: Vec<_> = requests
+        .iter()
+        .map(|r| r["method"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        methods,
+        [
+            "ping",
+            "tab.list",
+            "tab.create",
+            "agent.start",
+            "agent.get",
+            "agent.prompt"
+        ],
+        "capture polls agent.get once and only then delivers the prompt"
+    );
+    let prompts = prompts.lock().unwrap();
+    assert_eq!(prompts.len(), 1);
+    assert_eq!(
+        prompts[0],
+        mint_prompt("codex system instructions", "build the widget"),
+        "Mint receives ONE clearly delimited block: system instructions first, then the task"
+    );
+    let block = &prompts[0];
+    assert!(block.starts_with(MINT_SYSTEM_DELIMITER));
+    let task_pos = block.find(MINT_TASK_DELIMITER).unwrap();
+    assert!(block[..task_pos].contains("codex system instructions"));
+    assert!(block[task_pos..].contains("build the widget"));
+}
+
+#[test]
+fn managed_codex_resume_and_fork_prompt_task_only_with_the_real_thread_id() {
+    // Resume: the prompt is the task alone (the conversation already has the
+    // system instructions), and the reported session id is the real thread.
+    for (tail, thread) in [
+        (&["resume", "thread-7"][..], "thread-7"),
+        (&["fork", "thread-7"][..], "thread-7"),
+    ] {
+        let prompts = Arc::new(Mutex::new(Vec::<String>::new()));
+        let prompts_for_server = Arc::clone(&prompts);
+        let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+            "tab.list" => empty_tab_list(req),
+            "tab.create" => tab_created(req, "w1:p2"),
+            "agent.start" => {
+                let args: Vec<&str> = req["params"]["args"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_str().unwrap())
+                    .collect();
+                let mut expected = CODEX_STARTUP_TAIL.to_vec();
+                expected.extend_from_slice(tail);
+                assert_eq!(args, expected, "the session subcommand closes the argv");
+                agent_started(req, "w1:p2", false, true)
+            }
+            "agent.get" => agent_get_with_session(req, "w1:p2", codex_session(thread)),
+            "agent.prompt" => {
+                prompts_for_server
+                    .lock()
+                    .unwrap()
+                    .push(req["params"]["text"].as_str().unwrap().to_string());
+                agent_prompted(req, "w1:p2", "card-42-execute")
+            }
+            method => panic!("unexpected codex-{tail:?} method {method}"),
+        });
+        let spawner = HerdrSpawner::new(fake.socket.clone());
+        let handle = spawner
+            .spawn(&codex_req(tail, Some("next stage task")))
+            .unwrap();
+        assert_eq!(handle.captured_session_id.as_deref(), Some(thread));
+        let prompts = prompts.lock().unwrap();
+        assert_eq!(
+            prompts.as_slice(),
+            &["next stage task".to_string()],
+            "resume/fork receive the task alone — never a system block"
+        );
+    }
+}
+
+#[test]
+fn managed_codex_reuse_prompts_task_only_and_does_not_capture() {
+    let gets = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let gets_for_server = Arc::clone(&gets);
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => reply(
+            req,
+            json!({"type":"tab_list","tabs":[{
+                "tab_id":"w1:t1","workspace_id":"w1","number":1,
+                "label":"card-42","pane_count":1
+            }]}),
+        ),
+        "pane.list" => {
+            let mut prior = pane_info("w1:p-prior");
+            prior["label"] = json!("card-42-setup");
+            prior["agent"] = json!("codex");
+            prior["agent_status"] = json!("done");
+            reply(req, json!({"type":"pane_list","panes":[prior]}))
+        }
+        "agent.get" => {
+            gets_for_server.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            codex_reuse_agent_ready(req, "w1:p-prior", "done")
+        }
+        "agent.prompt" => {
+            assert_eq!(req["params"]["text"], "next stage task");
+            agent_prompted(req, "w1:p-prior", "card-42-execute")
+        }
+        method => panic!("unexpected codex-reuse method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+    let mut request = codex_req(&["resume", "thread-7"], Some("next stage task"));
+    request.tab_label = Some("card-42".into());
+    request.owned_tab_id = Some("w1:t1".into());
+    request.durable_pane_ids = vec!["w1:p-prior".into()];
+    request.reclaimable_pane_ids = vec!["w1:p-prior".into()];
+    request.reuse_pane_id = Some("w1:p-prior".into());
+
+    let handle = spawner.spawn(&request).unwrap();
+    assert_eq!(handle.pane_id.as_deref(), Some("w1:p-prior"));
+    assert_eq!(
+        handle.captured_session_id, None,
+        "same-pane reuse re-prompts the live conversation; there is nothing to capture"
+    );
+    assert_eq!(
+        gets.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "reuse does exactly one agent.get (quiescence) and no capture poll"
+    );
+}
+
+#[test]
+fn managed_codex_absent_session_degrades_within_bounds_and_launch_succeeds() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let gets = Arc::new(AtomicUsize::new(0));
+    let gets_for_server = Arc::clone(&gets);
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => {
+            assert_eq!(
+                req["params"]["args"].as_array().unwrap().len(),
+                CODEX_STARTUP_TAIL.len(),
+                "no prompt file flag may be appended when no session is reported"
+            );
+            agent_started(req, "w1:p2", false, true)
+        }
+        "agent.get" => {
+            gets_for_server.fetch_add(1, Ordering::SeqCst);
+            agent_get_result(req, "w1:p2", "card-42-execute", false, true)
+        }
+        "agent.prompt" => agent_prompted(req, "w1:p2", "card-42-execute"),
+        method => panic!("unexpected codex-absent method {method}"),
+    });
+    // Zero-delay clock: the bounded capture backoff never hits the wall.
+    let spawner = HerdrSpawner::with_pane_runner_and_delay(
+        fake.socket.clone(),
+        Arc::new(RecordingPaneRunner {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            behavior: Box::new(|_, _| unreachable!("managed launch must not use pane runner")),
+        }),
+        Arc::new(|_: Duration| {}),
+    );
+
+    let handle = spawner
+        .spawn(&codex_req(&[], Some("build the widget")))
+        .unwrap();
+    assert_eq!(
+        handle.captured_session_id, None,
+        "an absent thread report degrades to None"
+    );
+    assert_eq!(
+        gets.load(Ordering::SeqCst),
+        super::super::SESSION_CAPTURE_PROBES,
+        "the capture is bounded: exactly the probe budget, never an unbounded poll"
+    );
+    let requests = fake.requests.lock().unwrap();
+    let methods: Vec<_> = requests
+        .iter()
+        .map(|r| r["method"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        methods.last().copied(),
+        Some("agent.prompt"),
+        "basic launch stays successful without a reported session"
+    );
+}
+
+#[test]
+fn managed_codex_mismatched_session_report_degrades_immediately() {
+    // Wrong owner agent: the pane's session belongs to another agent.
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => agent_started(req, "w1:p2", false, true),
+        "agent.get" => agent_get_with_session(
+            req,
+            "w1:p2",
+            json!({"agent": "pi", "kind": "id", "source": "session", "value": "thread-x"}),
+        ),
+        "agent.prompt" => agent_prompted(req, "w1:p2", "card-42-execute"),
+        method => panic!("unexpected codex-wrong-agent method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+    let handle = spawner.spawn(&codex_req(&[], Some("task"))).unwrap();
+    assert_eq!(
+        handle.captured_session_id, None,
+        "a session owned by a different agent must not be captured as the codex thread id"
+    );
+
+    // `path` kind: a filesystem reference is not a resumable conversation id.
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => agent_started(req, "w1:p2", false, true),
+        "agent.get" => agent_get_with_session(
+            req,
+            "w1:p2",
+            json!({"agent": "codex", "kind": "path", "source": "pane", "value": "/tmp/s.json"}),
+        ),
+        "agent.prompt" => agent_prompted(req, "w1:p2", "card-42-execute"),
+        method => panic!("unexpected codex-path-kind method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+    let handle = spawner.spawn(&codex_req(&[], Some("task"))).unwrap();
+    assert_eq!(
+        handle.captured_session_id, None,
+        "a path-kind reference is not a conversation id"
+    );
+
+    // Blank value: nothing to resume against.
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => agent_started(req, "w1:p2", false, true),
+        "agent.get" => agent_get_with_session(
+            req,
+            "w1:p2",
+            json!({"agent": "codex", "kind": "id", "source": "session", "value": "  "}),
+        ),
+        "agent.prompt" => agent_prompted(req, "w1:p2", "card-42-execute"),
+        method => panic!("unexpected codex-blank-value method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+    let handle = spawner.spawn(&codex_req(&[], Some("task"))).unwrap();
+    assert_eq!(handle.captured_session_id, None, "a blank id must degrade");
+}
+
+#[test]
+fn managed_codex_rescue_shaped_launch_captures_but_never_prompts() {
+    // Rescue shape: `resume <id>` argv with initial_prompt cleared by
+    // `resume_invocation`. The capture still runs (the id is re-confirmed),
+    // but NO agent.prompt is sent — re-sending the task would re-run it.
+    let fake = serve_recording_herdr(move |req, _| match req["method"].as_str().unwrap() {
+        "tab.list" => empty_tab_list(req),
+        "tab.create" => tab_created(req, "w1:p2"),
+        "agent.start" => agent_started(req, "w1:p2", false, true),
+        "agent.get" => agent_get_with_session(req, "w1:p2", codex_session("thread-9")),
+        method => panic!("unexpected codex-rescue method {method}"),
+    });
+    let spawner = HerdrSpawner::new(fake.socket.clone());
+
+    let handle = spawner
+        .spawn(&codex_req(&["resume", "thread-9"], None))
+        .unwrap();
+    assert_eq!(handle.captured_session_id.as_deref(), Some("thread-9"));
+    let requests = fake.requests.lock().unwrap();
+    assert!(
+        requests.iter().all(|r| r["method"] != "agent.prompt"),
+        "a rescue-shaped launch must never re-send the card task"
     );
 }

--- a/crates/board-daemon/src/spawner/tests/mod.rs
+++ b/crates/board-daemon/src/spawner/tests/mod.rs
@@ -218,6 +218,39 @@ fn claude_req() -> HerdrLaunchPlan {
     }
 }
 
+/// A board-built codex launch plan: startup-only argv (Mint) or with the
+/// `resume <id>` / `fork <id>` subcommand pair appended last (the exact shape
+/// `board_core::harness::codex::managed_codex_invocation` persists).
+fn codex_req(session_tail: &[&str], initial_prompt: Option<&str>) -> HerdrLaunchPlan {
+    let mut argv = vec![
+        "codex".into(),
+        "--model".into(),
+        "gpt-5.6".into(),
+        "-c".into(),
+        "model_reasoning_effort=low".into(),
+    ];
+    argv.extend(session_tail.iter().map(|s| s.to_string()));
+    HerdrLaunchPlan {
+        name: "card-42-execute".into(),
+        name_fallback: Some("card-42-execute-r7".into()),
+        agent_kind: Some("codex".into()),
+        initial_prompt: initial_prompt.map(str::to_string),
+        system_prompt: Some("codex system instructions".into()),
+        tab_label: Some("kanban".into()),
+        owned_tab_id: None,
+        durable_pane_ids: Vec::new(),
+        reclaimable_pane_ids: Vec::new(),
+        durable_anchor_pane_ids: Vec::new(),
+        reuse_pane_id: None,
+        cwd: Some(PathBuf::from("/tmp/card cwd")),
+        workspace_ref: Some("w1".into()),
+        herdr_socket: None,
+        bootstrap: None,
+        env: vec![("BOARD_CARD_ID".into(), "42".into())],
+        argv,
+    }
+}
+
 fn assert_startup_prompt_file(
     req: &Value,
     expected_base_args: &[&str],

--- a/crates/board-daemon/src/supervisor.rs
+++ b/crates/board-daemon/src/supervisor.rs
@@ -286,6 +286,7 @@ fn adopt_alive(
         anchor_pane_id: current_run.herdr_anchor_pane_id.clone(),
         pid: None,
         herdr_socket: socket,
+        captured_session_id: current_run.session_id.clone(),
     };
     {
         let mut sched = d.sched.lock().unwrap();

--- a/crates/board-herdr/src/lib.rs
+++ b/crates/board-herdr/src/lib.rs
@@ -40,7 +40,7 @@ pub use params::{
 };
 pub use transport::{default_socket_path, SocketDeadlines};
 pub use types::{
-    AgentInfo, AgentStarted, AgentStatus, Layout, LayoutPane, LayoutSplit, NotificationShown,
-    NotificationSound, PaneInfo, PaneReadResult, Pong, ReadSource, Rect, SessionSnapshot,
-    SplitDirection, TabCreated, TabInfo, WorkspaceCreated, WorkspaceInfo,
+    AgentInfo, AgentSession, AgentStarted, AgentStatus, Layout, LayoutPane, LayoutSplit,
+    NotificationShown, NotificationSound, PaneInfo, PaneReadResult, Pong, ReadSource, Rect,
+    SessionSnapshot, SplitDirection, TabCreated, TabInfo, WorkspaceCreated, WorkspaceInfo,
 };

--- a/crates/board-herdr/src/types.rs
+++ b/crates/board-herdr/src/types.rs
@@ -109,6 +109,21 @@ pub struct PaneInfo {
     pub revision: u64,
 }
 
+/// A protocol-19 agent-session reference (the `AgentSessionInfo` object that
+/// `AgentInfo.agent_session` carries): a `{agent, kind, source, value}` DTO
+/// where `kind` is `"id"` or `"path"`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct AgentSession {
+    #[serde(default)]
+    pub agent: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub source: String,
+    #[serde(default)]
+    pub value: String,
+}
+
 /// An agent-bearing pane, as listed in `session.snapshot.agents`.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct AgentInfo {
@@ -131,6 +146,10 @@ pub struct AgentInfo {
     pub launch_pending: bool,
     #[serde(default)]
     pub interactive_ready: bool,
+    /// Session reference (`AgentSessionInfo | null` in the protocol-19
+    /// schema); absent on panes without a reported agent session.
+    #[serde(default)]
+    pub agent_session: Option<AgentSession>,
 }
 
 /// Live session state (subset the daemon consumes).

--- a/crates/board-herdr/tests/agent_session.rs
+++ b/crates/board-herdr/tests/agent_session.rs
@@ -1,0 +1,107 @@
+//! Public-API coverage for the protocol-19 `agent_session` DTO on
+//! [`board_herdr::AgentInfo`].
+//!
+//! Shapes verified against `tests/fixtures/schema.json` (Herdr 0.8.0,
+//! protocol 19): `success_response/$defs/AgentInfo.properties.agent_session`
+//! is `AgentSessionInfo | null`, where `AgentSessionInfo` is the
+//! `{agent, kind, source, value}` object with `kind` ∈ {`id`, `path`}.
+//! `agent_session` is not in `AgentInfo`'s `required` list, so a pane without
+//! a reported agent session omits the field entirely.
+
+use board_herdr::AgentInfo;
+use serde_json::json;
+
+/// Minimal protocol-19 `AgentInfo` (schema `required` list) plus the extra
+/// `agent`/`name` fields herdr sends, with `agent_session` present
+/// (`kind: "id"`).
+#[test]
+fn decodes_agent_session_present_with_id_kind() {
+    let info: AgentInfo = serde_json::from_value(json!({
+        "terminal_id": "term-2",
+        "agent_status": "working",
+        "workspace_id": "w1",
+        "tab_id": "w1:t1",
+        "pane_id": "w1:p2",
+        "focused": false,
+        "revision": 3,
+        "agent": "pi",
+        "name": "card-42-execute",
+        "agent_session": {
+            "agent": "pi",
+            "kind": "id",
+            "source": "session",
+            "value": "p19-session"
+        }
+    }))
+    .unwrap();
+
+    let session = info.agent_session.expect("agent_session should decode");
+    assert_eq!(session.agent, "pi");
+    assert_eq!(session.kind, "id");
+    assert_eq!(session.source, "session");
+    assert_eq!(session.value, "p19-session");
+}
+
+/// The same DTO with `kind: "path"` (a session reference by path).
+#[test]
+fn decodes_agent_session_present_with_path_kind() {
+    let info: AgentInfo = serde_json::from_value(json!({
+        "terminal_id": "term-2",
+        "agent_status": "done",
+        "workspace_id": "w1",
+        "tab_id": "w1:t1",
+        "pane_id": "w1:p2",
+        "focused": false,
+        "revision": 4,
+        "agent_session": {
+            "agent": "pi",
+            "kind": "path",
+            "source": "pane",
+            "value": "/home/user/.herdr/sessions/p19-session.json"
+        }
+    }))
+    .unwrap();
+
+    let session = info.agent_session.expect("agent_session should decode");
+    assert_eq!(session.agent, "pi");
+    assert_eq!(session.kind, "path");
+    assert_eq!(session.source, "pane");
+    assert_eq!(session.value, "/home/user/.herdr/sessions/p19-session.json");
+}
+
+/// `agent_session` omitted (the protocol-19 default for panes without a
+/// reported session) decodes as `None`.
+#[test]
+fn decodes_agent_session_absent_as_none() {
+    let info: AgentInfo = serde_json::from_value(json!({
+        "terminal_id": "term-1",
+        "agent_status": "idle",
+        "workspace_id": "w1",
+        "tab_id": "w1:t1",
+        "pane_id": "w1:p1",
+        "focused": true,
+        "revision": 2
+    }))
+    .unwrap();
+
+    assert_eq!(info.agent_session, None);
+}
+
+/// An explicit `null` (allowed by the schema's `AgentSessionInfo | null`
+/// anyOf) also decodes as `None`.
+#[test]
+fn decodes_agent_session_null_as_none() {
+    let info: AgentInfo = serde_json::from_value(json!({
+        "terminal_id": "term-1",
+        "agent_status": "idle",
+        "workspace_id": "w1",
+        "tab_id": "w1:t1",
+        "pane_id": "w1:p1",
+        "focused": true,
+        "revision": 2,
+        "agent_session": null
+    }))
+    .unwrap();
+
+    assert_eq!(info.agent_session, None);
+}

--- a/crates/board-tui/src/forms/builders.rs
+++ b/crates/board-tui/src/forms/builders.rs
@@ -219,13 +219,27 @@ fn effort_choice_opts(efforts: &[Effort], current: Option<&str>) -> (Vec<ChoiceO
 
 /// Shared permission selector: `(default)` (wire `None`) + each mode. Used by
 /// both the card `Permission` field and the column `PermissionOverride` field.
+/// Codex's stable wire ids get the same human labels as its `/permissions`
+/// picker; config-defined modes remain verbatim.
 fn permission_choice_opts(modes: &[String], current: Option<&str>) -> (Vec<ChoiceOpt>, usize) {
     let mut opts = vec![ChoiceOpt::default_opt()];
-    for m in modes {
-        opts.push(ChoiceOpt::str(m));
+    for mode in modes {
+        let label = match mode.as_str() {
+            "ask-for-approval" => "Ask for approval",
+            "approve-for-me" => "Approve for me",
+            "full-access" => "Full access",
+            other => other,
+        };
+        opts.push(ChoiceOpt {
+            label: label.to_string(),
+            val: ChoiceVal::Str(mode.clone()),
+        });
     }
     let idx = current
-        .and_then(|c| opts.iter().position(|o| o.label == c))
+        .and_then(|current| {
+            opts.iter()
+                .position(|option| matches!(&option.val, ChoiceVal::Str(value) if value == current))
+        })
         .unwrap_or(0);
     (opts, idx)
 }

--- a/crates/board-tui/tests/forms.rs
+++ b/crates/board-tui/tests/forms.rs
@@ -1,5 +1,5 @@
 use board_core::capability::{
-    claude_capabilities, pi_capabilities, HarnessCapabilities, ModelInfo,
+    claude_capabilities, codex_capabilities, pi_capabilities, HarnessCapabilities, ModelInfo,
 };
 use board_core::engine::{validate_card_space, validate_column_permission_override};
 use board_core::protocol::{Effort, SpaceKind};
@@ -67,7 +67,11 @@ fn card_harness_select_consumes_harness_list() {
     // (the card default).
     let mut form = Form::card_create(1);
     let before = choice_labels(&form, FieldId::Harness);
-    assert_eq!(before, vec!["pi".to_string(), "claude".to_string()]);
+    assert_eq!(
+        before,
+        vec!["pi".to_string(), "claude".to_string(), "codex".to_string()],
+        "the built-in catalog includes codex after claude"
+    );
     form.apply_options(
         None,
         Some(vec!["pi".into(), "claude".into(), "fake".into()]),
@@ -249,6 +253,148 @@ fn card_selectors_fall_back_to_default_capabilities_per_harness() {
         choice_labels(&unknown, FieldId::Permission),
         vec!["(default)", "ask"]
     );
+}
+
+#[test]
+fn card_codex_selectors_show_full_ladder_and_approval_modes() {
+    // The codex catalog drives the guided selectors: the full effort ladder
+    // with `off` first (mapped to codex `none` only at argv time), and the
+    // three user-facing approval presets. Sandbox is not a permission mode.
+    let mut form = Form::card_create(1);
+    set_choice(&mut form, FieldId::Harness, "codex");
+    form.apply_options(Some(codex_capabilities()), None, None, None);
+    assert_eq!(form.current_harness(), "codex");
+    assert_eq!(
+        choice_labels(&form, FieldId::Effort),
+        vec![
+            "(default)".to_string(),
+            "off".to_string(),
+            "minimal".to_string(),
+            "low".to_string(),
+            "medium".to_string(),
+            "high".to_string(),
+            "xhigh".to_string(),
+            "max".to_string(),
+        ],
+        "the full ladder, off first"
+    );
+    assert!(
+        form.field_visible(idx_of(&form, FieldId::Permission)),
+        "codex has approval modes, so the permission field is visible"
+    );
+    assert_eq!(
+        choice_labels(&form, FieldId::Permission),
+        vec![
+            "(default)".to_string(),
+            "Ask for approval".to_string(),
+            "Approve for me".to_string(),
+            "Full access".to_string(),
+        ]
+    );
+
+    // Submit carries the exact card overrides.
+    form.fields
+        .iter_mut()
+        .find(|f| f.id == FieldId::Title)
+        .unwrap()
+        .set_text("codex task");
+    set_choice(&mut form, FieldId::Effort, "off");
+    set_choice(&mut form, FieldId::Permission, "Full access");
+    match form.submit().unwrap() {
+        Submit::CardCreate(p) => {
+            assert_eq!(p.harness.as_deref(), Some("codex"));
+            assert_eq!(p.effort, Some(Effort::Off));
+            assert_eq!(p.permission_mode.as_deref(), Some("full-access"));
+        }
+        _ => panic!("expected CardCreate"),
+    }
+}
+
+#[test]
+fn card_codex_default_capabilities_before_fetch() {
+    // Before any catalog fetch, selecting codex answers from board-core's
+    // built-in snapshot (`default_capabilities`), not a hardcoded harness
+    // comparison — same ladder and approval enum the daemon will confirm.
+    let mut form = Form::card_create(1);
+    set_choice(&mut form, FieldId::Harness, "codex");
+    form.apply_options(None, None, None, None);
+    assert_eq!(form.current_harness(), "codex");
+    assert_eq!(
+        choice_labels(&form, FieldId::Effort),
+        vec![
+            "(default)".to_string(),
+            "off".to_string(),
+            "minimal".to_string(),
+            "low".to_string(),
+            "medium".to_string(),
+            "high".to_string(),
+            "xhigh".to_string(),
+            "max".to_string(),
+        ]
+    );
+    assert!(form.field_visible(idx_of(&form, FieldId::Permission)));
+    assert_eq!(
+        choice_labels(&form, FieldId::Permission),
+        vec![
+            "(default)".to_string(),
+            "Ask for approval".to_string(),
+            "Approve for me".to_string(),
+            "Full access".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn column_codex_override_selectors_show_ladder_and_approval() {
+    // Column override selectors share the card form's builders, so selecting
+    // codex offers the same full ladder and approval enum as the card form.
+    let mut form = Form::column_create(&[]);
+    set_choice(&mut form, FieldId::HarnessOverride, "codex");
+    form.apply_options(Some(codex_capabilities()), None, None, None);
+    assert_eq!(form.current_harness(), "codex");
+    assert_eq!(
+        choice_labels(&form, FieldId::EffortOverride),
+        vec![
+            "(default)".to_string(),
+            "off".to_string(),
+            "minimal".to_string(),
+            "low".to_string(),
+            "medium".to_string(),
+            "high".to_string(),
+            "xhigh".to_string(),
+            "max".to_string(),
+        ]
+    );
+    assert!(
+        form.field_visible(idx_of(&form, FieldId::PermissionOverride)),
+        "a codex override harness shows its approval selector"
+    );
+    assert_eq!(
+        choice_labels(&form, FieldId::PermissionOverride),
+        vec![
+            "(default)".to_string(),
+            "Ask for approval".to_string(),
+            "Approve for me".to_string(),
+            "Full access".to_string(),
+        ]
+    );
+
+    // Submit carries the exact column overrides.
+    form.fields
+        .iter_mut()
+        .find(|f| f.id == FieldId::Name)
+        .unwrap()
+        .set_text("Codex stage");
+    set_choice(&mut form, FieldId::EffortOverride, "minimal");
+    set_choice(&mut form, FieldId::PermissionOverride, "Ask for approval");
+    match form.submit().unwrap() {
+        Submit::ColumnCreate(p) => {
+            assert_eq!(p.harness_override.as_deref(), Some("codex"));
+            assert_eq!(p.effort_override.as_deref(), Some("minimal"));
+            assert_eq!(p.permission_override.as_deref(), Some("ask-for-approval"));
+        }
+        _ => panic!("expected ColumnCreate"),
+    }
 }
 
 /// A9: submit runs the core validators as a pre-flight, so the

--- a/crates/board-tui/tests/update/forms.rs
+++ b/crates/board-tui/tests/update/forms.rs
@@ -1,7 +1,7 @@
 //! Form tests: field cycling, capabilities, model/effort/harness/space selectors.
 
 use super::helpers::{
-    demo_client, driver_of, is_choice, key, opt_labels, set_choice, split_effort_caps,
+    demo_client, driver_of, is_choice, key, opt_labels, set_choice, split_effort_caps, CodexClient,
     RecordingClient,
 };
 use board_core::capability::{
@@ -201,7 +201,11 @@ fn new_card_defaults_to_pi_and_lists_both_builtins() {
     d.handle(key(KeyCode::Char('n')));
     let form = d.app.form.as_ref().unwrap();
     assert_eq!(form.current_harness(), "pi");
-    assert_eq!(opt_labels(form, FieldId::Harness), vec!["pi", "claude"]);
+    assert_eq!(
+        opt_labels(form, FieldId::Harness),
+        vec!["pi", "claude", "codex"],
+        "the built-in catalog includes codex after claude"
+    );
     assert_eq!(form.caps.as_ref().unwrap().harness, "pi");
 }
 
@@ -220,7 +224,7 @@ fn opening_column_form_loads_only_column_metadata() {
     assert_eq!(form.caps.as_ref().unwrap().harness, "pi");
     assert_eq!(
         opt_labels(form, FieldId::HarnessOverride),
-        vec!["none", "pi", "claude"]
+        vec!["none", "pi", "claude", "codex"]
     );
     assert!(form.spaces.is_empty(), "column forms do not load spaces");
     assert!(
@@ -325,6 +329,179 @@ fn switching_harness_reloads_capabilities() {
         .position(|field| field.id == FieldId::Permission)
         .unwrap();
     assert!(form.field_visible(permission_idx));
+}
+
+#[test]
+fn selecting_codex_in_card_form_shows_exact_efforts_and_approval_and_submits() {
+    // The live-catalog path: the client answers harness.capabilities for
+    // codex, and the guided selectors show the full effort ladder plus the
+    // three user-facing approval presets.
+    let client = CodexClient::new(demo_client().unwrap());
+    let created_cards = std::sync::Arc::clone(&client.created_cards);
+    let mut d = driver_of(client);
+    d.handle(key(KeyCode::Char('n')));
+    let form = d.app.form.as_mut().unwrap();
+    form.focus = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::Harness)
+        .unwrap();
+    d.handle(key(KeyCode::Right)); // pi -> claude
+    d.handle(key(KeyCode::Right)); // claude -> codex
+    let form = d.app.form.as_ref().unwrap();
+    assert_eq!(form.current_harness(), "codex");
+    assert_eq!(form.caps.as_ref().unwrap().harness, "codex");
+    assert_eq!(
+        opt_labels(form, FieldId::Effort),
+        vec![
+            "(default)",
+            "off",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ]
+    );
+    let permission_idx = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::Permission)
+        .unwrap();
+    assert!(form.field_visible(permission_idx));
+    assert_eq!(
+        opt_labels(form, FieldId::Permission),
+        vec![
+            "(default)",
+            "Ask for approval",
+            "Approve for me",
+            "Full access"
+        ]
+    );
+
+    // Submit: the exact codex overrides reach card.create.
+    let form = d.app.form.as_mut().unwrap();
+    form.fields[0].set_text("codex task");
+    set_choice(form, FieldId::Effort, "off");
+    set_choice(form, FieldId::Permission, "Full access");
+    d.handle(key(KeyCode::Enter));
+    let cards = created_cards.lock().unwrap();
+    assert_eq!(cards.len(), 1, "one card.create dispatched");
+    assert_eq!(cards[0]["harness"], "codex");
+    assert_eq!(cards[0]["effort"], "off");
+    assert_eq!(cards[0]["permission_mode"], "full-access");
+    assert_eq!(cards[0]["title"], "codex task");
+}
+
+#[test]
+fn selecting_codex_in_column_form_shows_exact_efforts_and_approval_and_submits() {
+    let client = CodexClient::new(demo_client().unwrap());
+    let created_columns = std::sync::Arc::clone(&client.created_columns);
+    let mut d = driver_of(client);
+    d.handle(key(KeyCode::Char('N')));
+    let form = d.app.form.as_mut().unwrap();
+    form.focus = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::HarnessOverride)
+        .unwrap();
+    d.handle(key(KeyCode::Right)); // (none) -> pi
+    d.handle(key(KeyCode::Right)); // pi -> claude
+    d.handle(key(KeyCode::Right)); // claude -> codex
+    let form = d.app.form.as_ref().unwrap();
+    assert_eq!(form.current_harness(), "codex");
+    assert_eq!(form.caps.as_ref().unwrap().harness, "codex");
+    assert_eq!(
+        opt_labels(form, FieldId::EffortOverride),
+        vec![
+            "(default)",
+            "off",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ]
+    );
+    let permission_idx = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::PermissionOverride)
+        .unwrap();
+    assert!(form.field_visible(permission_idx));
+    assert_eq!(
+        opt_labels(form, FieldId::PermissionOverride),
+        vec![
+            "(default)",
+            "Ask for approval",
+            "Approve for me",
+            "Full access"
+        ]
+    );
+
+    // Submit: the exact codex column overrides reach column.create.
+    let form = d.app.form.as_mut().unwrap();
+    form.fields[0].set_text("Codex stage");
+    set_choice(form, FieldId::EffortOverride, "minimal");
+    set_choice(form, FieldId::PermissionOverride, "Ask for approval");
+    d.handle(key(KeyCode::Enter));
+    let columns = created_columns.lock().unwrap();
+    assert_eq!(columns.len(), 1, "one column.create dispatched");
+    assert_eq!(columns[0]["harness_override"], "codex");
+    assert_eq!(columns[0]["effort_override"], "minimal");
+    assert_eq!(columns[0]["permission_override"], "ask-for-approval");
+    assert_eq!(columns[0]["name"], "Codex stage");
+}
+
+#[test]
+fn codex_selectors_survive_capabilities_fetch_failure() {
+    // The seeded demo client cannot answer harness.capabilities for codex, so
+    // the fetch fails and the form falls back to board-core's built-in
+    // snapshot — the effort ladder and approval enum still appear, from the
+    // catalog rather than a harness-name comparison.
+    let mut d = driver_of(demo_client().unwrap());
+    d.handle(key(KeyCode::Char('n')));
+    let form = d.app.form.as_mut().unwrap();
+    form.focus = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::Harness)
+        .unwrap();
+    d.handle(key(KeyCode::Right)); // pi -> claude
+    d.handle(key(KeyCode::Right)); // claude -> codex (caps fetch fails)
+    let form = d.app.form.as_ref().unwrap();
+    assert_eq!(form.current_harness(), "codex");
+    assert!(form.caps.is_none(), "the demo client has no codex catalog");
+    assert_eq!(
+        opt_labels(form, FieldId::Effort),
+        vec![
+            "(default)",
+            "off",
+            "minimal",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+        ]
+    );
+    let permission_idx = form
+        .fields
+        .iter()
+        .position(|field| field.id == FieldId::Permission)
+        .unwrap();
+    assert!(form.field_visible(permission_idx));
+    assert_eq!(
+        opt_labels(form, FieldId::Permission),
+        vec![
+            "(default)",
+            "Ask for approval",
+            "Approve for me",
+            "Full access"
+        ]
+    );
 }
 
 #[test]

--- a/crates/board-tui/tests/update/helpers.rs
+++ b/crates/board-tui/tests/update/helpers.rs
@@ -1,11 +1,12 @@
 //! Shared helpers for update integration tests.
 
-use board_core::capability::{HarnessCapabilities, ModelInfo};
+use board_core::capability::{codex_capabilities, HarnessCapabilities, ModelInfo};
 use board_core::client::BoardClient;
 use board_core::protocol::{CardStatus, Effort, Event};
 use board_tui::app::{App, Screen};
 pub use board_tui::testkit::{
     choice_labels as opt_labels, demo_client, is_choice, key, mouse, rendered_rows, set_choice,
+    DemoClient,
 };
 use board_tui::Driver;
 use serde_json::Value;
@@ -32,6 +33,47 @@ pub struct RecordingClient<C> {
 impl<C: BoardClient> BoardClient for RecordingClient<C> {
     fn call(&mut self, method: &str, params: Value) -> anyhow::Result<Value> {
         self.calls.lock().unwrap().push(method.to_string());
+        self.inner.call(method, params)
+    }
+
+    fn subscribe(&mut self) -> anyhow::Result<Box<dyn Iterator<Item = Event> + Send>> {
+        self.inner.subscribe()
+    }
+}
+
+/// A [`DemoClient`] wrapper that also answers `harness.capabilities` for the
+/// codex built-in (the seeded demo client knows pi and claude only) and
+/// records the `card.create` / `column.create` payloads, so driver tests can
+/// exercise the live-catalog path for codex and assert the exact overrides a
+/// codex form submits.
+pub struct CodexClient {
+    inner: DemoClient,
+    pub created_cards: Arc<Mutex<Vec<Value>>>,
+    pub created_columns: Arc<Mutex<Vec<Value>>>,
+}
+
+impl CodexClient {
+    pub fn new(inner: DemoClient) -> CodexClient {
+        CodexClient {
+            inner,
+            created_cards: Arc::new(Mutex::new(Vec::new())),
+            created_columns: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl BoardClient for CodexClient {
+    fn call(&mut self, method: &str, params: Value) -> anyhow::Result<Value> {
+        if method == "harness.capabilities"
+            && params.get("harness").and_then(Value::as_str) == Some("codex")
+        {
+            return Ok(serde_json::to_value(codex_capabilities()).unwrap());
+        }
+        match method {
+            "card.create" => self.created_cards.lock().unwrap().push(params.clone()),
+            "column.create" => self.created_columns.lock().unwrap().push(params.clone()),
+            _ => {}
+        }
         self.inner.call(method, params)
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ The reference detail behind the [root README](../README.md). Start here to find 
 | Herdr integrations | Pi v8; Claude v7 (installed and updated by the user) | [herdr.md](herdr.md), [install.md](install.md) |
 | Runtime launch | daemon-owned `Spawner`, placement, process/pane handles | [implementation.md](implementation.md) |
 | Config | typed `RootConfig`, one parse, environment overrides after parse | [configuration.md](configuration.md), [design.md](design.md) |
-| Live catalog | scenarios 01–30; provider-free fake/safe harness boundary | [e2e/README.md](../e2e/README.md) |
+| Live catalog | scenarios 01–31; provider-free fake/safe harness boundary | [e2e/README.md](../e2e/README.md) |
 | Branches | `dev` integration; `main` production (PR-only, merge-commit, signed); action-owned promotion; tags only from green `main` | [releasing.md](releasing.md) |
 
 Keep these links as navigation, not duplicate wire definitions: serde types and migrations are the
@@ -36,7 +36,7 @@ isolation is an agent prompt concern, not a board space primitive.
 The [`schema.sql`](../schema.sql) at the repo root is the fresh SQLite schema; migration behavior
 and upgrade tests live in `board-core::db`. Before handoff, check that docs still point to existing
 files, that the version matrix above says board protocol v1 / schema v13 / Herdr 0.8.0 / socket protocol 19, and that
-the scenario catalog lists every `e2e/NN-*.sh` from 01 through 30.
+the scenario catalog lists every `e2e/NN-*.sh` from 01 through 31.
 
 ## Test gates (single source)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,11 +32,41 @@ and `{permission_mode}` are available in `argv`. Optional keys `models`, `effort
 what lets `board card run focus` **reopen a run whose pane was closed** (see
 [`protocol.md`](protocol.md) → `run.focus`). It **defaults to `false`**: there is no
 universal CLI syntax for resuming, so herdr-board never guesses one — the built-ins `pi`
-(`--session-id <id>`) and `claude` (`--resume <id>`) declare it themselves. Setting `resume = true`
+(`--session-id <id>`), `claude` (`--resume <id>`), and `codex` (`resume <id>` subcommand) declare
+it themselves. Setting `resume = true`
 promises that your `argv` re-attaches to the conversation named by `$BOARD_RESUME_SESSION_ID`, which
 the daemon sets on the reopened pane along with `BOARD_RESCUE=1` (the run's argv is persisted fully
 materialized, so there is no placeholder left to substitute). Without it, focusing such a run is
 refused explicitly rather than starting a fresh conversation that would re-run the task.
+
+### The built-in `codex` vs. headless `codex exec`
+
+`codex` is a **built-in harness** dispatched as a Herdr-managed interactive agent (kind `"codex"`).
+The daemon reads the CLI's local `$CODEX_HOME/models_cache.json` (default
+`~/.codex/models_cache.json`) to offer its visible models and each model's supported reasoning
+levels. If the cache is missing or malformed, model entry remains free-form and the static effort
+ladder remains available. Cache-only levels the board protocol does not support, such as `ultra`,
+are omitted.
+
+The permission selector mirrors Codex's three presets and stores stable ids:
+
+- **Ask for approval** (`ask-for-approval`) — `--sandbox workspace-write --ask-for-approval on-request`.
+- **Approve for me** (`approve-for-me`) — `--approve-for-me`, which uses Codex's automatic reviewer
+  within its workspace-write sandbox and may consume additional model usage.
+- **Full access** (`full-access`) — `--dangerously-bypass-approvals-and-sandbox`; no sandbox or
+  approval prompts, so use only in an externally isolated environment.
+
+**Headless `codex exec`** remains separate: the one-shot non-interactive mode is deliberately not
+the built-in. If you want it, configure it as an ordinary unmanaged harness under a **different
+name**, e.g.:
+
+```toml
+[harness.codex-exec]
+argv = ["codex", "exec", "--sandbox", "workspace-write", "{model}", "{permission_mode}"]
+```
+
+It then behaves like every other config-defined harness: prompt via `$BOARD_PROMPT`, `resume` only
+if you declare it, and the configured runner bridge — never the managed `agent.start` path.
 
 The daemon parses the complete document once, including `[daemon]`, into typed settings. A missing
 file or omitted section uses the defaults shown above. An existing file with malformed TOML or an
@@ -56,5 +86,5 @@ override values also prevent daemon startup.
 | `BOARD_SPAWNER` | `herdr` or `local`; overrides `[daemon] spawner`. |
 | `BOARD_CARD_ID` / `BOARD_RUN_ID` | Injected into runs; `comment`/`done` use them by default. |
 | `BOARD_PROMPT` / `BOARD_SYSTEM_PROMPT` | Prompt delivery for custom harnesses. |
-| `BOARD_RESCUE` / `BOARD_RESUME_SESSION_ID` / `BOARD_RESCUED_RUN_ID` | Set on a *reopened* run pane only: marks it as an ephemeral rescue (not a tracked run), names the conversation to resume, and labels which run it continues. A reopened pane gets `BOARD_CARD_ID`/`BOARD_SOCKET`/`BOARD_BIN` but **never** `BOARD_RUN_ID` — that is the actor credential for `comment`/`done`, and a rescued pane must not be able to write to the finished run. |
+| `BOARD_RESCUE` / `BOARD_RESUME_SESSION_ID` / `BOARD_RESCUED_RUN_ID` | Set on a *reopened* run pane only: marks it as an ephemeral rescue (not a tracked run), names the conversation to resume, and labels which run it continues. A reopened pane gets `BOARD_CARD_ID`/`BOARD_SOCKET`/`BOARD_BIN` but explicitly clears `BOARD_RUN_ID` to empty (treated as unset) — that is the actor credential for `comment`/`done`, and a rescued pane must not be able to write to the finished run. |
 | `BOARD_TIMEOUT_UNIT_SECS` / `BOARD_LOCAL_POLL_MS` / `BOARD_TICK_MS` | Test-tuning knobs. |

--- a/docs/design.md
+++ b/docs/design.md
@@ -135,7 +135,7 @@ narrow terminals so the anchor remains reusable) and uses live geometry thereaft
 closed below the minimum of 24x6 for the shell and 12x8 for the agent; it never launches an agent
 on an undersized root or child.
 
-**Managed tabs are deliberately anchorless.** After a *successful* managed (Pi/Claude) launch —
+**Managed tabs are deliberately anchorless.** After a *successful* managed (Pi/Claude/Codex) launch —
 fresh, same-conversation reuse, or a `run.focus` rescue — the daemon closes the anchor pane, which
 is live-verified safe
 for its split child, so the tab holds exactly the one harness pane. The promoted run then persists
@@ -355,7 +355,7 @@ trigger = "manual"
 ```
 
 Notes:
-- Column `system_prompt` is combined with the mandatory board-protocol trailer and snapshotted at enqueue. For managed Pi it is delivered through a temporary file passed to `--append-system-prompt`; for managed Claude the file flag is `--append-system-prompt-file`. Neither replaces harness defaults/context files, and neither puts the system text directly in startup argv. It can invoke skills (`/quick-planner`, `/code-review`) — that's how "column triggers a skill" works, no special mechanism needed.
+- Column `system_prompt` is combined with the mandatory board-protocol trailer and snapshotted at enqueue. For managed Pi it is delivered through a temporary file passed to `--append-system-prompt`; for managed Claude the file flag is `--append-system-prompt-file`; codex has **no system-prompt file equivalent**, so its system instructions are delivered inside the single Mint `agent.prompt` block (see [Prompt assembly](#5-prompt-assembly)). Neither replaces harness defaults/context files, and neither puts the system text directly in startup argv. It can invoke skills (`/quick-planner`, `/code-review`) — that's how "column triggers a skill" works, no special mechanism needed.
 - `on_fail = "Execute"` from Review + comments-as-context gives the fix loop for free: the re-entered Execute run sees the reviewer's findings in its prompt.
 
 ### Cross-board card move (prototype)
@@ -448,7 +448,7 @@ that never recorded a pane at all. End to end:
 **Credentials: a rescued pane is not the run.** Pane-first placement means the pane's
 environment comes from the `pane.split` that creates it; the daemon installs the persisted run env
 plus `BOARD_CARD_ID`, `BOARD_SOCKET`, `BOARD_BIN`, `BOARD_RESCUE=1`, `BOARD_RESUME_SESSION_ID` and
-`BOARD_RESCUED_RUN_ID`. `BOARD_RUN_ID` is **withheld on purpose**. It is not documentation but the
+`BOARD_RESCUED_RUN_ID`. `BOARD_RUN_ID` is **cleared to empty on purpose** (empty is treated as unset). It is not documentation but the
 actor credential: `board comment` authenticates as `agent:$BOARD_RUN_ID`, `board done` forwards it as
 the run to finalize, and the configured-harness wrapper passes it to `run.pane_exited`. Since the
 rescued pane belongs to no run and the historical row must stay immutable, granting it that id would
@@ -547,7 +547,7 @@ execution, not to resurrect it as a run. Two consequences follow and are not wor
   title (`Board [<scope> · ACTIVE|ALL|ARCHIVED]`); the board has no persistent footer hint row, and transient toasts remain available above the action rail. Archived cards are
   inert until restored and render dimmed with `▣ ARCHIVED` when visible.
 - **Content-sized overlays (Regular/Wide):** within the `sheet_area` centered popup, card/column forms, move pickers, and help panels shrink to their content on large terminals and clamp to the available viewport on small terminals; Compact always gets the fullscreen sheet described above instead.
-- **Guided card & column forms** share one metadata source: both fetch `harness.capabilities` (models/efforts/permissions via the daemon-side `HarnessMeta` adapter trait) and `harness.list` (built-ins + config-defined harnesses). For cards: Pi is selected for new cards; Claude remains selectable. On open/harness change the form also fetches `space.list`. Model starts at `(default)` (unset), then catalog aliases and `(custom)` when free-form is supported. Effort follows the selected model's declared set, or the catalog default for omitted/free-form models. For Pi, that declared set comes from its documented `thinkingLevelMap` tri-state contract: omitted standard levels (`off`–`high`) remain supported, omitted extended levels (`xhigh`/`max`) do not, strings opt levels in, and `null` opts them out. Permission is hidden and submits `None` for Pi; Claude shows its modes. The rule is one predicate — `!permission_modes.is_empty()` against the effective capabilities — never a harness-name comparison, so it holds in the *not-yet-fetched* case too: a harness board-core does not know answers with an empty permission vocabulary, and the selector stays hidden until `harness.capabilities` returns. Inventing another CLI's enum is never safe; the old fallback guessed a six-item list that included a value the daemon rejects. Switching harness resets only incompatible values. Workspace labels are shown but ids are persisted. Fetch failures degrade to free text with a warning. For column config the same source drives the override fields: `harness_override` is a **select** over the available harnesses (`(none)` = no override), `effort_override` follows the override harness's catalog, and `permission_override` is **hidden** when the driving harness has no permission modes (e.g. Pi); changing the override harness refetches capabilities and resets only overrides that became invalid. The column `system_prompt` field is **hidden when the trigger is `manual`** (a manual column never launches a run, so the prompt is unused) and reappears when the trigger is switched to `auto`; it is hidden from the UI, not omitted, so submit still sends a `system_prompt` Patch that preserves whatever the column already stores.
+- **Guided card & column forms** share one metadata source: both fetch `harness.capabilities` (models/efforts/permissions via the daemon-side `HarnessMeta` adapter trait) and `harness.list` (built-ins + config-defined harnesses). For cards: Pi is selected for new cards; Claude remains selectable. On open/harness change the form also fetches `space.list`. Model starts at `(default)` (unset), then catalog aliases and `(custom)` when free-form is supported. Effort follows the selected model's declared set, or the catalog default for omitted/free-form models. For Pi, that declared set comes from its documented `thinkingLevelMap` tri-state contract: omitted standard levels (`off`–`high`) remain supported, omitted extended levels (`xhigh`/`max`) do not, strings opt levels in, and `null` opts them out. Codex models and per-model efforts come from `$CODEX_HOME/models_cache.json`, with free-form fallback; its permission selector labels the three stable wire presets as `Ask for approval`, `Approve for me`, and `Full access`. Permission is hidden and submits `None` for Pi; Claude shows its modes. The rule is one predicate — `!permission_modes.is_empty()` against the effective capabilities — never a harness-name comparison, so it holds in the *not-yet-fetched* case too: a harness board-core does not know answers with an empty permission vocabulary, and the selector stays hidden until `harness.capabilities` returns. Inventing another CLI's enum is never safe; the old fallback guessed a six-item list that included a value the daemon rejects. Switching harness resets only incompatible values. Workspace labels are shown but ids are persisted. Fetch failures degrade to free text with a warning. For column config the same source drives the override fields: `harness_override` is a **select** over the available harnesses (`(none)` = no override), `effort_override` follows the override harness's catalog, and `permission_override` is **hidden** when the driving harness has no permission modes (e.g. Pi); changing the override harness refetches capabilities and resets only overrides that became invalid. The column `system_prompt` field is **hidden when the trigger is `manual`** (a manual column never launches a run, so the prompt is unused) and reappears when the trigger is switched to `auto`; it is hidden from the UI, not omitted, so submit still sends a `system_prompt` Patch that preserves whatever the column already stores.
 - Long text (card description, column system prompt): modal textarea, `Ctrl+E` suspends the TUI into `$EDITOR`. The form's multiline field value now renders as a real wrapped paragraph (`Wrap { trim: false }`) with the same strong focused reverse treatment and white unfocused readability as title/name values; windowed field scrolling keeps the focused field wholly visible, and `Ctrl+J`/`Shift+Enter` remain newline paths; it previously joined the textarea's lines with a literal `"  ⏎  "` separator and hard-truncated the result to one line with `…` at every width, so most multiline content was unreadable. Returning from `$EDITOR` now forces a full terminal repaint (`terminal.clear()`) before the next draw, and so does a terminal resize; `RealEditor` re-entering the alternate screen behind `ratatui::Terminal`'s back previously left the next frame diffing against a stale cached buffer, so the screen stayed blank until some other full redraw happened to occur.
 - **Every destructive action confirms, and the confirmation is gated on the action being possible.** `x` (cancel a run) only opens the confirm sheet when the card actually has an open run, and otherwise toasts — `run.cancel` on a finished card is refused by the daemon, so "cancel the running run?" was a question with no true answer. `r` (retry) now confirms too: it relaunches a real agent, which is strictly more consequential than the cancel that already confirmed. Deleting a column with cards asks where to move them **and then confirms** — picking a destination is not consent to the delete, and that riskier path was the one left unguarded while the empty-column path had always confirmed. A running card's column can't be deleted at all. Both answers land on `Confirm::return_to`, the screen recorded on the way in.
 - Optional: apply a board template (e.g. the example pipeline above) onto an empty board — `T` on the
@@ -576,17 +576,27 @@ Pi:     pi [--model M] [--thinking E]
 Claude: claude [--model M] [--effort E] [--permission-mode P]
                --allowedTools "Bash(board:*)"
                (--session-id ID | --resume ID [--fork-session])
+Codex:  codex [--model M] [-c model_reasoning_effort=E]
+               [permission preset flags]
+               (resume <id> | fork <id>)        # Mint: no session tokens at all
 ```
+
+Codex notes: board effort `off` maps to `model_reasoning_effort=none` while building argv (every
+other protocol level keeps its spelling; cache-only `ultra` is filtered). `ask-for-approval` maps to
+`--sandbox workspace-write --ask-for-approval on-request`, `approve-for-me` to `--approve-for-me`,
+and `full-access` to `--dangerously-bypass-approvals-and-sandbox`. A codex Mint
+persists `session_id = NULL` (the board never invents a uuid for a harness that mints its own); the
+integration-reported thread id is captured after launch and promoted atomically onto run+card.
 
 After pane-first placement, boardd writes `system_prompt` to a temporary mode-`0600` file and calls
 the supported managed-agent interface as follows:
 
 ```
 agent.start {
-  name, kind:"pi"|"claude", pane_id,
-  args:<startup argv without executable> +
-       ["--append-system-prompt", FILE]          # Pi
-       ["--append-system-prompt-file", FILE],    # Claude
+  name, kind:"pi"|"claude"|"codex", pane_id,
+  args:<startup argv without executable> +       # codex: exactly the startup tail,
+       ["--append-system-prompt", FILE]          #   no prompt file, no `--`, no task
+       ["--append-system-prompt-file", FILE],    # Pi / Claude
   timeout_ms:30000
 }
 agent.get {target:pane_id}       # bounded polling until interactive_ready && !launch_pending
@@ -603,6 +613,14 @@ placement once. The temporary file is removed before spawn returns, on success o
 prompt is never part of `agent.start`; it is submitted only after readiness. An `agent_name_taken`
 response retries once on the same owned pane with `card-<id>-<column-slug>-r<run>`.
 
+**Codex prompt transport** (no system-prompt file exists): after readiness the daemon first runs the
+bounded `agent.get.agent_session` capture (at most 5 probes, 10s cap; accepts `agent:"codex"` +
+`kind:"id"` + non-empty `value`; anything else degrades to `None` with a warning and the launch
+continues), then submits via `agent.prompt`: a Mint receives one delimited block —
+`## herdr-board system instructions` then `## herdr-board card task` — while a resume/fork fresh
+pane receives the task alone (the conversation already carries the system instructions), same-pane
+reuse the task alone, and a rescue sends nothing.
+
 Configured harnesses use the same pane-first cwd/env placement, then `pane.rename`. Because direct
 `herdr pane run` does not preserve complex argv boundaries, boardd writes one mode-`0700`,
 self-removing script with every configured argv element POSIX-quoted and invokes exactly
@@ -612,7 +630,7 @@ the hidden `board __pane-exited --run-id "$BOARD_RUN_ID"` guard. That guard send
 `run.pane_exited {card_id,run_id}`; only the exact matching open queued or started configured run is failed, with no `on_fail`
 transition. A callback before registration is accepted. The same narrow race rule applies to an
 immediate configured-harness `board done`: the CLI forwards `BOARD_RUN_ID`, and only that exact
-queued run may finalize before runner registration; a queued built-in Pi/Claude completion is
+queued run may finalize before runner registration; a queued built-in (pi/claude/codex) completion is
 rejected because no managed pane exists yet. For an already-started run, `run_id` remains optional
 so manual/TUI callers remain compatible, but a supplied mismatched id is rejected. Stale,
 replaced, completed, and built-in callbacks are rejected, so a stale child cannot complete a
@@ -621,7 +639,7 @@ error. The script deletes itself when it starts; if the pane runner fails synchr
 removes it and closes only the pane boardd allocated. If scheduling succeeds but the pane never
 opens the script, the residual configured-script orphan is an accepted asynchronous limitation.
 
-- **Session strategy**: Pi's first auto column mints an exact `--session-id`; later stages reuse it; retry uses `--fork <old> --session-id <new>` and persists the new target. Claude keeps exact mint, `--resume`, and `--fork-session`. Column config can force `fresh_session = true`.
+- **Session strategy**: Pi's first auto column mints an exact `--session-id`; later stages reuse it; retry uses `--fork <old> --session-id <new>` and persists the new target. Claude keeps exact mint, `--resume`, and `--fork-session`. Codex mints its own thread id (no session flag, `NULL` persisted), captures the reported id after launch, and re-attaches with the `resume <id>` / `fork <id>` subcommands; a fork's newly captured id supersedes the recorded source id atomically, and a fork whose new id was never captured keeps the source id instead of wiping it. Column config can force `fresh_session = true` (for codex that means a fresh Mint rather than a resume).
 - **Configured harnesses** remain unmanaged. Their exact configured argv is not inferred to be Pi or Claude; prompt channels arrive as `BOARD_PROMPT` / `BOARD_SYSTEM_PROMPT`. The configured runner resolves a nonempty `HERDR_BIN_PATH`, otherwise `herdr`.
 
 ## 6. Data flow — the canonical walkthrough
@@ -632,7 +650,7 @@ opens the script, the residual configured-script orphan is an accepted asynchron
 4. Dispatcher (respecting per-space serial queue + global cap):
    a. Resolve the card's session socket and `ping` it. Anything except exact Herdr 0.8.0 / protocol 19 fails before workspace discovery/creation. Then reuse workspace `w4`, or create/reuse the card's labeled `new_workspace`; repository worktree isolation remains an agent prompt responsibility.
    b. Preflight the selected socket again at the spawner boundary. For a new durable run, the card's **`card-<id>` tab** is resolved by exact owned id (reconstructed from the newest matching durable pane in the same session/workspace when boardd restarts), or `tab.create {workspace_id,cwd,env,…}` supplies a new shell anchor — unless the dispatch just created the workspace, in which case the workspace's own initial tab is adopted (verified, then renamed) instead of leaving an unused tab. The anchor is labeled `card-<id>-anchor`, its exact id is persisted on the promoted run (NULL for managed runs, whose anchor is closed after a successful launch), and the run child is always created by `pane.split` from that anchor; `agent.start`/`pane run` never target the root. A renamed anchor is still selected only by exact identity; a closed anchor is recreated only from a durable board-run child in the exact proven tab, and missing proof creates a fresh tab without selecting a duplicate-label user tab. Exact ended children may be reclaimed before a later split so the anchor keeps usable geometry. The child receives the run env; the anchor receives only stable card identity. If multiple historical panes are live, newest run id wins; legacy rows retain their old lookup. Placement, cwd, and environment are not `agent.start` fields; the call receives neither the workspace placement nor the anchor pane id.
-   c. For Pi/Claude, write the snapshotted system prompt to a mode-`0600` temporary file; issue `agent.start {name,kind,pane_id,args}` on the split child with prompt-free startup args; a typed `agent_pane_busy` retries the exact request on that same child with bounded 100ms/200ms backoff (never another split); poll `agent.get` for readiness; then send only the task snapshot through `agent.prompt`. Remove the file. Card status → `running`; record the exact child pane/workspace ids. The pane is **visible** — you can watch or type into it anytime.
+   c. For Pi/Claude, write the snapshotted system prompt to a mode-`0600` temporary file; issue `agent.start {name,kind,pane_id,args}` on the split child with prompt-free startup args; a typed `agent_pane_busy` retries the exact request on that same child with bounded 100ms/200ms backoff (never another split); poll `agent.get` for readiness; then send only the task snapshot through `agent.prompt`. Remove the file. For codex, no prompt file exists: after the same readiness poll the daemon bounded-polls `agent.get.agent_session` (at most 5 probes / 10s) for the integration-reported thread id (`agent:"codex"`, `kind:"id"`, non-empty `value`), persists it atomically with the promotion, and then delivers the prompt — a Mint gets the delimited `system + task` block, a resume/fork fresh pane the task alone. Card status → `running`; record the exact child pane/workspace ids. The pane is **visible** — you can watch or type into it anytime.
 
    **Pane naming and ownership**: the managed agent name is `card-<id>-<column-slug>` (e.g. `card-42-plan`, `card-42-execute`). Herdr names are exclusive while a pane is open, so `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`. A persistent `agent_pane_busy` closes only the board-owned child and leaves the pre-existing anchor. If a placement target disappears, boardd closes only the pane it created (a missing pane is already clean), restarts discovery from `tab.list`, and retries the complete placement once. A terminal launch error also closes only that board-owned pane; pre-existing user panes are never cleanup targets.
 5. Agent plans, writes `docs/plans/meli-retry.md`, then calls `board comment 42 "Plan ready at docs/plans/meli-retry.md …"` and `board done 42 --outcome ok`. From a run, the CLI forwards `BOARD_RUN_ID`; manual/TUI completion omits it and remains compatible.
@@ -655,7 +673,7 @@ opens the script, the residual configured-script orphan is an accepted asynchron
 
 **Golden rule:** herdr status is a HINT; `board done` is the only terminal success truth. For a
 configured harness, that completion may arrive in the narrow queued-before-registration window;
-queued built-in Pi/Claude runs are deliberately not eligible. Pane-idle scraping alone is the
+queued built-in (pi/claude/codex) runs are deliberately not eligible. Pane-idle scraping alone is the
 documented weak point of every tmux-style orchestrator (claude-squad); the explicit `board done`
 channel is what makes auto-transition trustworthy, and silent finishes park
 the card in `awaiting` for review instead of guessing an outcome. Without the optional Pi
@@ -728,7 +746,7 @@ executes the returned plan; it performs no Herdr or SQLite I/O in the pure decis
 - `--max-budget-usd` per run (Claude supports it in print mode; interactive panes rely on timeout + human visibility).
 - Pi has no board tool-permission mode; no permission/approval flag is added and explicit Pi permission is rejected. Claude `bypassPermissions` requires explicit per-card opt-in, never a column default.
 - Cards never auto-move into *Done*; last auto hop is always a human-gated column.
-- Retry = a new run; Pi uses `--fork <old> --session-id <new>`, Claude uses `--resume <old> --fork-session`; history is preserved.
+- Retry = a new run; Pi uses `--fork <old> --session-id <new>`, Claude uses `--resume <old> --fork-session`, codex uses the `fork <id>` subcommand (the new thread id is captured after launch and supersedes the source id atomically); history is preserved.
 
 ### Diagnostic security boundary
 
@@ -784,6 +802,6 @@ herdr panes are fully drivable from the CLI (`pane send-keys` with named keys, `
 | 1. Unit | column engine, prompt assembly, queue, transitions | plain Rust tests, in-memory SQLite; no herdr |
 | 2. TUI snapshot | every view/modal/keybind incl. `?` help | ratatui `TestBackend` + fed `KeyEvent`s + `insta` snapshots; no herdr, no terminal |
 | 3. Daemon integration | dispatch → run → done → auto-move, without tokens | config fake harness plus built-in Pi adapter tests; real boardd paths, no provider call |
-| 4. Full E2E | real Herdr wiring | collision-resistant ephemeral named Herdr session plus disposable workspace; the standard suite uses checked-in fake Pi/Claude/configured harnesses and asserts pane-first placement/prompt/argv contracts against the current Herdr 0.8.0 / protocol 19 gate with zero provider cost. A separate opt-in real-Claude Haiku/low smoke is never in `run-all.sh`; its intended contract is one authorized attempt with no retry or fallback. |
+| 4. Full E2E | real Herdr wiring | collision-resistant ephemeral named Herdr session plus disposable workspace; the standard suite uses checked-in fake Pi/Claude/Codex/configured harnesses and asserts pane-first placement/prompt/argv contracts against the current Herdr 0.8.0 / protocol 19 gate with zero provider cost. A separate opt-in real-Claude Haiku/low smoke is never in `run-all.sh`; its intended contract is one authorized attempt with no retry or fallback. |
 
 Isolation rules for level 3–4: `BOARD_DB=/tmp/…` + dedicated daemon socket per test run so tests never touch the real board; every interactive/live test must create and use a collision-resistant ephemeral named Herdr session plus a disposable workspace, never a user's session, workspace, or tab. The session may run headlessly in CI, but it must retain the same named-session and workspace requirements.

--- a/docs/herdr.md
+++ b/docs/herdr.md
@@ -74,7 +74,10 @@ Installing one **writes into that harness's own config** (`pi` installs
 updates integrations** — running `herdr integration install <harness>` is a **user
 prerequisite** for live lifecycle signals. Check the reported version with
 `herdr integration status`; the board's current support matrix expects Pi v8 and
-Claude v7 when those harnesses are dispatched.
+Claude v7 when those harnesses are dispatched. For codex, the integration is what
+reports `AgentInfo.agent_session` (the thread id the board captures so a minted
+conversation can later be resumed/forked); without it a codex run still executes
+and completes, but its conversation cannot be reopened by id.
 
 ### 0.8.0 lifecycle implications
 
@@ -126,6 +129,16 @@ The delta is additive and outside the board client surface:
 - `antigravity_cli` (CLI spelling `antigravity-cli`) and `grok` are new
   integration targets with session reporting/native restore. They do not add
   board built-in harnesses.
+- `AgentInfo.agent_session` carries an `AgentSessionInfo | null` reference —
+  `{agent, kind, source, value}` with `kind` ∈ {`id`, `path`} — for panes whose
+  integration reported a session. It is absent on panes without one. `board-herdr`
+  decodes it (`AgentInfo.agent_session`) because the codex built-in harness needs
+  the reported thread id: a codex Mint persists `session_id = NULL` at enqueue,
+  and the daemon's bounded post-launch `agent.get` capture accepts only an
+  `id`-kind reference owned by the codex agent with a non-empty value, promoting
+  it atomically onto the run and card. A wrong-agent, `path`-kind, blank, or
+  never-reported session degrades the capture to `None` (run still executes);
+  the pane then keeps no recorded conversation id, so reuse/rescue fail closed.
 
 The client does not call the new workspace method. It preserves unknown additive
 events rather than treating them as a change to the used transport. The current
@@ -180,6 +193,19 @@ both tab and anchor are selected only from scoped durable pane identities.
 Labels are display metadata and never authorize a tab or pane.
 `agent.read` remains a terminal screen/scrollback read, not a semantic result
 channel.
+
+**Codex is a managed kind with no prompt file.** `kind:"codex"` starts the
+interactive Codex CLI with the same pane-first readiness contract, but there is
+no system-prompt-file equivalent: startup argv carries neither system nor task
+text (no `--append-system-prompt*`, no `--` delimiter), and the prompt travels
+exclusively through `agent.prompt` after readiness — a Mint receives one
+delimited block (`## herdr-board system instructions` then
+`## herdr-board card task`), a resume/fork fresh pane the task alone, same-pane
+reuse the task alone, a rescue nothing. Between readiness and the prompt, the
+daemon bounded-polls `agent.get.agent_session` (5 probes / 10s) for the
+integration-reported thread id and persists it atomically with the run
+promotion; a missing or unusable report degrades to `None` (see the protocol-19
+delta above).
 
 The rescue depends on two runtime facts that are not guaranteed by the request
 shapes: a pane label set with `pane.rename` must survive a subsequent

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -29,7 +29,7 @@ board wire DTOs; `board-herdr` owns only the verified Herdr socket surface; and 
 and `docs/protocol.md` explain behavior rather than defining duplicate serde shapes. Schema v13 adds
 soft-deleted comments and immutable comment-history snapshots; the CLI exposes their nested CRUD
 and history commands while boardd remains the sole SQLite writer. The complete live use-case catalog
-is [`../e2e/README.md`](../e2e/README.md), scenarios **01–30**; the safe
+is [`../e2e/README.md`](../e2e/README.md), scenarios **01–31**; the safe
 static harness is `e2e/test-harness.sh`, while `e2e/run-all.sh` is the opt-in live gate.
 
 The current Herdr boundary is deliberately narrower than the upstream schema. The 0.8.0/protocol-19
@@ -176,7 +176,7 @@ A (core+scaffold) → B (herdr client) ∥ C (TUI) → D (daemon+CLI+integration
 - C: insta snapshots via `ratatui::backend::TestBackend` + synthetic key events + FakeBoardClient: empty board (Todo only + hints), board with example pipeline & cards (status glyphs), new-card modal, column form, card detail w/ comments+runs, `?` help, delete-column prompt, move flow.
 - Restart recovery (`board-daemon::supervisor`) is a conservative one-pass classifier. Session resolution and snapshot I/O are injectable and happen before mutation. `Alive` adopts scheduler/watch intent and replays terminal status, `Gone` uses the existing pane-exit finalizer, and `Unknown` does nothing. The apply phase re-reads the open run/card, making duplicate passes idempotent and rejecting stale observations. Startup constructs/runs this pass for the Herdr spawner regardless of whether its initial best-effort client connected. The always-on supervisor then maintains independent per-socket streams and backoff, subscribes before taking a fresh bounded snapshot, and periodically reconciles missed events without resetting healthy sockets.
 - D: integration test (no herdr): start daemon on temp socket + temp DB with LocalSpawner + fake harness script → create card → move to auto column → fake agent comments + done → assert auto-transition, comments, run rows, statuses; timeout path; cancel path; queue serialization (two cards same space key run serially). The daemon comment suite also checks actor ownership, system-comment immutability, soft deletion, audit history, and event routing.
-- E: scenarios `e2e/01-core.sh` through `e2e/30-pane-reuse.sh` (real Herdr 0.8.0 / socket
+- E: scenarios `e2e/01-core.sh` through `e2e/31-managed-codex.sh` (real Herdr 0.8.0 / socket
   protocol 19, fake harnesses): disposable workspaces, pane-first placement, typed prompt delivery,
   bounded same-pane `agent_pane_busy` retry, supervisor recovery, timer refresh, and
   identity-gated cleanup. The managed fixtures use Pi integration v8 and Claude integration v7

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -250,12 +250,15 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   `fail`→on_fail; no target → card stays, status `done`/`failed`). It is also the confirm channel for
   an `awaiting` card (TUI `Enter` and `card run confirm` send the same request). The only queued
   exception is a configured harness: its `board done` must provide the exact queued run id and may
-  arrive before runner registration. A queued built-in Pi/Claude run is rejected because managed
-  completion requires a registered pane. A mismatched id/pane, missing id for the queued exception,
-  or otherwise ineligible run returns an error.
+  arrive before runner registration. A queued built-in (pi/claude/codex) run is rejected because
+  managed completion requires a registered pane. A mismatched id/pane, missing id for the queued
+  exception, or otherwise ineligible run returns an error.
 - `run.cancel {card_id}` → `{run, card}` — kills the pane (herdr `pane.close`), outcome `cancelled`, card status `failed`, no transition.
 - `run.retry {card_id}` → `{run, card}` — re-enqueue in the current column as a fresh run. Claude
-  resumes with `--fork-session`; Pi uses `--fork <old-id> --session-id <new-id>` and persists it.
+  resumes with `--fork-session`; Pi uses `--fork <old-id> --session-id <new-id>` and persists it;
+  codex retries with the `fork <id>` subcommand and persists the new thread id the integration
+  reports (the captured id supersedes the recorded source id atomically; a fork whose new id was
+  never captured keeps the source id instead of wiping it).
 - `run.focus {card_id, run_id, origin_socket}` →
   `{action, recorded_pane_id?, run_id, card_id, column_id, harness, session, session_id, pane_id}`
   — focuses **one exact run's** pane, reopening it if necessary. `run_id` is required: the daemon
@@ -295,7 +298,7 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   `pane.split` that creates the pane. A rescued pane receives the persisted run
   environment plus `BOARD_CARD_ID`, `BOARD_SOCKET`, `BOARD_BIN`, `BOARD_RESCUE=1`,
   `BOARD_RESUME_SESSION_ID=<conversation id>`, and `BOARD_RESCUED_RUN_ID=<run id>`.
-  **`BOARD_RUN_ID` is deliberately withheld.** It is not a label but the *actor credential*:
+  **`BOARD_RUN_ID` is deliberately cleared to empty** (the CLI treats empty as unset). It is not a label but the *actor credential*:
   `board comment` authenticates as `agent:$BOARD_RUN_ID`, `board done` forwards it as the run to
   finalize, and the configured-harness wrapper hands it to `run.pane_exited`. A rescued pane belongs
   to no run and the historical row is immutable, so granting it the closed run's id would either be
@@ -307,11 +310,15 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   and is consumed by no board command.
 
   Resume support is an **explicit per-harness capability** (`harness.capabilities.resume`:
-  `by_conversation_id` | `unsupported`), never an assumption about flag syntax. `pi` and `claude`
-  declare it; a `[harness.NAME]` harness declares it with `resume = true` and otherwise fails
+  `by_conversation_id` | `unsupported`), never an assumption about flag syntax. `pi`, `claude`, and
+  `codex` declare it; a `[harness.NAME]` harness declares it with `resume = true` and otherwise fails
   closed. Note that a recorded `session_id` is **not** evidence that a harness can resume it:
   enqueue mints a uuid and persists it even for a configured harness that never receives one, so the
-  capability gate is the only sound signal (verified live in `e2e/27-rescue-dead-pane.sh`).
+  capability gate is the only sound signal (verified live in `e2e/27-rescue-dead-pane.sh`). Codex
+  adds one more fail-closed rule: a codex Mint persists `session_id = NULL` until the
+  integration-reported thread id is captured, so a minted codex run that never reported a session
+  cannot be rescued (`run.focus` refuses with error 2 — no recorded conversation id) and the next
+  stage mints fresh instead of re-attaching to a conversation the board cannot name.
 
   Rescue is **idempotent**: before creating anything the daemon scans the workspace for a pane left
   by an earlier rescue of this exact run, identified by its pane label / agent name
@@ -358,7 +365,7 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
 wrapper. It accepts the exact matching open queued or started **configured** run (including a callback
 that arrives before spawn registration), then records `fail` with summary "configured harness exited
 without calling board done", adds "pane exited without board done", leaves the card in its current
-column, and does **not** apply `on_fail`. Stale/replaced/already-completed and built-in Pi/Claude
+column, and does **not** apply `on_fail`. Stale/replaced/already-completed and built-in (pi/claude/codex)
 runs are rejected. This is protected by the local board Unix socket trust boundary, not an unforgeable
 token; the wrapper ignores an expected rejection when `run.done` won the race. The generated
 script removes itself when it starts; if `pane run` accepts scheduling but the pane never opens
@@ -368,9 +375,10 @@ it, a residual configured-script orphan is an explicitly documented limitation.
 - `harness.capabilities {harness}` → `{harness, models:[{id, efforts:[…]}], model_freeform: bool, default_efforts:[…], permission_modes:[…], resume}`. `default_efforts` is serde-defaulted for backward-compatible clients and applies when model is omitted/free-form; a known model's own efforts remain authoritative. `resume` is `"by_conversation_id"` or `"unsupported"` and answers "can this harness re-attach to a conversation it recorded?" — the question `run.focus` must ask before reopening a run whose pane is gone. It is serde-defaulted to `"unsupported"`, so an older payload fails closed, and there is deliberately no universal-syntax assumption: each adapter declares it.
   - Built-in `pi`: static `models:[]`, `model_freeform:true`, `default_efforts:["off","minimal","low","medium","high","xhigh","max"]`, `permission_modes:[]`. Pi's catalog is user/provider-specific, so the daemon overlays a **live** catalog when it can resolve the pi agent dir (`$PI_CODING_AGENT_DIR`, else `~/.pi/agent`): it reads `auth.json` for the authenticated providers, then `models-store.json` and keeps only those providers' models as `provider/model` ids with per-model efforts from each model's `thinkingLevelMap`. Pi's map is tri-state: for standard levels `off` through `high`, an omitted key uses Pi's provider-default mapping, a string is supported with that mapping, and `null` is unsupported; for extended `xhigh`/`max`, only an explicit string is supported (omitted or `null` is unsupported). Efforts remain in canonical ascending order. This reproduces `pi --list-models` (provider-auth scoped) with richer per-model effort data. If the files are missing/unreadable it falls back to shelling out to `pi --list-models`, and finally to the static free-form catalog. `model_freeform` stays `true`, so arbitrary model strings remain valid. Tests leave the agent dir unset, so the catalog stays the static `models:[]`.
   - Built-in `claude` (CLI 2.1.209): models `fable`/`opus`/`sonnet`/`haiku`, each with `low|medium|high|xhigh|max`; the same levels are `default_efforts`; `model_freeform:true`; permissions are `["acceptEdits","auto","bypassPermissions","manual","dontAsk","plan"]`. Both built-ins report `resume:"by_conversation_id"` (`claude --resume <id>`; Pi re-uses `--session-id <id>`).
+  - Built-in `codex`: static fallback `models:[]`, `model_freeform:true`, `default_efforts:["off","minimal","low","medium","high","xhigh","max"]`, `permission_modes:["ask-for-approval","approve-for-me","full-access"]`, `resume:"by_conversation_id"` (`codex resume <id>`). At daemon startup `$CODEX_HOME/models_cache.json` (default `~/.codex/models_cache.json`) overlays the fallback with visible model slugs and each model's `supported_reasoning_levels`; missing/malformed caches retain free-form entry, `none` maps to `off`, and unknown protocol levels such as `ultra` are filtered. Model strings remain free-form via `--model`. Board effort maps to `-c model_reasoning_effort=<value>`. Permission presets combine sandbox and approval controls: `ask-for-approval` emits `--sandbox workspace-write --ask-for-approval on-request`; `approve-for-me` emits `--approve-for-me`; `full-access` emits `--dangerously-bypass-approvals-and-sandbox`. Codex mints its own thread/session uuid — there is no `--session-id` for Mint — so the daemon persists `NULL` at enqueue and captures the integration-reported id after launch via `agent.get.agent_session` (`AgentSessionInfo`, `{agent,kind,source,value}` with `kind: "id"`), promoting it atomically onto run+card. See [Dispatch semantics](#dispatch-semantics-column-engine--lives-in-board-core-pure-daemon-executes-effects) for the capture contract and the fail-closed degraded mode.
   - config-defined harnesses report `model_freeform:true` and the declared `models`/`efforts`/`permission_modes`; declared efforts also populate `default_efforts`. `resume` is `"by_conversation_id"` only when `[harness.NAME] resume = true` is declared, otherwise `"unsupported"` — the fail-closed default. Declaring it promises that the harness re-attaches to `$BOARD_RESUME_SESSION_ID` (see `run.focus`). Known model aliases use their declared effort set; omitted or free-form models use `default_efforts` (with a model-union fallback for older payloads that omitted `default_efforts`).
   - error 2 (not found) for an unknown harness, listing the known harnesses.
-- `harness.list` (no params) → `{harnesses:[…]}` — every harness the daemon knows about: the built-ins `pi`/`claude` in their default order (pi first), then every config-defined `[harness.NAME]` sorted, de-duplicated. This is the single source for BOTH the card `harness` and column `harness_override` selects in the TUI, so every harness menu shares one list in one (default-first) order.
+- `harness.list` (no params) → `{harnesses:[…]}` — every harness the daemon knows about: the built-ins `pi`/`claude`/`codex` in their default order (pi first), then every config-defined `[harness.NAME]` sorted, de-duplicated. This is the single source for BOTH the card `harness` and column `harness_override` selects in the TUI, so every harness menu shares one list in one (default-first) order.
 - `space.list {session?}` → `{spaces:[{id, label}]}` — workspaces in the given session (`null` = default), filled from that session's herdr `workspace.list`. Unknown/not-running session → error 4 listing the known sessions.
 - `session.list` (no params) → `{sessions:[{name, default: bool, running: bool}]}` — the daemon shells out to `herdr session list --json` (session enumeration is not in the herdr socket API; a session only knows itself). Binary resolved via `$HERDR_BIN_PATH`, else `herdr` on `$PATH`. Error 4 if herdr is unavailable / the CLI fails. That shell-out has a **10-second wall-clock budget** and the child is killed when it expires (error 4, naming the timeout): the session registry sits on the path of every request that resolves a session, and every caller reaches it through the blocking pool, so a hung `herdr` must not pin one of those threads forever. A normal `session list` is sub-100ms; the result is cached for the registry TTL.
 
@@ -397,7 +405,7 @@ it, a residual configured-script orphan is an explicitly documented limitation.
 | Status | Meaning |
 |---|---|
 | `idle` | At rest in a column; no active run. |
-| `queued` | Enqueued for dispatch into an auto column. A configured harness may complete this exact run immediately before runner registration; queued built-in Pi/Claude runs cannot be completed until their managed pane is registered. |
+| `queued` | Enqueued for dispatch into an auto column. A configured harness may complete this exact run immediately before runner registration; queued built-in (pi/claude/codex) runs cannot be completed until their managed pane is registered. |
 | `running` | A run is active and the agent is working. |
 | `blocked` | The agent/integration reported blocked; the run stays active. |
 | `awaiting` | The agent appears finished (or went idle) **without** `board done`. The run stays OPEN, the column timeout is paused, and the card never fails on its own — it waits for human review. |
@@ -459,11 +467,12 @@ Coarse by design — the TUI refetches only its selected `board.get {board_id}` 
 2. Queue key = `(session, space_kind, space_ref)`; one running card per key (FIFO); global semaphore default 3 (config `max_concurrent`). Session is part of the key so the same label/ref in two herdr sessions are distinct spaces.
 3. Spawn (daemon, via `Spawner` trait):
    - resolve session: card `session` (null = default) → Herdr socket via the session registry; an unknown/not-running session fails the run with a clear error listing known sessions. The per-session client is used for workspace resolve/create, spawn, kill, and liveness.
-   - harness session: resume `card.session_id` unless `column.fresh_session` or none. Pi mint/resume use exact `--session-id`; Pi retry forks old → a newly minted target id. Claude retains mint/`--resume`/`--fork-session`. Existing cards keep their stored harness/session.
+   - harness session: resume `card.session_id` unless `column.fresh_session` or none. Pi mint/resume use exact `--session-id`; Pi retry forks old → a newly minted target id. Claude retains mint/`--resume`/`--fork-session`. Codex Mint takes **no session flag** (it mints its own thread id and the enqueued run persists `session_id=NULL` — the board never invents a uuid); codex resume/fork are `resume <id>` / `fork <id>` subcommands appended last to the startup argv. Existing cards keep their stored harness/session.
    - **preflight before workspace mutation:** `ping` the selected socket and require exact Herdr 0.8.0 / protocol 19. Only then resolve `workspace` by id/case-insensitive label, or resolve `new_workspace` by label and, if absent, call `workspace.create {label,cwd,focus:false}`. Read the workspace cwd from its pane snapshot; snapshot failure or missing live cwd fails dispatch, never falling back to process cwd or a stale snapshot. When this dispatch itself created the workspace, its exact initial tab/root pane ids travel as a one-shot bootstrap hint: the first card-tab allocation verifies them (tab exists in that workspace, root is the tab's sole pane, root carries no agent), renames the tab to `card-<id>` and the root to `card-<id>-anchor`, and splits the run child from that root — so a daemon-created workspace has no unused initial tab. Any verification mismatch falls back to a fresh `tab.create` and never touches that root; reused/existing/user workspaces never carry a hint.
    - **preflight again at the spawner boundary:** this is the spawner's first protocol call, before placement, managed launch, or the configured runner.
    - build the run-child env `{BOARD_CARD_ID,BOARD_RUN_ID,BOARD_SOCKET,BOARD_BIN}` plus configured-harness prompt env. Current schema v13 runs place each card in a stable short `card-<id>` tab whose root is a shell anchor labeled `card-<id>-anchor`. The anchor receives only stable card identity; every run child is created by `pane.split` from it with the complete run cwd/env. Promotion persists the exact anchor id with the run **except** for managed launches, whose anchor is closed after a successful launch (see below), leaving the tab with exactly the harness pane and a NULL persisted anchor. The daemon reuses only exact tab/anchor identities reconstructed from the newest matching durable panes in the same session/workspace; labels are display metadata, never ownership. A renamed anchor remains selected by identity; a closed anchor is recreated only by splitting a currently live durable board child, otherwise a fresh tab is created. Same-conversation reuse eligibility is checked **before** anchor selection, so an anchorless managed tab still reuses its exact prior harness pane on the next hop. The initial split targets ratio `0.40` and clamps it on narrow terminals so the anchor remains reusable; later splits use layout geometry. Both fresh and recovered placement fail closed unless the live layout can provide a 24x6 anchor and a 12x8 child. Concurrent first allocations for one `(session,workspace,card)` key are serialized; if multiple historical panes are live, newest run id wins. Legacy rows retain the historical `kanban` lookup. Thus cwd/env/placement exist **before** launch; pane-first `agent.start` receives none of them and never receives the anchor pane id.
-   - managed Pi/Claude: create a mode-`0600` file containing the snapshotted system prompt; call `agent.start {name,kind,pane_id,args,timeout_ms:30000}` on the newly split child with prompt-free startup args and the harness-specific file flag. A typed `agent_pane_busy` response is treated as a bounded transient on that same child: retry the exact same request on the same pane at most twice, with 100ms then 200ms backoff; do not split or allocate another pane. Persistent busy is terminal and follows child-only cleanup, leaving the anchor. This is distinct from `pane_not_found`, which is a placement race: close the child when present, rediscover from `tab.list`, and retry complete placement once. Poll `agent.get {target:pane_id}` for at most 30s until `interactive_ready && !launch_pending`; then call `agent.prompt {target:pane_id,text:prompt_snapshot}`. Remove the prompt file before returning, including error paths. **After a successful managed launch** (fresh or reuse), the daemon closes the tab anchor with `pane.close` — closing a split parent is live-verified safe, and the harness pane keeps its process/env — so the tab converges to exactly one harness pane; the promoted run persists a NULL anchor. If that close fails, the anchor is kept (and persisted) rather than failing the already-successful launch. A failed launch never closes the anchor: it remains for the next allocation, per the child-only cleanup rule.
+   - managed Pi/Claude: create a mode-`0600` file containing the snapshotted system prompt; call `agent.start {name,kind,pane_id,args,timeout_ms:30000}` on the newly split child with prompt-free startup args and the harness-specific file flag. A typed `agent_pane_busy` response is treated as a bounded transient on that same child: retry the exact same request on the same pane at most twice, with 100ms then 200ms backoff; do not split or allocate another pane. Persistent busy is terminal and follows child-only cleanup, leaving the anchor. This is distinct from `pane_not_found`, which is a placement race: close the child when present, rediscover from `tab.list`, and retry complete placement once. Poll `agent.get {target:pane_id}` for at most 30s until `interactive_ready && !launch_pending`; then call `agent.prompt {target:pane_id,text:prompt_snapshot}`. Remove the prompt file before returning, including error paths.
+   - managed codex: the same `agent.start` readiness contract **without any prompt file** — codex has no system-prompt-file equivalent, so startup argv carries neither system nor task text and there is no `--` delimiter. After readiness the daemon runs a **bounded post-launch capture** on the same gated connection: it polls `agent.get` (at most 5 probes, 10s wall-clock cap) for `AgentInfo.agent_session`, and accepts only a reference with `agent:"codex"`, `kind:"id"`, and a non-empty `value` (the integration-reported thread id; `source` is deliberately unconstrained). A missing, wrong-agent, `path`-kind, or blank report degrades to `None` with a warning and the launch **continues**: basic execution works, but the run keeps its enqueue-time `NULL` id, so same-conversation reuse hops and `run.focus` rescue fail closed (no recorded id). A captured id is persisted atomically **with** the run promotion (run + card in one transaction), so a cancel-during-spawn that ends the run discards the capture together with the handle; a capture racing promotion writes through the same single-row UoW and fails closed if the run is no longer open. Then `agent.prompt` delivers the prompt: a Mint receives one delimited block (`## herdr-board system instructions` + `## herdr-board card task`), a resume/fork fresh pane receives the task alone, same-pane reuse the task alone, and a rescue sends nothing. **After a successful managed launch** (fresh or reuse), the daemon closes the tab anchor with `pane.close` — closing a split parent is live-verified safe, and the harness pane keeps its process/env — so the tab converges to exactly one harness pane; the promoted run persists a NULL anchor. If that close fails, the anchor is kept (and persisted) rather than failing the already-successful launch. A failed launch never closes the anchor: it remains for the next allocation, per the child-only cleanup rule.
    - managed pane name is `card-<id>-<column-slug>` (e.g. `card-14-execute`); `agent_name_taken` retries once on the same pane with `card-<id>-<column-slug>-r<run>`.
    - configured harness: `pane.rename` the owned pane, create one mode-`0700` self-removing script whose POSIX-quoted command is the exact configured argv, and invoke exactly the selected Herdr binary (`HERDR_BIN_PATH` when nonempty, otherwise `herdr`) as `pane run <pane_id> <script_path>` with `HERDR_SOCKET_PATH` set to the selected socket. The script runs the child, preserves its status, then calls hidden `board __pane-exited --run-id "$BOARD_RUN_ID"`; the internal run-id guard accepts only the exact open queued/started configured run (including callback-before-registration), rejects stale/completed and built-in runs, and never applies `on_fail`.
    - a disappearing selected/owned child restarts discovery at `tab.list` and retries the complete placement once. Retry/terminal cleanup closes only the board-created run child; the shell anchor and pre-existing panes are never closed. `pane_not_found` means cleanup already won. This placement rediscovery path is separate from the bounded same-child `agent_pane_busy` retry above. A synchronous configured-runner failure also removes its script; after successful scheduling, the script owns self-removal.
@@ -496,6 +505,21 @@ Their persisted startup argv contains neither system nor card prompt:
   `claude [--model M] [--effort E] [--permission-mode P] --allowedTools "Bash(board:*)" (--session-id UUID | --resume ID [--fork-session])`
   - pane-first managed launch uses `kind:"claude"`, startup args without `claude`, then appends
     `--append-system-prompt-file <mode-0600-file>`; `agent.prompt` separately carries the card task.
+- Built-in `codex`:
+  `codex [--model M] [-c model_reasoning_effort=E] [permission preset flags] (resume <id> | fork <id>)`
+  - board effort `off` maps to `model_reasoning_effort=none` only while building argv; `minimal`
+    through `max` keep their canonical spelling, and the `Effort` enum is unchanged (no `ultra`);
+  - `ask-for-approval` emits `--sandbox workspace-write --ask-for-approval on-request`;
+    `approve-for-me` emits `--approve-for-me`; `full-access` emits
+    `--dangerously-bypass-approvals-and-sandbox`;
+  - `resume <id>` / `fork <id>` are **subcommands** closing the startup argv (Mint carries no
+    session flag at all and no board-invented uuid);
+  - no system-prompt file and no prompt text in argv: the managed `agent.prompt` channels are the
+    only prompt transport (Mint: delimited `system + task` block; resume/fork fresh pane: task
+    only; same-pane reuse: task only; rescue: nothing).
+  - the thread id reported by the codex integration (`AgentInfo.agent_session`, `kind:"id"`) is
+    captured after readiness and persisted atomically with the run promotion (`NULL` at enqueue for
+    a Mint); a fork's newly captured id supersedes the recorded source id.
 - Config-defined harnesses (`~/.config/herdr-board/config.toml`) remain unmanaged even if their
   executable is named `pi` or `claude`:
   ```toml
@@ -520,7 +544,10 @@ materializes the historical all-in-one Pi/Claude argv from explicit managed meta
 path always uses the separated pane-first channels.
 
 Pi lifecycle status comes from Herdr's official Pi integration and the existing event watcher; there
-is no Pi-specific watcher. Without `herdr integration install pi`, explicit `board done`, spawn
+is no Pi-specific watcher. Codex lifecycle status comes from Herdr's official codex integration the
+same way. Without `herdr integration install pi` (or `… codex`), explicit `board done`, spawn
 failure, timeout, and pane exit still work, but working/blocked/done detection is
 unavailable and the idle→`awaiting` watchdog does not arm while status remains `unknown`
-(see [Card statuses & signals](#card-statuses--signals)).
+(see [Card statuses & signals](#card-statuses--signals)). For codex the integration also reports the
+thread id that enables resume/reuse/rescue; without it the run still executes and completes, but the
+conversation cannot be reopened by id.

--- a/docs/research.md
+++ b/docs/research.md
@@ -21,6 +21,7 @@ workspaces/tabs/panes/agents, with IDs shaped like `w3`, `w3:t1`, and `w3:p1`.
 | Place a pane first | Use `tab.create` or `pane.split {workspace_id, target_pane_id, cwd, env, direction, ratio, focus}`. Placement, cwd, and environment are established before managed launch. |
 | Start a managed agent | `herdr agent start NAME --kind KIND --pane ID [--timeout MS] -- [AGENT_ARG…]`; the socket `agent.start` request is `{name, kind, pane_id, args, timeout_ms}`. `kind` selects the canonical executable and `args` excludes it. Board-side launch therefore stays pane-first rather than embedding placement in the agent request. |
 | Inspect readiness | `herdr agent get TARGET` / `agent.get {target}` returns `interactive_ready` and `launch_pending`; readiness is `interactive_ready=true && launch_pending=false`. `agent.wait` waits for agent status, not this startup predicate. |
+| Capture a reported session | `agent.get` → `AgentInfo.agent_session` (`AgentSessionInfo | null` in the protocol-19 schema): `{agent, kind, source, value}` with `kind` ∈ {`id`, `path`}; the field is absent when no session was reported. The codex integration reports its self-minted thread id here; board-herdr decodes it and the daemon's bounded post-launch capture accepts only `agent:"codex"` + `kind:"id"` + non-empty `value`, promoting it atomically onto run+card. |
 | Submit a card task | `herdr agent prompt TARGET TEXT`; `agent.prompt {target,text,wait?}` preserves multiline text and optionally waits for status. Herdr handles the short send-text/Enter settling delay; no synthetic keystroke/Enter pair is needed. |
 | Read output | `herdr agent read TARGET --source recent-unwrapped --lines N` / `agent.read` reads terminal screen/scrollback, not a semantic result. Read responses include `truncated`; `true` means older terminal rows were omitted. |
 | Run an unmanaged command | `herdr pane run PANE_ID COMMAND…` remains a CLI-only boundary: the current socket schema has no `pane.run` method. It schedules the command, so herdr-board uses a temporary self-cleaning runner and a board callback for silent child exit. |
@@ -44,6 +45,12 @@ request fields, result envelopes, and event forms. The delta is additive:
 - The integration target vocabulary adds `antigravity_cli` (CLI spelling
   `antigravity-cli`) and `grok`, including their session-reporting/native-restore
   support. They are not board built-in harnesses.
+
+- `AgentInfo.agent_session` is `AgentSessionInfo | null` (`{agent, kind,
+  source, value}`, `kind` ∈ {`id`, `path`}) and absent when a pane reported no
+  session. The board decodes it for the codex built-in: the integration's
+  reported thread id is captured after launch and persisted atomically with the
+  run promotion; a Mint keeps `session_id = NULL` until then.
 
 The board client does not call `workspace.move_block` and does not need to decode
 `workspace.reordered` to run its queue. Unknown additive events remain observable as
@@ -137,7 +144,8 @@ through a temporary `0600` file, waits for `interactive_ready`, and sends the ca
 **Claude Code**: `-p/--print` headless; `--output-format text|json|stream-json` (+`--verbose`); `--system-prompt` / **`--append-system-prompt`** (+ `-file` variants); `--model`; **`--effort low|medium|high|xhigh|max`** (first-class flag); `--permission-mode acceptEdits|auto|bypassPermissions|manual|dontAsk|plan`; `--allowedTools`/`--disallowedTools`; **`--session-id <uuid>`** (pre-assign), `--resume <id>`, `--fork-session` (retry without polluting), `--no-session-persistence`; `--max-budget-usd` (print-only); `--json-schema` (structured final output); `--input-format stream-json` (long-lived multi-prompt process); `--bare`; `--bg`; `-n/--name` (label session). Hooks: Stop/StopFailure, SessionStart/SessionEnd — **Stop not fired on silent tool stop** ([#29881](https://github.com/anthropics/claude-code/issues/29881)), don't rely on it alone.
 
 **Adapter shape for built-in/future harnesses** = (binary, prompt style, model flag, permission flag, resume mechanism, resulting session id):
-- codex: `codex exec "p"` — `-m`, `--sandbox read-only|workspace-write|danger-full-access`, `--json`, `--output-last-message <path>`, resume `codex exec resume <id>`; effort via `-c model_reasoning_effort=…` (unverified key).
+- codex (interactive, the managed built-in): `--model` remains free-form, while the visible model slugs and their per-model efforts are discovered from `$CODEX_HOME/models_cache.json`; effort uses `-c model_reasoning_effort=…` (board `off` maps to `none`, protocol-known levels keep their spelling, cache-only `ultra` is filtered). The Codex permission picker is represented by three presets combining approval and sandbox: `ask-for-approval` → `--sandbox workspace-write --ask-for-approval on-request`; `approve-for-me` → `--approve-for-me` (automatic reviewer, workspace-write); `full-access` → `--dangerously-bypass-approvals-and-sandbox`. There is **no `--session-id` for Mint** — codex mints its own thread uuid, so the board persists `NULL` and captures the id the Herdr integration reports via `agent_session`; resume/fork are **subcommands** `codex resume <id>` / `codex fork <id>`; no system-prompt-file equivalent (prompt travels only through `agent.prompt`).
+- codex headless: `codex exec "p"` — `-m`, `--sandbox …`, `--json`, `--output-last-message <path>`, resume `codex exec resume <id>`. Not a built-in: configure it under another harness name (e.g. `[harness.codex-exec]`) to keep it unmanaged.
 - gemini: `gemini -p "p"` — `-m`, `--approval-mode default|auto_edit|yolo|plan`; `-o json` (unverified spelling).
 - opencode: `opencode run "p"` — `--model provider/model`; `opencode serve` + `--attach` to amortize startup (session flags unverified).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -127,10 +127,12 @@ The current parity/schema-v13 change is specified test-first:
   CRUD/audit semantics stay in hermetic core/daemon/CLI tests; the live suite does not duplicate
   every management RPC.
 
-The authoritative [`e2e/README.md`](../e2e/README.md) catalog currently covers scenarios 01–30,
-and `e2e/run-all.sh` includes every numbered script. Scenarios 18–29 extend the live coverage with
+The authoritative [`e2e/README.md`](../e2e/README.md) catalog currently covers scenarios 01–31,
+and `e2e/run-all.sh` includes every numbered script. Scenarios 18–31 extend the live coverage with
 nullable/validation, late-start and recovery, active-run timing, TUI layout and board transfers,
-pane rescue, Pi catalog behavior, and diagnostics. This document describes the intended coverage
+pane rescue, Pi catalog behavior, diagnostics, pane reuse, and the managed Codex launch contract
+(self-minted thread capture, delimited mint prompt, fork/reuse/rescue, fail-closed missing-report
+rescue). This document describes the intended coverage
 and gate configuration; it does **not** claim that the full live E2E suite has passed.
 
 Nullable update coverage in `board-core` is table-driven across every column/card nullable:
@@ -314,7 +316,8 @@ state is copied. Its intended contract is one authorized Haiku/low attempt with 
   script. The standard suite creates a mode-`0700` managed root with controlled `HOME`, `ZDOTDIR`,
   rc files, `PATH`, and exported fake-provider functions; it never sources user rc files. It
   resolves the Herdr executable to an absolute path before narrowing the managed pane `PATH`.
-  Built-in managed agents see checked-in `e2e/fake-bin/pi` and `e2e/fake-bin/claude` only inside
+  Built-in managed agents see checked-in `e2e/fake-bin/pi`, `e2e/fake-bin/claude`, and
+  `e2e/fake-bin/codex` only inside
   the disposable Herdr server/workspaces. The fixtures record argv/readiness/prompt evidence
   under the scenario temp dir and call only the isolated `board comment`/`board done`; they never
   replace user installations or make model calls.
@@ -432,9 +435,10 @@ E2E_REAL_PI=1 e2e/real-pi-smoke.sh  # explicit real-provider opt-in; may incur c
 E2E_REAL_PI=1 E2E_REAL_PI_MODEL=openai-codex/gpt-5.3 E2E_REAL_PI_EFFORT=high e2e/real-pi-smoke.sh  # model/effort overrides; model must exist in `pi --list-models`
 E2E_REAL_PI=1 E2E_REAL_PI_NEW_WORKSPACE=1 e2e/real-pi-smoke.sh  # daemon-created new_workspace space; asserts one card tab + one Pi pane, no anchor
 E2E_REAL_CLAUDE_HAIKU=1 e2e/real-claude-haiku-smoke.sh  # one authorized Haiku/low attempt; may incur cost
+E2E_REAL_CODEX=1 e2e/real-codex-smoke.sh  # one authorized Codex/low attempt; may incur cost
 ```
 
-- Standard suite requires **exactly Herdr 0.8.0 / socket protocol 19**, `python3`, Bash ≥4, and `cargo`. It supports Linux and macOS; `run-all.sh` resolves Herdr and Bash absolutely before narrowing `PATH`. Every scenario preflights both `herdr --version` and a socket `ping`; older and unknown/future protocols fail before dispatch. The forced-build standard suite is configured to exercise scenarios 01–30 without provider calls; this is coverage guidance, not a claim that a full live run has passed. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages minimal completed onboarding/theme, exact workspace trust, the current Claude integration hook, credentials, and approved `remote-settings.json` under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied, and it has no retry or fallback. Its independent identity implementation remains Linux-only and is outside the portable provider-free gate. Both opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
+- Standard suite requires **exactly Herdr 0.8.0 / socket protocol 19**, `python3`, Bash ≥4, and `cargo`. It supports Linux and macOS; `run-all.sh` resolves Herdr and Bash absolutely before narrowing `PATH`. Every scenario preflights both `herdr --version` and a socket `ping`; older and unknown/future protocols fail before dispatch. The forced-build standard suite is configured to exercise scenarios 01–31 without provider calls; this is coverage guidance, not a claim that a full live run has passed. The real-Pi smoke additionally verifies Pi's runtime default model, current Herdr integration, and WezTerm. The real-Claude smoke is an intended-contract validation only: it requires a logged-in real Claude CLI plus current Herdr Claude integration v7, stages minimal completed onboarding/theme, exact workspace trust, the current Claude integration hook, credentials, and approved `remote-settings.json` under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied, and it has no retry or fallback. The real-Codex smoke is the same intended-contract shape for the Codex built-in: it requires the current Herdr Codex integration and hook, stages only codex auth/config/hook under a disposable `CODEX_HOME`, and authorizes one low-effort attempt with no retry or fallback. Their independent identity implementations remain Linux-only and are outside the portable provider-free gate. All three opt-ins compare user/repository state and clean exact resources. `run-all.sh` builds
   the release binary once; scenarios reuse it. Every scenario boots and cleans its own ephemeral
   session; scenario 03 additionally owns an independently tokened secondary session.
 - Exit codes: scenario `0` = PASS, `3` = SKIP, other = FAIL; `run-all.sh` exits

--- a/e2e/14-column-config.sh
+++ b/e2e/14-column-config.sh
@@ -31,11 +31,11 @@ step "harness.list advertises built-ins + config-defined harnesses"
 brpc harness.list '{}' | python3 -c '
 import json, sys
 hs = json.load(sys.stdin)["harnesses"]
-# Built-ins first in default order (pi before claude), then config-defined sorted.
-assert hs == ["pi", "claude", "fake", "fake-ov"], hs
+# Built-ins first in default order, then config-defined sorted.
+assert hs == ["pi", "claude", "codex", "fake", "fake-ov"], hs
 print("  harnesses:", ", ".join(hs))
 '
-ok "harness.list returns built-ins (pi, claude) and config-defined (fake, fake-ov)"
+ok "harness.list returns built-ins (pi, claude, codex) and config-defined (fake, fake-ov)"
 
 step "HERDR MUTATION: create disposable workspace for the override column"
 e2e_ws_create board-colcfg-e2e; WS_ID="$E2E_WS"

--- a/e2e/31-managed-codex.sh
+++ b/e2e/31-managed-codex.sh
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# 31-managed-codex.sh — managed Codex protocol-19/current launch contract,
+# provider-free through e2e/fake-bin/codex.
+#
+# Contract exercised end to end against a real Herdr:
+#   1. Mint: `codex [--model M] [-c model_reasoning_effort=E] [approval
+#      preset]` — no session flag (codex mints its own thread
+#      id), no prompt text in argv, no system-prompt file; the daemon captures
+#      the integration-reported thread id from `agent.get.agent_session` and
+#      persists it on run+card; the card task arrives through `agent.prompt`
+#      as ONE delimited system+task block and matches the run snapshots;
+#   2. Retry: `board retry` forks the recorded thread (`codex fork <id>` tail),
+#      the fork mints a NEW thread which replaces the source id at promotion;
+#   3. Same-conversation reuse: a non-fresh auto hop re-prompts the SAME pane
+#      (no second `agent.start`) with the task alone and keeps the thread id;
+#   4. Rescue: a run whose pane is closed is reopened with `codex resume <id>`
+#      in a new pane WITHOUT re-sending the task; the runs row stays
+#      byte-for-byte unchanged; a second focus reuses the rescued pane;
+#   5. Fail-closed missing report: a card whose model is the documented
+#      sentinel `no-session` makes the fixture report only the idle lifecycle,
+#      so the capture degrades, the mint still completes with session_id NULL,
+#      rescue is refused with an actionable diagnostic, and a non-fresh hop
+#      cannot reuse the conversation (it mints fresh instead);
+#   6. Managed tabs stay anchorless: every launch converges the `card-<id>`
+#      tab to exactly one Codex harness pane.
+set -euo pipefail
+. "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/lib.sh"
+
+# Fake-managed setup creates roots, so cleanup must already be armed.
+trap e2e_cleanup EXIT
+e2e_enable_fake_pi
+[ -x "$E2E_FAKE_PI_BIN_DIR/codex" ] || fail "fake codex missing/not executable at $E2E_FAKE_PI_BIN_DIR/codex"
+# Same-conversation reuse needs the looping fixture, and a daemon split pane
+# inherits the SERVER's env (never the workspace env), so the knob must be
+# exported before e2e_boot boots the ephemeral server.
+export FAKE_PI_LOOP=1
+e2e_boot   # e2e_init + e2e_build + e2e_isolate + e2e_daemon_start (in that order)
+
+# The board protocol trailer (the column has no custom system_prompt, so this
+# is the exact `system_prompt_snapshot` the daemon persisted).
+CODEX_PROTOCOL="## herdr-board protocol
+You are running a herdr-board card (\$BOARD_CARD_ID is preset). When this stage's goal is met you MUST finish with exactly two commands: first \`board comment \"<your results, files touched, findings>\"\`, then \`board done --outcome ok\`. If the stage goal was NOT met — something failed or you got lost — use \`board done --outcome fail --summary \"<why>\"\` instead. Always comment before done. Never use \`board move\`/\`cancel\`/\`retry\` on your own card. Finishing or going idle WITHOUT \`board done\` leaves the card in \`awaiting\` for human review — a run is never auto-completed."
+
+codex_failure_diag() {
+  local phase="$1" card="$2" panes record
+  printf '\n--- codex %s failure diagnostics (disposable session only) ---\n' "$phase" >&2
+  e2e_card_failure_diag "$card"
+  printf 'fixture_records=%s\n' "$(find "$E2E_TMP" -maxdepth 1 -type f -name 'fake-codex-run-*.json' -printf . 2>/dev/null | wc -c)" >&2
+  for record in "$E2E_TMP"/fake-codex-run-*.json; do
+    [ -f "$record" ] || continue
+    python3 - "$record" <<'PY' >&2 || true
+import json, sys
+try:
+    x = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception as e:
+    print(f"record_error={type(e).__name__}")
+else:
+    safe = {k: v for k, v in x.items() if k not in ("prompt", "expected_prompt")}
+    print("record: %s" % safe)
+PY
+  done
+  panes="$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}" 2>/dev/null || true)"
+  printf '%s\n' "pane.list: ${panes:-<unavailable>}" >&2
+  printf '%s\n' 'daemon.log tail:' >&2
+  tail -60 "$E2E_TMP/daemon.log" 2>/dev/null >&2 || true
+  printf '%s\n' '--- end codex diagnostics ---' >&2
+}
+
+# One pane's field from the disposable workspace (read-only probe).
+pane_field() {
+  hrpc pane.list "{\"workspace_id\":\"$1\"}" | python3 -c '
+import json, sys
+pane_id, field = sys.argv[1:3]
+for pane in json.load(sys.stdin).get("panes", []):
+    if pane.get("pane_id") == pane_id:
+        print(pane.get(field) or "")
+        break
+' "$2" "$3"
+}
+
+# --- Phase 1: mint + thread capture + exact delimited prompt + anchorless ----
+step "Mint: fresh Codex launch captures its self-minted thread id"
+e2e_ws_create codex-mint; WS_ID="$E2E_WS"
+EXEC_ID="$(col_create '{"name":"Codex Execute","trigger":"auto"}')"
+card_json="$("$BOARD_BIN" card new --title 'Codex Mint' --description $'codex mint task with spaces\nand a newline' \
+  --harness codex --model c31/codex-model --effort low --permission ask-for-approval \
+  --space-kind workspace --space-ref "$WS_ID" --json)"
+CARD_ID="$(printf '%s' "$card_json" | jget id)" || fail "could not parse mint card id"
+mut "board move $CARD_ID 'Codex Execute' -> managed agent.start kind=codex (mint)"
+e2e_board_herdr_mutate -- move "$CARD_ID" "$EXEC_ID" --json >/dev/null
+outcome="$(wait_ok "$CARD_ID" 100)" || {
+  codex_failure_diag mint "$CARD_ID"
+  fail "managed Codex mint outcome '$outcome' (readiness/capture/agent.prompt did not complete)"
+}
+[ "$outcome" = ok ] || fail "managed Codex mint did not complete ok (got '$outcome')"
+MINT_RUN="$(card_field "$CARD_ID" runs[-1].id)"
+MINT_PANE="$(card_field "$CARD_ID" runs[-1].herdr_pane_id)"
+MINT_THREAD="codex-thread-$CARD_ID-$MINT_RUN"
+[ -n "$MINT_RUN" ] && [ -n "$MINT_PANE" ] || fail "mint run did not record its identity"
+[ "$(card_field "$CARD_ID" runs[-1].session_id)" = "$MINT_THREAD" ] \
+  || fail "mint did not capture/persist the reported thread id (expected $MINT_THREAD)"
+MINT_RECORD="$E2E_TMP/fake-codex-run-$MINT_RUN.json"
+[ -f "$MINT_RECORD" ] || fail "fake Codex did not record run $MINT_RUN"
+ok "run $MINT_RUN captured thread $MINT_THREAD (pane $MINT_PANE)"
+
+step "Assert the mint argv, the session capture, and the delimited prompt"
+"$BOARD_BIN" card show "$CARD_ID" --json >"$E2E_TMP/codex-mint-show.json"
+python3 - "$MINT_RECORD" "$E2E_TMP/codex-mint-show.json" "$CARD_ID" "$MINT_RUN" "$MINT_THREAD" \
+  "$BOARD_SOCKET" "$HERDR_SOCKET_PATH" "$CODEX_PROTOCOL" <<'PY' || fail "mint record assertions failed"
+import json, sys
+record, show_path, card, run, thread, board, herdr, protocol = sys.argv[1:]
+x = json.load(open(record, encoding="utf-8"))
+show = json.load(open(show_path, encoding="utf-8"))
+expected_prompt = show["runs"][-1]["prompt_snapshot"]
+assert str(x["card_id"]) == card and x["run_id"] == int(run)
+assert x["board_socket"] == board and x["herdr_socket"] == herdr
+assert x["mode"] == "mint" and x["resume_id"] is None and x["fork_id"] is None
+assert x["model"] == "c31/codex-model" and x["effort"] == "low" and x["permission_mode"] == "ask-for-approval"
+assert x["system_prompt_file"] is None and x["startup_argv_has_no_prompt"] is True
+# The ask-for-approval preset maps to the explicit workspace-write sandbox
+# plus the on-request policy pair.
+expected_argv = ["--model", "c31/codex-model", "-c", "model_reasoning_effort=low",
+                 "--sandbox", "workspace-write", "--ask-for-approval", "on-request"]
+assert x["argv"] == expected_argv, f"mint argv {x['argv']} != {expected_argv}"
+assert not any("codex mint task" in arg for arg in x["argv"])
+# The reported thread id is exactly what the daemon captured and persisted.
+assert x["thread_id"] == thread and x["agent_session_id"] == thread
+reports = x["reports"]
+assert [r["phase"] for r in reports] == ["session_identity", "idle_lifecycle"]
+assert all(r["ok"] and r["reply"]["result"]["type"] == "ok" for r in reports)
+identity, idle = (r["request"] for r in reports)
+assert identity["method"] == "pane.report_agent_session"
+assert idle["method"] == "pane.report_agent" and idle["params"]["state"] == "idle"
+assert identity["params"]["source"] == idle["params"]["source"] == "herdr:codex"
+assert identity["params"]["agent_session_id"] == thread
+assert identity["params"]["session_start_source"] == "startup"
+assert x["readiness_report"] == "ok" and x["herdr_pane_id"]
+# The Mint prompt is ONE delimited block: system instructions, then the task.
+block = "## herdr-board system instructions\n" + protocol + "\n\n## herdr-board card task\n" + expected_prompt
+assert x["stdin_isatty"] is True and x["prompt_received_via_stdin"] is True
+assert x["prompt_matches_mint_block"] is True
+assert x["mint_system_half"] == protocol, "the delivered system half is not the exact protocol trailer"
+assert x["prompt"] == block, "the delivered mint prompt is not the exact delimited system+task block"
+print("  Mint: no session flag/prompt in argv; thread id captured; exact delimited block delivered", file=sys.stderr)
+PY
+
+step "Assert the managed mint tab is anchorless with exactly one Codex pane"
+python3 - "$(hrpc tab.list "{\"workspace_id\":\"$WS_ID\"}")" \
+  "$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}")" "$CARD_ID" "$MINT_PANE" \
+  <<'PY' || fail "mint tab did not converge to one Codex pane"
+import json, sys
+tabs = json.loads(sys.argv[1]).get("tabs", [])
+panes = json.loads(sys.argv[2]).get("panes", [])
+card, pane = sys.argv[3:5]
+match = [t for t in tabs if t.get("label") == f"card-{card}"]
+assert len(match) == 1, f"expected one card-{card} tab, got {len(match)}"
+owned = [p for p in panes if p.get("tab_id") == match[0]["tab_id"]]
+assert len(owned) == 1, f"expected exactly one pane in the mint tab, got {len(owned)}"
+assert owned[0]["pane_id"] == pane and owned[0].get("agent") == "codex"
+assert not any(p.get("label") == f"card-{card}-anchor" for p in owned)
+PY
+ok "mint tab holds exactly the one Codex pane, no anchor"
+
+# --- Phase 2: retry forks the recorded thread into a NEW conversation -------
+step "Retry: with the mint pane closed, board retry forks into a NEW Codex thread"
+# A finished run's terminal is routinely closed by the user. Closing it also
+# removes the reuse candidate, so the retry exercises the fork LAUNCH itself
+# (`codex fork <thread>` in a fresh pane) rather than a same-pane re-prompt.
+mut "pane.close $MINT_PANE (disposable board-owned pane of the finished mint run)"
+e2e_hrpc_mutate -- pane.close "{\"pane_id\":\"$MINT_PANE\"}" >/dev/null 2>&1 || true
+for _ in $(seq 1 40); do
+  hrpc pane.get "{\"pane_id\":\"$MINT_PANE\"}" >/dev/null 2>&1 || break
+  sleep .1
+done
+! hrpc pane.get "{\"pane_id\":\"$MINT_PANE\"}" >/dev/null 2>&1 \
+  || fail "mint pane $MINT_PANE is still alive; the fork launch case cannot be exercised"
+mut "board retry $CARD_ID -> codex fork <recorded thread>"
+e2e_board_herdr_mutate -- retry "$CARD_ID" >/dev/null
+fork_outcome="$(wait_runs "$CARD_ID" 2 100)" || {
+  codex_failure_diag fork "$CARD_ID"
+  fail "Codex fork run did not finish (outcome '$fork_outcome')"
+}
+[ "$fork_outcome" = ok ] || fail "Codex fork outcome '$fork_outcome' (expected ok)"
+FORK_RUN="$(card_field "$CARD_ID" runs[-1].id)"
+FORK_PANE="$(card_field "$CARD_ID" runs[-1].herdr_pane_id)"
+FORK_THREAD="codex-thread-$CARD_ID-$FORK_RUN"
+[ -n "$FORK_RUN" ] && [ -n "$FORK_PANE" ] || fail "fork run did not record its identity"
+[ "$(card_field "$CARD_ID" runs[-1].session_id)" = "$FORK_THREAD" ] \
+  || fail "fork did not capture/persist the NEW thread id (expected $FORK_THREAD, the fork source is $MINT_THREAD)"
+FORK_RECORD="$E2E_TMP/fake-codex-run-$FORK_RUN.json"
+[ -f "$FORK_RECORD" ] || fail "fake Codex did not record fork run $FORK_RUN"
+"$BOARD_BIN" card show "$CARD_ID" --json >"$E2E_TMP/codex-fork-show.json"
+python3 - "$FORK_RECORD" "$E2E_TMP/codex-fork-show.json" "$CARD_ID" "$FORK_RUN" \
+  "$MINT_THREAD" "$FORK_THREAD" <<'PY' || fail "fork record assertions failed"
+import json, sys
+record, show_path, card, run, source, thread = sys.argv[1:]
+x = json.load(open(record, encoding="utf-8"))
+show = json.load(open(show_path, encoding="utf-8"))
+assert str(x["card_id"]) == card and x["run_id"] == int(run)
+assert x["mode"] == "fork" and x["fork_id"] == source and x["resume_id"] is None
+# The fork is a fresh launch whose argv closes with the `fork <id>` subcommand.
+assert x["argv"][-2:] == ["fork", source], f"fork argv tail {x['argv'][-2:]} != ['fork', {source}]"
+# The fork minted a NEW thread, which the capture persisted over the source id.
+assert x["thread_id"] == thread and x["agent_session_id"] == thread
+assert x["model"] == "c31/codex-model" and x["effort"] == "low"
+assert x["system_prompt_file"] is None and x["startup_argv_has_no_prompt"] is True
+# Resume/fork receive the task ALONE — never the system block.
+assert x["prompt_matches_run_snapshot"] is True
+assert x["prompt"] == show["runs"][-1]["prompt_snapshot"]
+assert "## herdr-board system instructions" not in x["prompt"]
+assert "## herdr-board card task" not in x["prompt"]
+print("  Fork: 'fork <source>' closes the argv; new thread captured; task-only prompt", file=sys.stderr)
+PY
+ok "fork run $FORK_RUN replaced thread $MINT_THREAD with $FORK_THREAD (pane $FORK_PANE)"
+
+step "Assert the fork recreated the card tab and converged to one Codex pane"
+python3 - "$(hrpc tab.list "{\"workspace_id\":\"$WS_ID\"}")" \
+  "$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}")" "$CARD_ID" "$FORK_PANE" \
+  <<'PY' || fail "fork tab did not converge to one Codex pane"
+import json, sys
+tabs = json.loads(sys.argv[1]).get("tabs", [])
+panes = json.loads(sys.argv[2]).get("panes", [])
+card, pane = sys.argv[3:5]
+match = [t for t in tabs if t.get("label") == f"card-{card}"]
+assert len(match) == 1
+owned = [p for p in panes if p.get("tab_id") == match[0]["tab_id"]]
+assert len(owned) == 1, f"expected exactly one pane in the fork tab, got {len(owned)}"
+assert owned[0]["pane_id"] == pane and owned[0].get("agent") == "codex"
+assert not any(p.get("label") == f"card-{card}-anchor" for p in owned)
+PY
+ok "the fork's fresh launch recreated the card tab with exactly one Codex pane"
+
+# --- Phase 3: same-conversation reuse across a non-fresh auto hop -----------
+step "Same-conversation reuse: a non-fresh auto hop re-prompts the SAME pane"
+# FAKE_PI_LOOP must reach the managed pane: a daemon split pane inherits the
+# SERVER's env (not the workspace env), so this is exported before e2e_boot
+# and stays on for the whole scenario (other cards' finished panes merely
+# linger until their next shim's prompt timeout — harmless for assertions).
+e2e_ws_create codex-reuse; REUSE_WS="$E2E_WS"
+MANUAL_ID="$(col_create '{"name":"Codex Manual","trigger":"manual"}')"
+IMPL_ID="$(col_create "{\"name\":\"Codex Implement\",\"trigger\":\"auto\",\"on_success_column_id\":$MANUAL_ID,\"fresh_session\":false}")"
+SETUP_ID="$(col_create "{\"name\":\"Codex Setup\",\"trigger\":\"auto\",\"on_success_column_id\":$IMPL_ID,\"fresh_session\":true}")"
+[ -n "$SETUP_ID" ] && [ -n "$IMPL_ID" ] && [ -n "$MANUAL_ID" ] \
+  || fail "could not create the reuse chain columns"
+reuse_json="$("$BOARD_BIN" card new --title 'Codex Reuse' -d 'traverse the codex chain' \
+  --harness codex --model c31/reuse-model --effort off \
+  --space-kind workspace --space-ref "$REUSE_WS" --json)"
+REUSE_ID="$(printf '%s' "$reuse_json" | jget id)" || fail "could not parse reuse card id"
+mut "board move $REUSE_ID 'Codex Setup' -> codex mint; non-fresh hop reuses pane"
+e2e_board_herdr_mutate -- move "$REUSE_ID" "$SETUP_ID" --json >/dev/null
+chain_outcome="$(wait_runs "$REUSE_ID" 2 120)" || {
+  codex_failure_diag reuse "$REUSE_ID"
+  fail "codex chain did not produce 2 runs (last='$chain_outcome')"
+}
+[ "$chain_outcome" = ok ] || fail "codex chain last outcome '$chain_outcome' (expected ok)"
+"$BOARD_BIN" card show "$REUSE_ID" --json >"$E2E_TMP/codex-reuse-show.json"
+REUSE_RUN1="$(card_field "$REUSE_ID" runs[0].id)"
+REUSE_RUN2="$(card_field "$REUSE_ID" runs[-1].id)"
+REUSE_THREAD="codex-thread-$REUSE_ID-$REUSE_RUN1"
+python3 - "$E2E_TMP/codex-reuse-show.json" "$(hrpc tab.list "{\"workspace_id\":\"$REUSE_WS\"}")" \
+  "$(hrpc pane.list "{\"workspace_id\":\"$REUSE_WS\"}")" "$REUSE_ID" "$REUSE_THREAD" \
+  <<'PY' || fail "reuse chain assertions failed"
+import json, sys
+show_path, tabs_json, panes_json, card, thread = sys.argv[1:]
+show = json.load(open(show_path, encoding="utf-8"))
+runs = show["runs"]
+assert len(runs) == 2, f"expected 2 runs, got {len(runs)}"
+assert all(r.get("outcome") == "ok" for r in runs)
+# ONE conversation: the minted thread survives the resume hop, and ONE pane
+# serves both runs (no second agent.start).
+assert runs[0]["session_id"] == thread, f"run 1 session {runs[0].get('session_id')} != {thread}"
+assert runs[1]["session_id"] == thread, f"run 2 session {runs[1].get('session_id')} != {thread}"
+assert runs[0]["herdr_pane_id"] == runs[1]["herdr_pane_id"], "the resume hop must reuse the mint pane"
+# The retry-style fork contract stays on the enqueue argv, while the reuse hop
+# keeps the resume spelling (its enqueue-time argv is persisted on the run).
+argv0 = json.loads(runs[0]["argv_json"])
+argv1 = json.loads(runs[1]["argv_json"])
+assert "-c" in argv0 and argv0[argv0.index("-c") + 1] == "model_reasoning_effort=none", \
+    "board effort off must map to codex model_reasoning_effort=none"
+assert argv1[-2:] == ["resume", thread], f"reuse hop argv tail {argv1[-2:]} != ['resume', {thread}]"
+panes = json.loads(panes_json).get("panes", [])
+tabs = json.loads(tabs_json).get("tabs", [])
+match = [t for t in tabs if t.get("label") == f"card-{card}"]
+assert len(match) == 1
+owned = [p for p in panes if p.get("tab_id") == match[0]["tab_id"]]
+assert len(owned) == 1 and owned[0].get("agent") == "codex", f"tab holds {len(owned)} panes"
+assert owned[0]["pane_id"] == runs[1]["herdr_pane_id"]
+assert not any(p.get("label") == f"card-{card}-anchor" for p in owned)
+print("  Reuse: 2 runs share pane %s and thread %s (off -> model_reasoning_effort=none)" %
+      (runs[1]["herdr_pane_id"], thread), file=sys.stderr)
+PY
+REUSE_RECORD="$E2E_TMP/fake-codex-run-$REUSE_RUN1.json"
+python3 - "$REUSE_RECORD" "$E2E_TMP/codex-reuse-show.json" "$REUSE_RUN1" <<'PY' \
+  || fail "reuse fixture record assertions failed"
+import json, sys
+record, show_path, run1 = sys.argv[1:]
+x = json.load(open(record, encoding="utf-8"))
+show = json.load(open(show_path, encoding="utf-8"))
+# The SAME process served both stages: minted at run 1, re-prompted for run 2.
+assert x["mode"] == "mint" and x["effort"] == "none"
+assert x["prompt_matches_mint_block"] is True, "stage 1 must have delivered the delimited mint block"
+assert x["prompt_matches_run_snapshot"] is True, "stage 2 must have delivered the task alone"
+assert x["prompt"] == show["runs"][-1]["prompt_snapshot"], "the last delivered prompt is stage 2's task"
+print("  Reuse fixture: one process, mint block then task-only re-prompt, both verified", file=sys.stderr)
+PY
+ok "non-fresh hop reused one pane/conversation; the chain landed on the manual column"
+
+# --- Phase 4: rescue reopens a dead pane with `resume <id>`, no re-prompt ----
+step "Rescue: a dead Codex pane is reopened with codex resume <thread>"
+rescue_json="$("$BOARD_BIN" card new --title 'Codex Rescue' --description 'work to continue' \
+  --harness codex --model c31/rescue-model --effort medium \
+  --space-kind workspace --space-ref "$WS_ID" --json)"
+RCUE_ID="$(printf '%s' "$rescue_json" | jget id)" || fail "could not parse rescue card id"
+mut "board move $RCUE_ID 'Codex Execute' -> managed codex mint (rescue target)"
+e2e_board_herdr_mutate -- move "$RCUE_ID" "$EXEC_ID" --json >/dev/null
+rcue_outcome="$(wait_ok "$RCUE_ID" 100)" || {
+  codex_failure_diag rescue "$RCUE_ID"
+  fail "codex rescue-target run did not finish (outcome '$rcue_outcome')"
+}
+[ "$rcue_outcome" = ok ] || fail "codex rescue-target outcome '$rcue_outcome' (expected ok)"
+RCUE_RUN="$(card_field "$RCUE_ID" runs[-1].id)"
+RCUE_PANE="$(card_field "$RCUE_ID" runs[-1].herdr_pane_id)"
+RCUE_THREAD="$(card_field "$RCUE_ID" runs[-1].session_id)"
+[ -n "$RCUE_RUN" ] && [ -n "$RCUE_PANE" ] || fail "rescue-target run did not record its identity"
+[ "$RCUE_THREAD" = "codex-thread-$RCUE_ID-$RCUE_RUN" ] || fail "rescue-target thread mismatch"
+RUNS_BEFORE="$E2E_TMP/codex-runs-before.json"
+"$BOARD_BIN" card show "$RCUE_ID" --json | python3 -c '
+import json, sys
+print(json.dumps(json.load(sys.stdin)["runs"], sort_keys=True))
+' >"$RUNS_BEFORE"
+ok "rescue-target run $RCUE_RUN recorded thread $RCUE_THREAD (pane $RCUE_PANE)"
+
+step "HERDR MUTATION: pane.close $RCUE_PANE (the run's terminal is closed)"
+mut "pane.close $RCUE_PANE (disposable board-owned pane of a finished run)"
+e2e_hrpc_mutate -- pane.close "{\"pane_id\":\"$RCUE_PANE\"}" >/dev/null 2>&1 || true
+for _ in $(seq 1 40); do
+  hrpc pane.get "{\"pane_id\":\"$RCUE_PANE\"}" >/dev/null 2>&1 || break
+  sleep .1
+done
+! hrpc pane.get "{\"pane_id\":\"$RCUE_PANE\"}" >/dev/null 2>&1 \
+  || fail "recorded pane $RCUE_PANE is still alive; the rescue case cannot be exercised"
+
+focus_json="$(e2e_board_herdr_mutate -- card run focus "$RCUE_ID" "$RCUE_RUN" --json)"
+printf '  %s\n' "$focus_json"
+focus_action="$(printf '%s' "$focus_json" | jget action)"
+[ "$focus_action" = rescued ] || fail "focus reported action '$focus_action' (expected 'rescued')"
+RESCUED_PANE="$(printf '%s' "$focus_json" | jget pane_id)"
+[ -n "$RESCUED_PANE" ] && [ "$RESCUED_PANE" != "$RCUE_PANE" ] \
+  || fail "focus returned no NEW rescued pane id"
+hrpc pane.get "{\"pane_id\":\"$RESCUED_PANE\"}" >/dev/null \
+  || fail "rescued pane $RESCUED_PANE does not exist"
+rescue_label="$(pane_field "$WS_ID" "$RESCUED_PANE" label)"
+[ "$rescue_label" = "card-$RCUE_ID-r$RCUE_RUN-rescue" ] \
+  || fail "rescued pane label '$rescue_label' is not 'card-$RCUE_ID-r$RCUE_RUN-rescue'"
+RCUE_RESUME_RECORD="$E2E_TMP/fake-codex-run-$RCUE_RUN-rescue.json"
+for _ in $(seq 1 100); do
+  [ -f "$RCUE_RESUME_RECORD" ] && break
+  sleep .1
+done
+[ -f "$RCUE_RESUME_RECORD" ] || fail "the rescued pane's fake Codex never recorded its startup"
+python3 - "$RCUE_RESUME_RECORD" "$RCUE_THREAD" "$RCUE_RUN" "$RCUE_ID" "$CODEX_PROTOCOL" \
+  <<'PY' || fail "rescue record assertions failed"
+import json, sys
+path, thread, run_id, card_id, protocol = sys.argv[1:]
+record = json.load(open(path, encoding="utf-8"))
+# Resume: `codex resume <id>` closes the argv with the recorded thread.
+assert record["mode"] == "resume" and record["resume_id"] == thread
+assert record["argv"][-2:] == ["resume", thread]
+assert record["thread_id"] == thread and record["fork_id"] is None
+assert record["run_id"] == int(run_id) and record["card_id"] == int(card_id)
+assert record["rescue"] is True
+# The persisted execution environment is preserved, not rebuilt from config.
+assert record["model"] == "c31/rescue-model" and record["effort"] == "medium"
+# The card task must NOT appear in startup argv, and a rescue sends NO
+# agent.prompt at all, so the shim's prompt evidence must be absent.
+assert record["startup_argv_has_no_prompt"] is True
+assert not any("work to continue" in arg for arg in record["argv"])
+assert "prompt" not in record, "a rescue must never re-send the card task"
+print("  Rescue startup:", json.dumps({k: record[k] for k in
+      ("mode", "resume_id", "thread_id", "model", "effort", "argv")}, ensure_ascii=False))
+PY
+ok "harness resumed thread $RCUE_THREAD without re-sending the card task"
+
+step "Focus again: must reuse the rescued pane, never create a second one"
+PANES_AFTER_RESCUE="$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("panes",[])))')"
+again_json="$(e2e_board_herdr_mutate -- card run focus "$RCUE_ID" "$RCUE_RUN" --json)"
+again_action="$(printf '%s' "$again_json" | jget action)"
+[ "$again_action" = focused_rescued_pane ] \
+  || fail "second focus reported '$again_action' (expected 'focused_rescued_pane')"
+[ "$(printf '%s' "$again_json" | jget pane_id)" = "$RESCUED_PANE" ] \
+  || fail "second focus did not reuse rescued pane $RESCUED_PANE"
+[ "$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("panes",[])))')" = "$PANES_AFTER_RESCUE" ] \
+  || fail "second focus created another pane"
+ok "second focus reused $RESCUED_PANE and created no extra pane"
+
+step "Assert the rescue wrote NOTHING to the database"
+"$BOARD_BIN" card show "$RCUE_ID" --json | python3 -c '
+import json, sys
+print(json.dumps(json.load(sys.stdin)["runs"], sort_keys=True))
+' >"$E2E_TMP/codex-runs-after.json"
+diff -u "$RUNS_BEFORE" "$E2E_TMP/codex-runs-after.json" \
+  || fail "a rescue mutated the runs table (it must be byte-for-byte immutable)"
+run_rows="$(python3 -c '
+import json, sys
+print(len(json.load(open(sys.argv[1], encoding="utf-8"))))
+' "$E2E_TMP/codex-runs-after.json")"
+[ "$run_rows" = 1 ] || fail "expected exactly 1 run row, found $run_rows"
+ok "the historical run row is unchanged and no run row was added"
+
+step "Assert the managed rescue converged the recreated tab to one Codex pane"
+RESCUED_TAB="$(pane_field "$WS_ID" "$RESCUED_PANE" tab_id)"
+[ -n "$RESCUED_TAB" ] || fail "rescued pane is not in any tab"
+python3 - "$(hrpc tab.list "{\"workspace_id\":\"$WS_ID\"}")" \
+  "$(hrpc pane.list "{\"workspace_id\":\"$WS_ID\"}")" \
+  "$RESCUED_TAB" "$RCUE_ID" "$RESCUED_PANE" <<'PY' || fail "rescued tab did not converge"
+import json, sys
+tabs = json.loads(sys.argv[1]).get("tabs", [])
+panes = json.loads(sys.argv[2]).get("panes", [])
+rescued_tab, card, pane = sys.argv[3:6]
+match = [t for t in tabs if t.get("tab_id") == rescued_tab]
+assert len(match) == 1 and match[0].get("label") == f"card-{card}"
+owned = [p for p in panes if p.get("tab_id") == rescued_tab]
+assert len(owned) == 1 and owned[0]["pane_id"] == pane and owned[0].get("agent") == "codex"
+assert not any(p.get("label") == f"card-{card}-anchor" for p in owned)
+PY
+ok "the managed rescue closed its anchor; the recreated tab holds exactly one Codex pane"
+
+# --- Phase 5: fail-closed missing session report -----------------------------
+step "Fail-closed: no session report -> mint completes NULL, rescue is refused"
+# The daemon's split-pane launch env cannot carry scenario exports, so the
+# per-run sentinel model `no-session` (documented in e2e/fake-bin/codex)
+# switches the fixture into idle-report-only mode for this card.
+e2e_ws_create codex-nosession; NOSESSION_WS="$E2E_WS"
+NOSESSION_EXEC="$(col_create '{"name":"NoSession Execute","trigger":"auto"}')"
+NOSESSION_IMPL="$(col_create "{\"name\":\"NoSession Impl\",\"trigger\":\"auto\",\"fresh_session\":false}")"
+nosession_json="$("$BOARD_BIN" card new --title 'Codex No Session' --description 'degraded integration' \
+  --harness codex --model no-session --effort off --permission full-access \
+  --space-kind workspace --space-ref "$NOSESSION_WS" --json)"
+NS_ID="$(printf '%s' "$nosession_json" | jget id)" || fail "could not parse no-session card id"
+mut "board move $NS_ID 'NoSession Execute' -> managed codex mint WITHOUT session report"
+e2e_board_herdr_mutate -- move "$NS_ID" "$NOSESSION_EXEC" --json >/dev/null
+ns_outcome="$(wait_ok "$NS_ID" 100)" || {
+  codex_failure_diag nosession "$NS_ID"
+  fail "no-session codex mint did not complete (outcome '$ns_outcome')"
+}
+[ "$ns_outcome" = ok ] || fail "no-session codex outcome '$ns_outcome' (expected ok: basic execution continues)"
+NS_RUN="$(card_field "$NS_ID" runs[-1].id)"
+NS_PANE="$(card_field "$NS_ID" runs[-1].herdr_pane_id)"
+NS_THREAD="codex-thread-$NS_ID-$NS_RUN"
+[ -n "$NS_RUN" ] && [ -n "$NS_PANE" ] || fail "no-session run did not record its identity"
+if card_field "$NS_ID" runs[-1].session_id >/dev/null 2>&1; then
+  fail "no-session mint must persist NULL session_id, got '$(card_field "$NS_ID" runs[-1].session_id)'"
+fi
+NS_RECORD="$E2E_TMP/fake-codex-run-$NS_RUN.json"
+[ -f "$NS_RECORD" ] || fail "fake Codex did not record the no-session run $NS_RUN"
+python3 - "$NS_RECORD" "$NS_THREAD" <<'PY' || fail "no-session record assertions failed"
+import json, sys
+record, thread = sys.argv[1:]
+x = json.load(open(record, encoding="utf-8"))
+assert x["no_session_report"] is True and x["agent_session_id"] is None
+assert x["agent_session_path"] is None and x["session_start_source"] is None
+reports = x["reports"]
+assert [r["phase"] for r in reports] == ["idle_lifecycle"], "only the idle lifecycle may be reported"
+assert all(r["ok"] for r in reports)
+assert x["readiness_report"] == "ok"
+# The fixture still mints an internal thread (codex mints its own), it just
+# never reports it — so the board cannot know it.
+assert x["mode"] == "mint" and x["thread_id"] == thread
+# off -> model_reasoning_effort=none, and the prompt still arrives (as the
+# delimited mint block) even without a session report.
+assert x["effort"] == "none" and x["permission_mode"] == "full-access"
+assert x["argv"][-3:] == ["-c", "model_reasoning_effort=none", "--dangerously-bypass-approvals-and-sandbox"]
+assert x["prompt_matches_mint_block"] is True and x["prompt_received_via_stdin"] is True
+print("  No-session mint: idle-only report, NULL persisted, prompt still delivered", file=sys.stderr)
+PY
+ok "no-session mint completed ok with session_id NULL (basic execution continues)"
+
+step "Rescue of the no-session run must fail closed, non-destructively"
+mut "pane.close $NS_PANE (disposable board-owned pane of the no-session run)"
+e2e_hrpc_mutate -- pane.close "{\"pane_id\":\"$NS_PANE\"}" >/dev/null 2>&1 || true
+for _ in $(seq 1 40); do
+  hrpc pane.get "{\"pane_id\":\"$NS_PANE\"}" >/dev/null 2>&1 || break
+  sleep .1
+done
+before_refuse="$(hrpc pane.list "{\"workspace_id\":\"$NOSESSION_WS\"}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("panes",[])))')"
+set +e
+refuse_out="$(e2e_board_herdr_mutate -- card run focus "$NS_ID" "$NS_RUN" --json 2>&1)"
+refuse_code=$?
+set -e
+[ "$refuse_code" -ne 0 ] || fail "focus on a no-session codex run unexpectedly succeeded"
+printf '%s\n' "$refuse_out" | grep -q "no harness conversation id" \
+  || fail "refusal does not name the missing conversation id: $refuse_out"
+printf '%s\n' "$refuse_out" | grep -qi "retry the card" \
+  || fail "refusal is not actionable: $refuse_out"
+[ "$(hrpc pane.list "{\"workspace_id\":\"$NOSESSION_WS\"}" | python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("panes",[])))')" = "$before_refuse" ] \
+  || fail "a refused rescue created a pane (it must be non-destructive)"
+ok "the no-session run's rescue is refused by name with an actionable diagnostic"
+
+step "A non-fresh hop on a no-session card cannot reuse: it mints fresh instead"
+mut "board move $NS_ID 'NoSession Impl' -> cannot reuse without a thread id"
+e2e_board_herdr_mutate -- move "$NS_ID" "$NOSESSION_IMPL" --json >/dev/null
+ns2_outcome="$(wait_runs "$NS_ID" 2 100)" || {
+  codex_failure_diag nosession-reuse "$NS_ID"
+  fail "no-session second run did not finish (outcome '$ns2_outcome')"
+}
+[ "$ns2_outcome" = ok ] || fail "no-session second run outcome '$ns2_outcome' (expected ok)"
+NS_RUN2="$(card_field "$NS_ID" runs[-1].id)"
+NS_PANE2="$(card_field "$NS_ID" runs[-1].herdr_pane_id)"
+[ "$NS_RUN2" != "$NS_RUN" ] || fail "the no-session hop did not create a new run"
+[ "$NS_PANE2" != "$NS_PANE" ] || fail "the no-session hop must mint a fresh pane, not reuse"
+NS_RECORD2="$E2E_TMP/fake-codex-run-$NS_RUN2.json"
+[ -f "$NS_RECORD2" ] || fail "fake Codex did not record the no-session hop run $NS_RUN2"
+python3 - "$NS_RECORD2" "$NS_ID" "$NS_RUN2" "$NS_THREAD" <<'PY' || fail "no-session hop record assertions failed"
+import json, sys
+record, card, run, prior_thread = sys.argv[1:]
+x = json.load(open(record, encoding="utf-8"))
+assert x["no_session_report"] is True and x["mode"] == "mint"
+assert x["thread_id"] != prior_thread, "without a recorded id the hop cannot reuse; it must mint a NEW thread"
+assert x["run_id"] == int(run) and str(x["card_id"]) == card
+PY
+ok "the no-session hop minted a fresh conversation (no reuse possible without an id)"
+
+ok "fixture boundary: no provider was called; live Herdr readiness, capture, prompts, fork, reuse, rescue, and fail-closed paths proven"
+step "31-managed-codex: MINT CAPTURE + FORK + REUSE + RESCUE + FAIL-CLOSED CONTRACTS PASSED"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,9 +9,9 @@ exercises the herdr wire integration end to end.
 For the layers below this one (unit, daemon+CLI integration, TUI snapshots), the
 isolation/safety design, and the **how-to-write-a-scenario** guide, see
 [`../docs/testing.md`](../docs/testing.md). This file is the authoritative use-case catalog for board protocol v1 / SQLite schema v13:
-every numbered scenario from **01 through 30** must appear here and in `run-all.sh`. The provider-free
+every numbered scenario from **01 through 31** must appear here and in `run-all.sh`. The provider-free
 safe boundary is `fake-agent.sh`,
-`fake-bin/{pi,claude}`, and `test-harness.sh`; prompt/system-prompt contents are never logged.
+`fake-bin/{pi,claude,codex}`, and `test-harness.sh`; prompt/system-prompt contents are never logged.
 Scenario 21 is the active-run timer/event-refresh characterization. The CI live gate is configured to
 exercise the complete catalog after the cheaper static checks succeed.
 
@@ -49,6 +49,7 @@ exercise the complete catalog after the cheaper static checks succeed.
 | Pi's authenticated file catalog applies sparse/null `thinkingLevelMap` semantics in `harness.capabilities`, and the real TUI cycles the exact corrected effort order without submitting a card or launching Pi | `28-pi-effort-catalog.sh` | live, provider-free; no model invocation |
 | Private daily NDJSON diagnostics prune only exact owned files beyond 30 days and record redacted board/Herdr success, error, and subscription metadata | `29-diagnostic-logs.sh` | live, provider-free; no payloads or model invocation |
 | A non-fresh auto chain reuses ONE managed agent pane (and one conversation) across stages via `agent.prompt` (no new `pane.split`/`agent.start`); the managed tab stays anchorless with exactly one harness pane; a fresh column still mints a new pane, and a manual landing keeps the pane open | `30-pane-reuse.sh` | live, checked-in fake `pi`, zero provider cost |
+| Managed Codex mint captures its self-minted thread id from `agent.get.agent_session` (mint persists NULL at enqueue, the captured id atomically at promotion) and receives ONE delimited system+task `agent.prompt` block; retry runs `codex fork <id>` and captures the NEW thread; a non-fresh hop reuses the same pane with the task alone; a rescue reopens the dead pane with `codex resume <id>` without re-sending the task; a missing session report degrades the capture (mint completes NULL) and rescue fails closed with an actionable refusal; every managed tab converges anchorless to exactly one Codex pane | `31-managed-codex.sh` | live, checked-in fake `codex`, zero provider cost |
 
 ### How the live scenario produces Herdr `done`
 
@@ -121,7 +122,7 @@ unmarked, or out-of-root paths. Named-session sockets must be at most 92 bytes, 
 short `/tmp/hb-e2e.XXXXXX` isolated root. `TMPDIR` is pinned to that exact marker-owned root, so
 generated configured-harness scripts remain contained even if asynchronous `pane run` never opens
 their normal self-removing script. The forced-build standard suite is configured and required to exercise
-scenarios 01–30 without provider calls; this is a coverage requirement, not a claim that a live run
+scenarios 01–31 without provider calls; this is a coverage requirement, not a claim that a live run
 has completed. Scenarios 18–29 use only the configured or managed
 fake harnesses and never record prompt or system-prompt bodies.
 
@@ -139,6 +140,7 @@ E2E_REAL_PI=1 e2e/real-pi-smoke.sh  # REAL provider, explicit opt-in, may incur 
 E2E_REAL_PI=1 E2E_REAL_PI_MODEL=openai-codex/gpt-5.3 E2E_REAL_PI_EFFORT=high e2e/real-pi-smoke.sh  # explicit model/effort overrides (validated in `pi --list-models`)
 E2E_REAL_PI=1 E2E_REAL_PI_NEW_WORKSPACE=1 e2e/real-pi-smoke.sh  # card creates its workspace via new_workspace; asserts one card tab + one Pi pane
 E2E_REAL_CLAUDE_HAIKU=1 e2e/real-claude-haiku-smoke.sh  # one authorized REAL Haiku/low attempt
+E2E_REAL_CODEX=1 e2e/real-codex-smoke.sh  # one authorized REAL Codex attempt (low effort); may incur cost
 ```
 
 **Keep mode** (`--keep`, or `E2E_KEEP=1`): skips session stop/delete **and** workspace close,
@@ -167,7 +169,7 @@ personal Claude state. Its intended contract is one authorized attempt with no r
 | `test-harness.sh` | Deterministic Linux/macOS shell safety checks for signed ownership tokens, key scrubbing, every exact-resource ledger kind, replacement, malformed record, and standalone parity; starts no Herdr resources. |
 | `process_identity.py` | Standard-library platform backend: Linux `/proc`; Darwin `libproc`/`KERN_PROCARGS2`; exact argv/start/executable capture and HMAC verification. |
 | `fake-agent.sh` | Config-defined/shared fake harness used by provider-free configured-harness scenarios. |
-| `fake-bin/pi` / `fake-bin/claude` | Executables exposed only inside disposable standard-E2E Herdr servers/workspaces. They emulate interactive readiness/session reports, require the exact `agent.prompt` bytes before completion, record evidence under isolated temp, and never modify installed tools or call a provider. |
+| `fake-bin/pi` / `fake-bin/claude` / `fake-bin/codex` | Executables exposed only inside disposable standard-E2E Herdr servers/workspaces. They emulate interactive readiness/session reports, require the exact `agent.prompt` bytes before completion, record evidence under isolated temp, and never modify installed tools or call a provider. The codex fixture additionally emulates the self-minted thread id (`AgentInfo.agent_session`) that the real Codex integration reports, plus an opt-in degraded mode (a `--model no-session` sentinel card, or `FAKE_CODEX_NO_SESSION=1` where the env can reach the pane) that reports no session identity. |
 | `16-managed-p17.sh` | Managed pane-first Pi/Claude protocol-19/current launch, no-provider boundary, and anchorless managed tabs that converge to exactly one harness pane (historical filename). |
 | `17-configured-p17-runner.sh` | Unmanaged protocol-19/current configured-command `pane run` bridge and exact argv/env evidence (historical filename). |
 | `18-nullable-clear.sh` | Nullable clearing, merged validation, atomic rejection, and post-clear configured dispatch; no prompt-body logging. |
@@ -183,13 +185,15 @@ personal Claude state. Its intended contract is one authorized attempt with no r
 | `28-pi-effort-catalog.sh` | Auth-scoped Pi file discovery plus exact board-RPC and real-TUI proof of sparse/null thinking-level semantics; never starts Pi or submits a card. |
 | `29-diagnostic-logs.sh` | Daily NDJSON validity, private modes, exact 30-day retention boundary, board/Herdr completion metadata, sentinel absence, and exact cleanup. |
 | `30-pane-reuse.sh` | Non-fresh auto-chain pane reuse: one managed agent pane + one conversation across resume hops (no second `pane.split`/`agent.start`), anchorless managed tab with exactly one harness pane, fresh column still mints, manual landing keeps the pane open; checked-in fake `pi`. |
+| `31-managed-codex.sh` | Managed Codex protocol-19/current launch: self-minted thread capture from `agent.get.agent_session` (mint persists NULL at enqueue and the captured id atomically at promotion), ONE delimited system+task `agent.prompt` block on mint, `codex fork <id>` on retry with the new thread replacing the source id, same-pane/task-only reuse across a non-fresh hop, `codex resume <id>` rescue without re-sending the task (runs row byte-for-byte unchanged), fail-closed missing-report rescue (no session report → mint completes NULL, rescue refused with an actionable diagnostic), and anchorless managed tabs that converge to exactly one Codex pane; checked-in fake `codex`, zero provider cost. |
 | `real-pi-smoke.sh` | Fail-closed real-provider poem smoke. Detects Pi's runtime default model (`E2E_REAL_PI_MODEL` overrides it, validated in `pi --list-models`), passes `E2E_REAL_PI_EFFORT` (default `low`) as the thinking level consistently in card create + evidence, and `E2E_REAL_PI_NEW_WORKSPACE=1` switches to a daemon-created `new_workspace` space (discovered for cleanup; final structure is exactly one `card-<id>` tab with one Pi harness pane and no anchor/unused tab). Isolates board/Pi session output under `/tmp`, verifies the current Pi integration v8/WezTerm, poem/comments/argv/git/settings, and supports keep mode for visual audit. Not in `run-all.sh`. |
 | `real-claude-haiku-smoke.sh` | Fail-closed intended-contract smoke. Requires exact opt-in, authorizes one Claude Haiku/low attempt with no retry/fallback, stages only completed onboarding/theme, exact workspace trust, the installed current Claude integration v7 hook, credentials, and approved remote-settings bytes under `/tmp` so startup dialogs cannot consume `agent.prompt`; no broad personal Claude state is copied. Independently identity-gates the daemon and Herdr server and cleans exact resources. Not in `run-all.sh`. |
+| `real-codex-smoke.sh` | Fail-closed real-provider smoke. Requires exact opt-in (`E2E_REAL_CODEX=1`), authorizes one low-effort Codex attempt with no retry/fallback, stages only codex auth, config, and the installed current Herdr agent-state hook under a disposable `CODEX_HOME` so startup dialogs cannot consume `agent.prompt`; no broad personal Codex state is copied. Preflights the current Codex Herdr integration and staged login status, asserts the captured thread id (`agent_session` kind `id`), exact startup argv (no prompt text, `model_reasoning_effort=low`), the marker file bytes, the agent comment, and exactly one run; independently identity-gates the daemon and Herdr server and cleans exact resources. Linux-only `/proc` identity, outside the portable provider-free gate. Not in `run-all.sh`. |
 | `hrpc.py` | One-shot raw **herdr** socket RPC (honours `HERDR_SOCKET_PATH`) for structural asserts (`tab.list`/`pane.list`/`pane.layout`). |
 | `12-cwd-boards.sh` | Scoped board identity/isolation plus real TUI title/picker. |
 | `13-jump-to-pane.sh` | Canonical CLI and same-session TUI focus of a deliberately selected run through a real plugin overlay. |
 | `NN-*.sh` | The scenarios above. |
-| `run-all.sh` | Builds once, runs scenarios 01–30 as environment-scrubbed children with their own sessions, captures artifacts, and prints the summary (`--require-all` forbids skips). |
+| `run-all.sh` | Builds once, runs scenarios 01–31 as environment-scrubbed children with their own sessions, captures artifacts, and prints the summary (`--require-all` forbids skips). |
 | `ci.sh` | Pins, caches, and verifies Herdr for Linux x86_64; runs the complete suite with `--require-all`; exports only its exact private artifact root to `e2e-artifacts/`. |
 
 Columns have no `board` CLI verb, so scenarios configure them over the boardd

--- a/e2e/fake-bin/codex
+++ b/e2e/fake-bin/codex
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Hermetic, no-provider Codex stand-in for protocol-19 managed launches.
+# Codex mints its own thread/session id, has no system-prompt file, and carries
+# no prompt text in startup argv: the card task (Mint: system_prompt + task
+# block; resume/fork: task only) must arrive through the interactive terminal
+# via Herdr's agent.prompt AFTER the integration reported session identity +
+# idle readiness. This fixture pins that contract (mirror of
+# crates/board-core/tests/harness_codex.rs C3/C6):
+#   Mint   codex [--model M] [-c model_reasoning_effort=E]
+#                [approval preset]                                  (no id!)
+#   Resume codex ... resume <thread-id>       (subcommand, LAST two argv)
+#   Fork   codex ... fork <thread-id>         (subcommand, LAST two argv)
+#   -c model_reasoning_effort: board `off` maps to `none`; the other levels
+#     keep their spelling (minimal|low|medium|high|xhigh|max); `off`/`ultra`
+#     and any other -c key are rejected (the prompt must never ride -c).
+#   Approval presets (board-facing ids, each with an exact CLI spelling):
+#     ask-for-approval -> --sandbox workspace-write --ask-for-approval on-request
+#     approve-for-me   -> --approve-for-me
+#     full-access      -> --dangerously-bypass-approvals-and-sandbox
+#     The old codex-internal ids untrusted/on-request/never are rejected.
+#   --session-id/--resume/--fork flags, --append-system-prompt*, and `--` are
+#     invalid for codex: resume/fork are subcommands, mint has no session flag,
+#     and there is no system-prompt file equivalent.
+# The minted thread id is deterministic and stable so scenario 31 can predict
+# it: "${FAKE_CODEX_THREAD_ID:-codex-thread-$BOARD_CARD_ID}-$RUN_LABEL"
+# (FAKE_CODEX_THREAD_ID is an optional base; fork/mint always append the run
+# label, so two mints never collide). Resume reuses the argv id verbatim.
+# The thread id is reported to Herdr via pane.report_agent_session
+# (--agent-session-id) exactly like the real Codex integration reports
+# AgentInfo.agent_session; the daemon's post-launch agent.get capture (C4/C5)
+# reads it back. `board comment`/`done` run only after the terminal shim
+# verified agent.prompt bytes equal the committed run's prompt_snapshot.
+set -euo pipefail
+
+: "${BOARD_CARD_ID:?BOARD_CARD_ID required}"
+: "${BOARD_SOCKET:?BOARD_SOCKET required}"
+: "${HERDR_SOCKET_PATH:?HERDR_SOCKET_PATH required}"
+
+# A *rescued* pane never receives BOARD_RUN_ID (the actor credential): it may
+# not write to the immutable historical run row. The inert BOARD_RESCUED_RUN_ID
+# label names its artifacts instead, and rescue must re-attach to the recorded
+# thread (`resume <id>`) — minting a new thread on rescue would break the
+# byte-for-byte runs-row guarantee.
+if [ "${BOARD_RESCUE:-0}" = "1" ]; then
+  [ -z "${BOARD_RUN_ID:-}" ] \
+    || { echo 'fake codex: a rescued pane must NOT receive BOARD_RUN_ID' >&2; exit 2; }
+  : "${BOARD_RESCUED_RUN_ID:?BOARD_RESCUED_RUN_ID required on a rescued pane}"
+  RUN_LABEL="$BOARD_RESCUED_RUN_ID"
+else
+  : "${BOARD_RUN_ID:?BOARD_RUN_ID required}"
+  RUN_LABEL="$BOARD_RUN_ID"
+fi
+
+argv=("$@")
+model=""; effort=""; permission=""; sandbox=""
+sub=""; sub_id=""
+while (($#)); do
+  case "$1" in
+    --model|-m)
+      (($# >= 2)) || { echo 'fake codex: --model missing value' >&2; exit 2; }
+      [ -z "$model" ] || { echo 'fake codex: duplicate --model' >&2; exit 2; }
+      model="$2"; shift 2 ;;
+    -c)
+      (($# >= 2)) || { echo 'fake codex: -c missing value' >&2; exit 2; }
+      case "$2" in
+        model_reasoning_effort=none|model_reasoning_effort=minimal|model_reasoning_effort=low|model_reasoning_effort=medium|model_reasoning_effort=high|model_reasoning_effort=xhigh|model_reasoning_effort=max)
+          effort="${2#model_reasoning_effort=}" ;;
+        model_reasoning_effort=*)
+          echo "fake codex: board effort must map off->none (got: $2)" >&2; exit 2 ;;
+        *)
+          echo "fake codex: unexpected -c config; the prompt must never ride -c: $2" >&2; exit 2 ;;
+      esac
+      shift 2 ;;
+    --ask-for-approval|-a)
+      # Only the on-request policy may ride this flag — the board-facing
+      # `ask-for-approval` preset spells it explicitly. The codex-internal
+      # ids `untrusted`/`never` are no longer board vocabulary.
+      (($# >= 2)) || { echo 'fake codex: --ask-for-approval missing value' >&2; exit 2; }
+      [ "$2" = "on-request" ] || {
+        echo "fake codex: --ask-for-approval accepts only on-request (the ask-for-approval preset): $2" >&2; exit 2; }
+      [ -z "$permission" ] || { echo 'fake codex: duplicate approval preset' >&2; exit 2; }
+      permission="ask-for-approval"; shift 2 ;;
+    --approve-for-me)
+      [ -z "$permission" ] || { echo 'fake codex: duplicate approval preset' >&2; exit 2; }
+      permission="approve-for-me"; shift 1 ;;
+    --dangerously-bypass-approvals-and-sandbox)
+      [ -z "$permission" ] || { echo 'fake codex: duplicate approval preset' >&2; exit 2; }
+      permission="full-access"; shift 1 ;;
+    --sandbox)
+      # Sandbox is a separate dimension: the board spells it explicitly ONLY
+      # for the ask-for-approval preset, and only as workspace-write. A
+      # user-config --sandbox on a configured launch is still recorded.
+      (($# >= 2)) || { echo 'fake codex: --sandbox missing value' >&2; exit 2; }
+      [ -z "$sandbox" ] || { echo 'fake codex: duplicate --sandbox' >&2; exit 2; }
+      sandbox="$2"; shift 2 ;;
+    --session-id|--resume|--fork|--append-system-prompt|--append-system-prompt-file|--)
+      echo "fake codex: invalid protocol-19 startup option: $1" >&2; exit 2 ;;
+    resume|fork)
+      # Subcommands are the session flags and MUST close the argv: nothing may
+      # follow the thread id (in particular no task text).
+      (($# == 2)) || { echo "fake codex: '$1 <id>' must be the last two argv entries" >&2; exit 2; }
+      [ -z "$sub" ] || { echo 'fake codex: duplicate subcommand' >&2; exit 2; }
+      [ -n "$2" ] || { echo "fake codex: '$1' needs a non-empty thread id" >&2; exit 2; }
+      case "$2" in
+        *[!A-Za-z0-9._:-]*) echo "fake codex: suspicious '$1' thread id (leaked prompt?): $2" >&2; exit 2 ;;
+      esac
+      sub="$1"; sub_id="$2"; shift 2 ;;
+    -*) echo "fake codex: unexpected startup option: $1" >&2; exit 2 ;;
+    *) echo "fake codex: card prompt leaked into startup argv: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Preset/pair consistency: the ask-for-approval preset REQUIRES the
+# explicit workspace-write sandbox; the other presets never carry --sandbox.
+case "$permission" in
+  ask-for-approval)
+    [ "$sandbox" = "workspace-write" ] \
+      || { echo 'fake codex: ask-for-approval must pair with --sandbox workspace-write' >&2; exit 2; } ;;
+  approve-for-me|full-access)
+    [ -z "$sandbox" ] || { echo "fake codex: $permission never carries --sandbox" >&2; exit 2; } ;;
+esac
+
+mode="mint"; resume_id=""; fork_id=""
+case "$sub" in
+  "")    mode="mint" ;;
+  resume) mode="resume"; resume_id="$sub_id" ;;
+  fork)  mode="fork";  fork_id="$sub_id" ;;
+esac
+
+# A rescued pane must re-attach to the recorded thread, and the daemon's
+# BOARD_RESUME_SESSION_ID must name exactly the id in `resume <id>`.
+if [ "${BOARD_RESCUE:-0}" = "1" ]; then
+  [ "$mode" = "resume" ] \
+    || { echo "fake codex: a rescued pane must resume, not $mode" >&2; exit 2; }
+  : "${BOARD_RESUME_SESSION_ID:?BOARD_RESUME_SESSION_ID required on a rescued pane}"
+  [ "$BOARD_RESUME_SESSION_ID" = "$resume_id" ] \
+    || { echo "fake codex: resume id '$BOARD_RESUME_SESSION_ID' != argv 'resume $resume_id'" >&2; exit 2; }
+fi
+
+# Mint/fork create a NEW thread (codex mints its own id; the board must never
+# invent one). Deterministic + stable: scenario 31 can predict the id from the
+# card and run ids, or pin a base with FAKE_CODEX_THREAD_ID.
+if [ "$mode" = "resume" ]; then
+  thread_id="$resume_id"
+else
+  thread_id="${FAKE_CODEX_THREAD_ID:-codex-thread-$BOARD_CARD_ID}-$RUN_LABEL"
+fi
+
+suffix=""
+if [ "${BOARD_RESCUE:-0}" = "1" ]; then
+  suffix="-rescue"
+fi
+record="$(dirname "$BOARD_SOCKET")/fake-codex-run-$RUN_LABEL$suffix.json"
+python3 - "$record" "$RUN_LABEL" "$PWD" "$BOARD_CARD_ID" "$BOARD_SOCKET" \
+  "$HERDR_SOCKET_PATH" "$mode" "$model" "$effort" "$permission" "$sandbox" \
+  "$thread_id" "$resume_id" "$fork_id" "${BOARD_RESCUE:-0}" "${argv[@]}" <<'PY'
+import json, sys
+(path, run_id, cwd, card_id, board_socket, herdr_socket, mode, model, effort,
+ permission, sandbox, thread_id, resume_id, fork_id, rescue, *argv) = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as target:
+    json.dump({
+        "run_id": int(run_id), "card_id": int(card_id), "cwd": cwd,
+        "board_socket": board_socket, "herdr_socket": herdr_socket,
+        "mode": mode, "model": model or None,
+        "effort": effort or None, "permission_mode": permission or None,
+        "sandbox": sandbox or None,
+        "thread_id": thread_id,
+        "resume_id": resume_id or None, "fork_id": fork_id or None,
+        "argv": argv,
+        "system_prompt_file": None,
+        "startup_argv_has_no_prompt": True,
+        "rescue": rescue == "1",
+    }, target, ensure_ascii=False, indent=2)
+    target.write("\n")
+PY
+
+# Mirror the real Codex integration startup ordering: establish a unique
+# transcript path, emit the terminal identity surface, report the minted
+# thread id (AgentInfo.agent_session) + idle lifecycle, and only then let Herdr
+# deliver agent.prompt. No fixture path calls board done early.
+#
+# Opt-in degraded-integration mode: report ONLY the idle lifecycle, never a
+# session identity, so Herdr's agent.get carries no agent_session and the
+# daemon's bounded capture (C5) degrades — the basic mint still completes,
+# but the run persists NULL and rescue must fail closed. Scenario 31 pins
+# that contract; the record's `reports` proves no session report ran.
+#
+# The managed pane's env is the daemon's launch env (a split pane does not
+# inherit the workspace env), so a scenario-level export cannot reach this
+# process. The fixture therefore also honors the documented per-run sentinel:
+# a --model value of exactly `no-session` (codex models are free-form).
+if [ "${FAKE_CODEX_NO_SESSION:-0}" != "1" ] && [ "$model" != "no-session" ]; then
+  FAKE_CODEX_NO_SESSION=0
+else
+  FAKE_CODEX_NO_SESSION=1
+fi
+# The degraded no-session mode skips the transcript and the identity report
+# entirely: there is no session evidence to hand out.
+session_dir="$(dirname "$BOARD_SOCKET")/fake-codex-sessions"
+mkdir -p "$session_dir"
+# Unique per process: a run can be reopened more than once (each reopen is a
+# fresh launch), and the exclusive-create below must keep catching a genuine
+# double-launch of the SAME process rather than failing a legitimate retry.
+session_path="$session_dir/${thread_id}-${RUN_LABEL}${suffix}-$$.jsonl"
+if [ "${FAKE_CODEX_NO_SESSION:-0}" != "1" ]; then
+python3 - "$session_path" "$thread_id" "$RUN_LABEL" <<'PY'
+import json, os, sys
+path, thread_id, run_id = sys.argv[1:]
+with open(path, "x", encoding="utf-8") as target:
+    json.dump({"type": "session", "thread_id": thread_id, "run_id": int(run_id)}, target)
+    target.write("\n")
+os.chmod(path, 0o600)
+PY
+fi
+printf '\033]0;Codex\007'
+printf '\n──────────────────────────────────────────────────────\n❯ \n──────────────────────────────────────────────────────\n'
+if [ "${FAKE_CODEX_NO_SESSION:-0}" = "1" ]; then
+  # report ONLY the idle lifecycle (comment above explains the per-run
+  # sentinel: env cannot cross into the daemon's split-pane launch env).
+  python3 - "$record" "$thread_id" "$RUN_LABEL" <<'PY'
+import json, os, socket, sys, time
+record_path, thread_id, run_id = sys.argv[1:]
+pane_id = os.environ.get("HERDR_PANE_ID", "")
+socket_path = os.environ.get("HERDR_SOCKET_PATH", "")
+envelope = {
+    "id": f"e2e:herdr:codex:{os.getpid()}:idle",
+    "method": "pane.report_agent",
+    "params": {
+        "pane_id": pane_id,
+        "source": "herdr:codex",
+        "agent": "codex",
+        "seq": time.time_ns(),
+        "state": "idle",
+    },
+}
+result = {"phase": "idle_lifecycle", "request": envelope}
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(2.0)
+    client.connect(socket_path)
+    client.sendall((json.dumps(envelope, separators=(",", ":")) + "\n").encode())
+    chunks = bytearray()
+    while b"\n" not in chunks:
+        chunk = client.recv(65536)
+        if not chunk:
+            break
+        chunks.extend(chunk)
+    client.close()
+    reply = json.loads(bytes(chunks).splitlines()[0])
+    result["reply"] = reply
+    result["ok"] = "result" in reply and "error" not in reply
+except Exception as error:
+    result["ok"] = False
+    result["error"] = f"{type(error).__name__}: {error}"
+with open(record_path, encoding="utf-8") as source:
+    record = json.load(source)
+record.update({
+    "herdr_pane_id": pane_id,
+    "report_socket": socket_path,
+    "agent_session_id": None,
+    "agent_session_path": None,
+    "session_start_source": None,
+    "thread_id": thread_id,
+    "reports": [result],
+    "readiness_report": "ok" if result["ok"] else "failed:idle_lifecycle",
+    "no_session_report": True,
+})
+with open(record_path, "w", encoding="utf-8") as target:
+    json.dump(record, target, ensure_ascii=False, indent=2)
+    target.write("\n")
+if not result["ok"]:
+    print(f"fake codex: idle lifecycle report failed: {result}", file=sys.stderr)
+    raise SystemExit(2)
+PY
+else
+  python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/managed-agent-report.py" \
+    "$record" codex "$thread_id" "$session_path" startup
+fi
+
+# A rescued pane resumes an existing conversation, so the daemon deliberately
+# sends NO agent.prompt (re-sending the card task would re-run it). Skip the
+# prompt shim entirely and just stay interactive, which is what a resumed
+# session looks like.
+if [ "${BOARD_RESCUE:-0}" = "1" ]; then
+  sleep "${FAKE_MANAGED_HOLD:-60}"
+  exit 0
+fi
+
+# Spawn registration commits only after readiness polling + agent.prompt
+# return. A same-conversation reuse hop re-prompts this SAME process on its
+# pane (no new agent.start), so the fixture loops: read one stage's prompt,
+# comment, done, then block on the next prompt. FAKE_PI_LOOP is the channel
+# lib.sh already forwards to managed workspaces; FAKE_CODEX_LOOP is the
+# canonical name once plumbing exists.
+loop=0
+[ "${FAKE_CODEX_LOOP:-0}" = "1" ] && loop=1
+[ "${FAKE_PI_LOOP:-0}" = "1" ] && loop=1
+trace=""
+if [ "$loop" = "1" ]; then
+  trace="$(dirname "$BOARD_SOCKET")/fake-codex-loop-$RUN_LABEL.log"
+  printf 'pid=%s loop=1 pane=%s record=%s\n' "$$" "${HERDR_PANE_ID:-<unset>}" "$record" >>"$trace"
+fi
+
+run_one_codex_stage() {
+  [ -z "$trace" ] || printf 'stage: shim start\n' >>"$trace"
+  FAKE_MANAGED_KIND=codex FAKE_PI_LOOP="$loop" \
+    python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/managed-terminal-shim.py" "$record" || {
+      rc=$?
+      if [ -n "$trace" ]; then
+        printf 'stage: shim fail rc=%s\n' "$rc" >>"$trace"
+        python3 - "$record" >>"$trace" <<'PY' || true
+import hashlib, json, sys
+try:
+    x=json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception as e:
+    print(f"record_error={type(e).__name__}")
+else:
+    for key in ("prompt_error", "prompt_received_via_stdin", "prompt_matches_run_snapshot"):
+        print(f"{key}={x.get(key)!r}")
+    for key in ("prompt", "expected_prompt"):
+        value=(x.get(key) or "").encode()
+        print(f"{key}_len={len(value)} {key}_sha256={hashlib.sha256(value).hexdigest()}")
+PY
+      fi
+      return "$rc"
+    }
+  [ -z "$trace" ] || printf 'stage: shim ok\n' >>"$trace"
+  sleep "${FAKE_CODEX_SLEEP:-${FAKE_PI_SLEEP:-1.5}}"
+  "${BOARD_BIN:?BOARD_BIN required}" comment "fake codex: agent.prompt delivered the card task; no system-prompt file in argv" || {
+    rc=$?; [ -z "$trace" ] || printf 'stage: comment fail rc=%s\n' "$rc" >>"$trace"; return "$rc"
+  }
+  [ -z "$trace" ] || printf 'stage: comment ok\n' >>"$trace"
+  "$BOARD_BIN" done --outcome ok || {
+    rc=$?; [ -z "$trace" ] || printf 'stage: done fail rc=%s\n' "$rc" >>"$trace"; return "$rc"
+  }
+  [ -z "$trace" ] || printf 'stage: done ok\n' >>"$trace"
+}
+
+if [ "$loop" = "1" ]; then
+  while true; do
+    run_one_codex_stage
+  done
+else
+  run_one_codex_stage
+  sleep "${FAKE_MANAGED_HOLD:-60}"
+fi

--- a/e2e/fake-bin/managed-terminal-shim.py
+++ b/e2e/fake-bin/managed-terminal-shim.py
@@ -107,7 +107,11 @@ def main() -> int:
     # not treat the marker itself as proof: it requires bytes delivered here.
     print("HERDR_FAKE_MANAGED_INTERACTIVE_READY", flush=True)
     try:
-        tty.setraw(fd)
+        # TCSADRAIN (not the tty.setraw default TCSAFLUSH): a second prompt can
+        # arrive while this shim is still starting (the daemon's reuse hop races
+        # the loop's next shim), and TCSAFLUSH would DISCARD those pending bytes
+        # before select ever sees them. Draining output only keeps the queue.
+        tty.setraw(fd, when=termios.TCSADRAIN)
         if multi_turn:
             try:
                 # A real managed client is only idle once its input loop is
@@ -136,10 +140,11 @@ def main() -> int:
             if not data:
                 break
             saw_transport_bytes = True
+            prompt_raw = bytes(data)
             try:
-                candidate = normalize_terminal_prompt(bytes(data))
+                candidate = normalize_terminal_prompt(prompt_raw)
             except UnicodeDecodeError as error:
-                update(record_path, prompt_raw_hex=bytes(data).hex(), prompt_error=str(error))
+                update(record_path, prompt_raw_hex=prompt_raw.hex(), prompt_error=str(error))
                 print(f"managed terminal shim: prompt was not UTF-8: {error}", file=sys.stderr)
                 return 2
             # A subsequent turn can begin with a residual Enter/framing batch
@@ -147,7 +152,6 @@ def main() -> int:
             # keep waiting for this turn's substantive agent.prompt payload.
             if candidate:
                 prompt = candidate
-                prompt_raw = bytes(data)
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_attributes)
 
@@ -157,7 +161,10 @@ def main() -> int:
             if saw_transport_bytes
             else f"no agent.prompt bytes within {timeout:g}s"
         )
-        update(record_path, prompt_error=reason)
+        fields: dict[str, object] = {"prompt_error": reason}
+        if saw_transport_bytes:
+            fields["prompt_raw_hex"] = prompt_raw.hex()
+        update(record_path, **fields)
         print(f"managed terminal shim: {reason}", file=sys.stderr)
         return 2
 
@@ -215,12 +222,28 @@ def main() -> int:
         update(record_path, prompt_error="run prompt_snapshot was not committed within 10s")
         print("managed terminal shim: authoritative run prompt unavailable", file=sys.stderr)
         return 2
-    if prompt != expected:
-        update(record_path, expected_prompt=expected, prompt_error="agent.prompt did not match run snapshot")
-        print("managed terminal shim: agent.prompt did not match run snapshot", file=sys.stderr)
-        return 2
-    update(record_path, prompt_matches_run_snapshot=True)
-    return 0
+    if prompt == expected:
+        update(record_path, prompt_matches_run_snapshot=True)
+        return 0
+    # A codex Mint receives ONE delimited block: `## herdr-board system
+    # instructions` + non-empty system text + `## herdr-board card task` + the
+    # exact run snapshot. The system half is private DB state (never exposed
+    # by `card show`), so the fixture pins the block structure and the exact
+    # task half here, records the system half verbatim, and the scenario
+    # reconstructs the full block from its own sources. Resume, fork, and
+    # same-pane reuse deliver the task alone and matched above.
+    mint_block = None
+    if os.environ.get("FAKE_MANAGED_KIND", "pi") == "codex":
+        prefix = "## herdr-board system instructions\n"
+        task_delim = "\n\n## herdr-board card task\n"
+        if prompt.startswith(prefix) and task_delim in prompt[len(prefix):]:
+            system_half = prompt[len(prefix):].split(task_delim, 1)[0]
+            if system_half and prompt == prefix + system_half + task_delim + expected:
+                update(record_path, prompt_matches_mint_block=True, mint_system_half=system_half)
+                return 0
+    update(record_path, expected_prompt=expected, prompt_error="agent.prompt did not match run snapshot")
+    print("managed terminal shim: agent.prompt did not match run snapshot", file=sys.stderr)
+    return 2
 
 
 if __name__ == "__main__":

--- a/e2e/real-codex-smoke.sh
+++ b/e2e/real-codex-smoke.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+# Opt-in, fail-closed REAL Codex smoke. Intentionally not in run-all.sh.
+#
+# One authorized attempt with the real Codex CLI through the real Herdr codex
+# integration: no retry, no fallback. It stages ONLY the codex auth, config,
+# and the installed current Herdr agent-state hook under a disposable CODEX_HOME
+# so startup dialogs cannot consume `agent.prompt`; no broad personal Codex
+# state is copied. The independent /proc identity implementation is Linux-only
+# and outside the portable provider-free gate (same design as
+# real-claude-haiku-smoke.sh).
+set -euo pipefail
+umask 077
+
+if [ "${E2E_REAL_CODEX:-}" != "1" ]; then
+  echo "real-codex-smoke: refusing real provider call; set E2E_REAL_CODEX=1 exactly" >&2
+  exit 2
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd -P)"
+RUN_ID="$$"
+SESSION="hb-codex-$RUN_ID"
+EVIDENCE="/tmp/herdr-board-real-codex-evidence-$RUN_ID"
+TMP=""
+WORKSPACE_DIR=""
+STAGED_CODEX_HOME=""
+DB=""
+SOCKET=""
+CONFIG=""
+TARGET=""
+BOARD_BIN=""
+CODEX_BIN=""
+HERDR_BIN="${HERDR_BIN_PATH:-herdr}"
+CARGO_BIN=""
+REAL_CODEX_DIR="${CODEX_HOME:-$HOME/.codex}"
+REAL_AUTH=""
+REAL_CONFIG=""
+REAL_HOOK=""
+REAL_HASHES_BEFORE=""
+BASE_STATUS=""
+SERVER_PID=""
+SERVER_IDENTITY=""
+DAEMON_PID=""
+DAEMON_IDENTITY=""
+SESSION_STARTED=0
+WS_ID=""
+CARD_ID=""
+RESULT_FILE=""
+MARKER="HERDR_BOARD_REAL_CODEX_OK"
+TASK=""
+RUN_SUCCEEDED=0
+LAST_ERROR="preflight did not complete"
+
+mkdir -m 700 "$EVIDENCE"
+printf 'RUNNING\n' >"$EVIDENCE/result.txt"
+
+# --- exact Linux /proc identity (independent implementation, like the
+# --- real-Claude smoke; documented as Linux-only) ---------------------------
+e2e_process_identity_capture() {
+  local pid="$1" session="$2" name="$3" expected_command="${4:-}"
+  [ -r "/proc/$pid/stat" ] && [ -r "/proc/$pid/cmdline" ] && [ -L "/proc/$pid/exe" ] || return 1
+  python3 - "$pid" "$session" "$name" "$expected_command" <<'PY'
+import json, os, sys
+pid, session, name, expected_command = sys.argv[1:]
+try:
+    stat = open(f"/proc/{pid}/stat", encoding="utf-8").read()
+    start_time = stat[stat.rfind(")") + 2:].split()[19]
+    exe = os.readlink(f"/proc/{pid}/exe")
+    argv = [part.decode("utf-8", "surrogateescape")
+            for part in open(f"/proc/{pid}/cmdline", "rb").read().split(b"\0") if part]
+except (IndexError, OSError, UnicodeError):
+    raise SystemExit(1)
+if (session not in argv or name not in argv
+        or (expected_command and expected_command not in argv[:2])):
+    raise SystemExit(1)
+print(json.dumps({"pid": pid, "start_time": start_time, "exe": exe,
+                  "session": session, "name": name, "cmdline": argv},
+                 sort_keys=True, ensure_ascii=True, separators=(",", ":")))
+PY
+}
+
+e2e_process_identity_verify() {
+  local pid="$1" token="$2"
+  [ -n "$token" ] && [ -r "/proc/$pid/stat" ] && [ -r "/proc/$pid/cmdline" ] && [ -L "/proc/$pid/exe" ] || return 1
+  python3 - "$pid" "$token" <<'PY'
+import json, os, sys
+pid, token = sys.argv[1:]
+try:
+    recorded = json.loads(token)
+    required = {"pid", "start_time", "exe", "session", "name", "cmdline"}
+    if set(recorded) != required or recorded["pid"] != pid:
+        raise ValueError("invalid identity token")
+    if not all(isinstance(recorded[key], str) for key in required - {"cmdline"}):
+        raise ValueError("invalid identity fields")
+    if not isinstance(recorded["cmdline"], list) or not all(isinstance(v, str) for v in recorded["cmdline"]):
+        raise ValueError("invalid argv")
+    stat = open(f"/proc/{pid}/stat", encoding="utf-8").read()
+    start_time = stat[stat.rfind(")") + 2:].split()[19]
+    exe = os.readlink(f"/proc/{pid}/exe")
+    argv = [part.decode("utf-8", "surrogateescape")
+            for part in open(f"/proc/{pid}/cmdline", "rb").read().split(b"\0") if part]
+    if (start_time != recorded["start_time"] or exe != recorded["exe"]
+            or argv != recorded["cmdline"]
+            or recorded["session"] not in argv or recorded["name"] not in argv):
+        raise ValueError("identity changed")
+except (IndexError, OSError, UnicodeError, ValueError, TypeError, json.JSONDecodeError):
+    raise SystemExit(1)
+PY
+}
+
+hash_real_files() {
+  python3 - "$REAL_AUTH" "$REAL_CONFIG" "$REAL_HOOK" <<'PY'
+import hashlib, json, pathlib, sys
+out = {}
+for raw in sys.argv[1:]:
+    path = pathlib.Path(raw)
+    h = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(chunk)
+    out[str(path)] = h.hexdigest()
+print(json.dumps(out, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+write_state() {
+  [ -n "$TMP" ] || return 0
+  {
+    printf 'SESSION=%q\n' "$SESSION"
+    printf 'TMP=%q\n' "$TMP"
+    printf 'EVIDENCE=%q\n' "$EVIDENCE"
+    printf 'WORKSPACE_DIR=%q\n' "$WORKSPACE_DIR"
+    printf 'BOARD_BIN=%q\n' "$BOARD_BIN"
+    printf 'BOARD_DB=%q\n' "$DB"
+    printf 'BOARD_SOCKET=%q\n' "$SOCKET"
+    printf 'HERDR_BOARD_CONFIG=%q\n' "$CONFIG"
+    printf 'HERDR_SOCKET_PATH=%q\n' "${SOCK:-}"
+    printf 'SESSION_PID=%q\n' "$SERVER_PID"
+    printf 'SERVER_IDENTITY=%q\n' "$SERVER_IDENTITY"
+    printf 'DAEMON_PID=%q\n' "$DAEMON_PID"
+    printf 'DAEMON_IDENTITY=%q\n' "$DAEMON_IDENTITY"
+    printf 'WS_ID=%q\n' "$WS_ID"
+    printf 'CARD_ID=%q\n' "$CARD_ID"
+  } >"$STATE"
+  chmod 600 "$STATE"
+}
+
+fail() {
+  LAST_ERROR="$*"
+  printf 'real-codex-smoke: %s\n' "$*" >&2
+  exit 1
+}
+
+capture_runtime_evidence() {
+  local pane_id=""
+  if [ -n "$CARD_ID" ] && [ -x "$BOARD_BIN" ]; then
+    "$BOARD_BIN" card show "$CARD_ID" --json >"$EVIDENCE/card-final.json" 2>/dev/null || true
+  fi
+  if [ -n "${SOCK:-}" ] && [ -S "${SOCK:-}" ]; then
+    HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" api snapshot >"$EVIDENCE/herdr-snapshot.json" 2>/dev/null || true
+    if [ -s "$EVIDENCE/card-final.json" ]; then
+      pane_id="$(jq -r '.runs[-1].herdr_pane_id // empty' "$EVIDENCE/card-final.json" 2>/dev/null)"
+      if [ -n "$pane_id" ]; then
+        HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" pane read "$pane_id" \
+          --source recent-unwrapped --lines 200 --format text \
+          >"$EVIDENCE/pane-final.txt" 2>"$EVIDENCE/pane-final.err" || true
+      fi
+    fi
+  fi
+  [ -z "$TMP" ] || [ ! -f "$TMP/daemon.log" ] || cp "$TMP/daemon.log" "$EVIDENCE/daemon.log"
+  [ -z "$TMP" ] || [ ! -f "$TMP/herdr-server.log" ] || cp "$TMP/herdr-server.log" "$EVIDENCE/herdr-server.log"
+}
+
+cleanup() {
+  local incoming_rc=$? final_rc cleanup_error="" final_status="" hashes_after=""
+  trap - EXIT ERR INT TERM
+  set +e
+
+  capture_runtime_evidence
+
+  local server_identity_ok=0
+  if ! e2e_process_identity_verify "$SERVER_PID" "$SERVER_IDENTITY"; then
+    cleanup_error+="server_identity_mismatch;"
+  else
+    server_identity_ok=1
+    if [ -n "$WS_ID" ] && [ -n "${SOCK:-}" ]; then
+      printf 'HERDR MUTATION: close disposable workspace %s on recorded socket\n' "$WS_ID"
+      HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" workspace close "$WS_ID" >/dev/null 2>&1 \
+        || cleanup_error+="workspace_close_failed;"
+    fi
+  fi
+
+  if [ -n "$DAEMON_PID" ]; then
+    if e2e_process_identity_verify "$DAEMON_PID" "$DAEMON_IDENTITY"; then
+      kill "$DAEMON_PID" 2>/dev/null || cleanup_error+="daemon_kill_failed;"
+      wait "$DAEMON_PID" 2>/dev/null || true
+    else
+      cleanup_error+="daemon_identity_mismatch;"
+    fi
+  fi
+
+  if [ "$server_identity_ok" = 1 ] && [ "$SESSION_STARTED" = 1 ]; then
+    printf 'HERDR MUTATION: stop/delete disposable session %s\n' "$SESSION"
+    "$HERDR_BIN" session stop "$SESSION" >/dev/null 2>&1 || cleanup_error+="session_stop_failed;"
+    "$HERDR_BIN" session delete "$SESSION" >/dev/null 2>&1 || cleanup_error+="session_delete_failed;"
+  fi
+  if [ "$server_identity_ok" = 1 ] && [ -n "$SERVER_PID" ] \
+      && e2e_process_identity_verify "$SERVER_PID" "$SERVER_IDENTITY"; then
+    kill "$SERVER_PID" 2>/dev/null || cleanup_error+="server_kill_failed;"
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+
+  [ -z "$TMP" ] || rm -rf -- "$TMP"
+  [ -z "${STATE:-}" ] || rm -f -- "$STATE"
+
+  local sessions_json=""
+  if ! sessions_json="$("$HERDR_BIN" session list --json 2>/dev/null)"; then
+    cleanup_error+="session_absence_unverified;"
+  elif ! printf '%s' "$sessions_json" | jq -e '.sessions | type == "array"' >/dev/null 2>&1; then
+    cleanup_error+="session_list_invalid;"
+  elif printf '%s' "$sessions_json" \
+      | jq -e --arg session "$SESSION" '.sessions[]? | select(.name == $session)' >/dev/null 2>&1; then
+    cleanup_error+="session_remains;"
+  fi
+  if [ -n "$TMP" ] && [ -e "$TMP" ]; then cleanup_error+="temp_remains;"; fi
+  if [ -n "${SOCK:-}" ] && [ -e "${SOCK:-}" ]; then cleanup_error+="socket_remains;"; fi
+  [ -z "${STATE:-}" ] || [ ! -e "$STATE" ] || cleanup_error+="state_remains;"
+
+  if [ -n "$BASE_STATUS" ] || [ -d "$ROOT/.git" ]; then
+    if ! final_status="$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
+      cleanup_error+="repo_status_recheck_failed;"
+    else
+      printf '%s\n' "$final_status" >"$EVIDENCE/git-status-after.txt"
+      if [ "$final_status" != "$BASE_STATUS" ]; then cleanup_error+="repo_status_changed;"; fi
+    fi
+  else
+    cleanup_error+="repo_status_baseline_missing;"
+  fi
+  if [ -n "$REAL_HASHES_BEFORE" ] && [ -f "$REAL_AUTH" ] && [ -f "$REAL_CONFIG" ] \
+      && [ -f "$REAL_HOOK" ]; then
+    hashes_after="$(hash_real_files 2>/dev/null)"
+    printf '%s\n' "$hashes_after" | jq . >"$EVIDENCE/real-codex-hashes-after.json" 2>/dev/null
+    if [ "$hashes_after" != "$REAL_HASHES_BEFORE" ]; then cleanup_error+="real_codex_files_changed;"; fi
+  else
+    cleanup_error+="real_codex_hash_recheck_failed;"
+  fi
+
+  if [ "$incoming_rc" -ne 0 ] || [ "$RUN_SUCCEEDED" -ne 1 ] || [ -n "$cleanup_error" ]; then
+    final_rc=1
+    {
+      echo "FAIL"
+      printf 'reason=%s\n' "$LAST_ERROR"
+      printf 'cleanup_errors=%s\n' "${cleanup_error:-none}"
+      printf 'session=%s\n' "$SESSION"
+      printf 'cleanup_verified=%s\n' "$([ -z "$cleanup_error" ] && echo yes || echo no)"
+      printf 'evidence=%s\n' "$EVIDENCE"
+    } >"$EVIDENCE/result.txt"
+    cat "$EVIDENCE/result.txt" >&2
+  else
+    final_rc=0
+    {
+      echo "PASS"
+      printf 'candidate_board=%s\n' "$BOARD_BIN"
+      printf 'session=%s\n' "$SESSION"
+      printf 'card_id=%s\n' "$CARD_ID"
+      printf 'effort=low\n'
+      printf 'exactly_one_run=yes\n'
+      printf 'repo_status_unchanged=yes\n'
+      printf 'real_codex_files_unchanged=yes\n'
+      printf 'cleanup_verified=yes\n'
+      printf 'evidence=%s\n' "$EVIDENCE"
+    } >"$EVIDENCE/result.txt"
+    cat "$EVIDENCE/result.txt"
+  fi
+  exit "$final_rc"
+}
+trap 'LAST_ERROR="command failed at line $LINENO"' ERR
+trap cleanup EXIT
+trap 'LAST_ERROR="interrupted"; exit 130' INT TERM
+
+# --- preflight: tools, real codex, current Herdr codex integration -----------
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+CARGO_BIN="$(command -v cargo || true)"
+[ -n "$CARGO_BIN" ] || fail "cargo is required"
+command -v "$HERDR_BIN" >/dev/null 2>&1 || fail "herdr is required ($HERDR_BIN)"
+CODEX_BIN="$(type -P codex || true)"
+[ -n "$CODEX_BIN" ] || fail "real codex executable not found"
+CODEX_BIN="$(readlink -f -- "$CODEX_BIN")"
+case "$CODEX_BIN" in
+  "$ROOT/e2e/fake-bin/codex"|*/e2e/fake-bin/codex)
+    fail "refusing checked-in e2e fake codex: $CODEX_BIN"
+    ;;
+esac
+if declare -F codex >/dev/null 2>&1; then
+  fail "refusing shell function named codex; a physical real Codex executable is required"
+fi
+
+HERDR_VERSION="$($HERDR_BIN --version 2>&1)"
+[ "$HERDR_VERSION" = "herdr 0.8.0" ] \
+  || fail "requires exactly Herdr 0.8.0 (got: $HERDR_VERSION)"
+HERDR_SCHEMA="$($HERDR_BIN api schema --json)"
+printf '%s' "$HERDR_SCHEMA" | jq -e '.protocol == 19' >/dev/null \
+  || fail "requires Herdr schema protocol 19"
+CODEX_VERSION="$($CODEX_BIN --version 2>&1)"
+INTEGRATION_LINE="$($HERDR_BIN integration status | awk '$1 == "codex:" {print; exit}')"
+printf '%s\n' "$INTEGRATION_LINE" \
+  | grep -Eq '^codex:[[:space:]]+current([[:space:]]+\(.+\))?$' \
+  || fail "Codex Herdr integration must be current (got: ${INTEGRATION_LINE:-missing})"
+
+if "$HERDR_BIN" session list --json | jq -e --arg session "$SESSION" \
+    '.sessions[]? | select(.name == $session)' >/dev/null; then
+  fail "generated session already exists: $SESSION"
+fi
+
+TMP="$(mktemp -d /tmp/hb-codex.XXXXXX)"
+STATE="$TMP/state.env"
+WORKSPACE_DIR="$TMP/workspace"
+STAGED_CODEX_HOME="$TMP/codex-home"
+DB="$TMP/board.db"
+SOCKET="$TMP/board.sock"
+CONFIG="$TMP/config.toml"
+TARGET="$TMP/target"
+RESULT_FILE="$WORKSPACE_DIR/result.txt"
+mkdir -m 700 "$WORKSPACE_DIR" "$STAGED_CODEX_HOME" "$TARGET" "$TMP/zdot"
+WORKSPACE_DIR="$(cd "$WORKSPACE_DIR" && pwd -P)"
+write_state
+
+REAL_AUTH="$REAL_CODEX_DIR/auth.json"
+REAL_CONFIG="$REAL_CODEX_DIR/config.toml"
+REAL_HOOK="$REAL_CODEX_DIR/herdr-agent-state.sh"
+[ -f "$REAL_AUTH" ] || fail "missing real Codex auth: $REAL_AUTH"
+[ -f "$REAL_CONFIG" ] || fail "missing real Codex config: $REAL_CONFIG"
+[ -f "$REAL_HOOK" ] || fail "missing the current Herdr Codex agent-state hook: $REAL_HOOK"
+
+# Stage only the credentials, the config, and the installed current Herdr hook
+# under a disposable CODEX_HOME — no history, models cache, or other personal
+# Codex state crosses the boundary.
+cp "$REAL_AUTH" "$STAGED_CODEX_HOME/auth.json"
+cp "$REAL_CONFIG" "$STAGED_CODEX_HOME/config.toml"
+cp "$REAL_HOOK" "$STAGED_CODEX_HOME/herdr-agent-state.sh"
+chmod 600 "$STAGED_CODEX_HOME/auth.json" "$STAGED_CODEX_HOME/config.toml" \
+  "$STAGED_CODEX_HOME/herdr-agent-state.sh"
+
+BASE_STATUS="$(git -C "$ROOT" status --porcelain=v1 --untracked-files=all)"
+printf '%s\n' "$BASE_STATUS" >"$EVIDENCE/git-status-before.txt"
+REAL_HASHES_BEFORE="$(hash_real_files)"
+printf '%s\n' "$REAL_HASHES_BEFORE" | jq . >"$EVIDENCE/real-codex-hashes-before.json"
+
+# Auth preflight through the staged CODEX_HOME (read-only; no launch yet).
+if ! CODEX_HOME="$STAGED_CODEX_HOME" "$CODEX_BIN" login status >"$TMP/codex-login-status.txt" 2>&1; then
+  fail "staged Codex auth status command failed"
+fi
+grep -qiE 'logged in|Logged in' "$TMP/codex-login-status.txt" \
+  || fail "real Codex auth is not logged in through staged credentials"
+printf 'logged_in=yes\nconfig=staged\n' >"$EVIDENCE/auth-preflight.txt"
+
+{
+  printf 'herdr_version=%s\n' "$HERDR_VERSION"
+  printf 'herdr_schema_protocol=19\n'
+  printf 'codex_version=%s\n' "$CODEX_VERSION"
+  printf 'codex_binary=%s\n' "$CODEX_BIN"
+  printf 'codex_integration=%s\n' "$INTEGRATION_LINE"
+  printf 'codex_hook=%s\n' "$REAL_HOOK"
+  printf 'requested_effort=low\n'
+} >"$EVIDENCE/preflight.txt"
+printf '%s\n' "$INTEGRATION_LINE" >"$EVIDENCE/integration.txt"
+
+# Build and test this checkout's candidate in an isolated target. --locked
+# prevents dependency resolution from changing the checkout.
+CARGO_TARGET_DIR="$TARGET" "$CARGO_BIN" test --locked \
+  --manifest-path "$ROOT/Cargo.toml" -p board-core --test managed_spawn \
+  >"$EVIDENCE/protocol19-test.log" 2>&1
+CARGO_TARGET_DIR="$TARGET" "$CARGO_BIN" build --locked --release \
+  --manifest-path "$ROOT/Cargo.toml" -p board-cli \
+  >"$EVIDENCE/candidate-build.log" 2>&1
+BOARD_BIN="$TARGET/release/board"
+[ -x "$BOARD_BIN" ] || fail "candidate release board was not built"
+EXPECTED_VERSION="$(CARGO_TARGET_DIR="$TARGET" "$CARGO_BIN" metadata --locked --no-deps \
+  --format-version 1 --manifest-path "$ROOT/Cargo.toml" \
+  | jq -er '.packages[] | select(.name == "board-cli") | .version')"
+BOARD_VERSION="$($BOARD_BIN --version)"
+[ "$BOARD_VERSION" = "board $EXPECTED_VERSION" ] \
+  || fail "candidate version assertion failed: expected board $EXPECTED_VERSION, got $BOARD_VERSION"
+{
+  printf 'candidate_binary=%s\n' "$BOARD_BIN"
+  printf 'candidate_version=%s\n' "$BOARD_VERSION"
+  printf 'expected_workspace_version=%s\n' "$EXPECTED_VERSION"
+} >"$EVIDENCE/board-version.txt"
+write_state
+
+cat >"$CONFIG" <<'EOF'
+[daemon]
+spawner = "herdr"
+tick_ms = 200
+EOF
+chmod 600 "$CONFIG"
+
+CANDIDATE_PATH="$(dirname "$BOARD_BIN"):$(dirname "$CODEX_BIN"):$PATH"
+printf 'export PATH=%q\nexport CODEX_HOME=%q\n' \
+  "$CANDIDATE_PATH" "$STAGED_CODEX_HOME" >"$TMP/zdot/.zshrc"
+cp "$TMP/zdot/.zshrc" "$TMP/zdot/.zprofile"
+chmod 600 "$TMP/zdot/.zshrc" "$TMP/zdot/.zprofile"
+
+# --- disposable session, workspace, daemon, and ONE card ---------------------
+printf 'HERDR MUTATION: boot exact disposable real-Codex session %s\n' "$SESSION"
+env -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_TAB_ID -u HERDR_WORKSPACE_ID \
+  -u HERDR_SOCKET_PATH -u 'BASH_FUNC_codex%%' \
+  BOARD_DB="$DB" BOARD_SOCKET="$SOCKET" HERDR_BOARD_CONFIG="$CONFIG" \
+  CODEX_HOME="$STAGED_CODEX_HOME" ZDOTDIR="$TMP/zdot" \
+  PATH="$CANDIDATE_PATH" \
+  "$HERDR_BIN" --session "$SESSION" server >"$TMP/herdr-server.log" 2>&1 &
+SERVER_PID=$!
+SERVER_IDENTITY=""
+for _ in $(seq 1 25); do
+  SERVER_IDENTITY="$(e2e_process_identity_capture "$SERVER_PID" "$SESSION" "$SESSION" "$HERDR_BIN")" && break
+  sleep 0.02
+done
+if [ -z "$SERVER_IDENTITY" ]; then
+  kill "$SERVER_PID" 2>/dev/null || true
+  wait "$SERVER_PID" 2>/dev/null || true
+  fail "could not capture disposable Herdr server identity"
+fi
+SESSION_STARTED=1
+write_state
+
+SOCK=""
+for _ in $(seq 1 75); do
+  if ! e2e_process_identity_verify "$SERVER_PID" "$SERVER_IDENTITY"; then
+    fail "disposable Herdr server failed identity check before readiness"
+  fi
+  SOCK="$($HERDR_BIN session list --json 2>/dev/null \
+    | jq -r --arg session "$SESSION" \
+      '.sessions[]? | select(.name == $session and .running == true) | .socket_path' \
+    | head -1)"
+  [ -n "$SOCK" ] && [ -S "$SOCK" ] && break
+  sleep 0.2
+done
+[ -n "$SOCK" ] && [ -S "$SOCK" ] || fail "disposable Herdr session failed to boot"
+e2e_process_identity_verify "$SERVER_PID" "$SERVER_IDENTITY" \
+  || fail "disposable Herdr server failed identity check before socket publication"
+write_state
+PING="$(HERDR_SOCKET_PATH="$SOCK" python3 "$ROOT/e2e/hrpc.py" ping '{}')"
+printf '%s' "$PING" | jq -e '.version == "0.8.0" and .protocol == 19' >/dev/null \
+  || fail "disposable session ping is not Herdr 0.8.0 protocol 19"
+printf '%s\n' "$PING" >"$EVIDENCE/herdr-ping.json"
+
+printf 'HERDR MUTATION: create one disposable workspace in %s\n' "$SESSION"
+WS_JSON="$(HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" workspace create \
+  --cwd "$WORKSPACE_DIR" --label "real-codex-$RUN_ID" --no-focus \
+  --env "BOARD_BIN=$BOARD_BIN" --env "BOARD_DB=$DB" --env "BOARD_SOCKET=$SOCKET" \
+  --env "HERDR_BOARD_CONFIG=$CONFIG" --env "BOARD_SCOPE_PATH=$WORKSPACE_DIR" \
+  --env "CODEX_HOME=$STAGED_CODEX_HOME" --env "PATH=$CANDIDATE_PATH")"
+WS_ID="$(printf '%s' "$WS_JSON" | jq -er '.result.workspace.workspace_id // .workspace.workspace_id')"
+printf '%s\n' "$WS_JSON" >"$EVIDENCE/workspace-created.json"
+write_state
+
+export BOARD_DB="$DB" BOARD_SOCKET="$SOCKET" HERDR_BOARD_CONFIG="$CONFIG"
+export HERDR_SOCKET_PATH="$SOCK" BOARD_SPAWNER=herdr BOARD_SCOPE_PATH="$WORKSPACE_DIR"
+env CODEX_HOME="$STAGED_CODEX_HOME" PATH="$CANDIDATE_PATH" \
+  "$BOARD_BIN" daemon --foreground >"$TMP/daemon.log" 2>&1 &
+DAEMON_PID=$!
+DAEMON_IDENTITY=""
+for _ in $(seq 1 25); do
+  DAEMON_IDENTITY="$(e2e_process_identity_capture "$DAEMON_PID" "$BOARD_BIN" daemon "$BOARD_BIN")" && break
+  sleep 0.02
+done
+if [ -z "$DAEMON_IDENTITY" ]; then
+  kill "$DAEMON_PID" 2>/dev/null || true
+  wait "$DAEMON_PID" 2>/dev/null || true
+  fail "could not capture candidate board daemon identity"
+fi
+write_state
+for _ in $(seq 1 50); do
+  "$BOARD_BIN" daemon status >/dev/null 2>&1 && break
+  sleep 0.2
+done
+"$BOARD_BIN" daemon status >/dev/null 2>&1 || fail "candidate daemon did not become ready"
+
+BOARD_ID="$(python3 "$ROOT/scripts/board-rpc.py" board.open \
+  "$(python3 -c 'import json,sys; print(json.dumps({"scope_path":sys.argv[1]}))' "$WORKSPACE_DIR")" \
+  | jq -er '.result.board.id')"
+EXEC_ID="$(python3 "$ROOT/scripts/board-rpc.py" column.create \
+  "$(python3 -c 'import json,sys; print(json.dumps({"board_id":int(sys.argv[1]),"name":"Execute","trigger":"auto","system_prompt":"Perform only the trusted static smoke task in the disposable workspace; follow the herdr-board completion protocol exactly."}))' "$BOARD_ID")" \
+  | jq -er '.result.id')"
+
+TASK="Create exactly the file $RESULT_FILE in the disposable workspace. Its complete bytes must be exactly one UTF-8 line: $MARKER followed by one newline. Do not modify any other file. Verify the bytes locally. Then run exactly one board comment whose body contains both marker $MARKER and path $RESULT_FILE, and finish with board done --outcome ok. If any check fails, comment with the failure and use board done --outcome fail."
+CARD_JSON="$("$BOARD_BIN" card new --title "Real Codex smoke" \
+  --description "$TASK" --column "$EXEC_ID" --harness codex \
+  --effort low --space-kind workspace --space-ref "$WS_ID" --json)"
+CARD_ID="$(printf '%s' "$CARD_JSON" | jq -er '.id')"
+printf '%s\n' "$CARD_JSON" >"$EVIDENCE/card-created.json"
+write_state
+printf 'real-codex-smoke: card=%s session=%s workspace=%s evidence=%s\n' \
+  "$CARD_ID" "$SESSION" "$WS_ID" "$EVIDENCE"
+
+# One bounded polling window; there is deliberately no retry or fallback path.
+OUTCOME=""
+: >"$EVIDENCE/status-samples.jsonl"
+for poll in $(seq 1 600); do
+  SHOW="$("$BOARD_BIN" card show "$CARD_ID" --json 2>/dev/null || true)"
+  if printf '%s' "$SHOW" | jq -e '.card.id != null' >/dev/null 2>&1; then
+    printf '%s' "$SHOW" | jq -c --argjson poll "$poll" \
+      '{poll:$poll,status:.card.status,run_count:(.runs|length),outcome:(.runs[-1].outcome // null)}' \
+      >>"$EVIDENCE/status-samples.jsonl"
+    OUTCOME="$(printf '%s' "$SHOW" | jq -r '.runs[-1].outcome // empty')"
+  fi
+  SNAP="$(HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" api snapshot 2>/dev/null || true)"
+  if printf '%s' "$SNAP" | jq -e '.result.snapshot' >/dev/null 2>&1; then
+    printf '%s\n' "$SNAP" >"$EVIDENCE/herdr-snapshot.json"
+  fi
+  [ -z "$OUTCOME" ] || break
+  sleep 0.5
+done
+[ "$OUTCOME" = "ok" ] || fail "single Codex run ended with outcome '${OUTCOME:-timeout}'"
+
+"$BOARD_BIN" card show "$CARD_ID" --json >"$EVIDENCE/card-final.json"
+HERDR_SOCKET_PATH="$SOCK" "$HERDR_BIN" api snapshot >"$EVIDENCE/herdr-snapshot.json"
+python3 - "$DB" "$EVIDENCE/counts.json" <<'PY'
+import json, sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+out = {
+    "boards": con.execute("select count(*) from boards").fetchone()[0],
+    "cards": con.execute("select count(*) from cards").fetchone()[0],
+    "runs": con.execute("select count(*) from runs").fetchone()[0],
+}
+with open(sys.argv[2], "w", encoding="utf-8") as stream:
+    json.dump(out, stream, sort_keys=True)
+    stream.write("\n")
+assert out["cards"] == 1 and out["runs"] == 1
+PY
+
+python3 - "$EVIDENCE/card-final.json" "$EVIDENCE/herdr-snapshot.json" \
+  "$RESULT_FILE" "$MARKER" "$TASK" "$WS_ID" <<'PY'
+import json, pathlib, sys
+show_path, snapshot_path, result_path, marker, task, workspace_id = sys.argv[1:]
+show = json.load(open(show_path, encoding="utf-8"))
+snapshot = json.load(open(snapshot_path, encoding="utf-8"))
+card = show["card"]
+runs = show["runs"]
+comments = show["comments"]
+assert card["harness"] == "codex"
+assert card["effort"] == "low"
+assert card["space_kind"] == "workspace" and card["space_ref"] == workspace_id
+assert len(runs) == 1
+run = runs[0]
+assert run["harness"] == "codex" and run["outcome"] == "ok"
+assert run["herdr_workspace_id"] == workspace_id and run["herdr_pane_id"]
+# The thread id is the integration-reported self-minted conversation id.
+assert run["session_id"] and run["session_id"] != "null"
+assert run["prompt_snapshot"].startswith(task + "\n\n")
+assert "board done --outcome ok" in run["prompt_snapshot"]
+argv = json.loads(run["argv_json"])
+assert argv[0] == "codex"
+assert "-c" in argv and argv[argv.index("-c") + 1] == "model_reasoning_effort=low"
+assert not any(arg.startswith("instructions=") for arg in argv)
+assert all(task not in arg and marker not in arg and result_path not in arg for arg in argv)
+agent_comments = [c for c in comments if c["author"] == f"agent:{run['id']}"]
+assert agent_comments
+assert any(marker in c["body"] and result_path in c["body"] for c in agent_comments)
+path = pathlib.Path(result_path)
+assert path.is_file() and not path.is_symlink()
+assert path.read_bytes() == marker.encode("utf-8") + b"\n"
+panes = snapshot["result"]["snapshot"].get("panes", [])
+matched = [p for p in panes if p.get("pane_id") == run["herdr_pane_id"]]
+assert len(matched) == 1
+pane = matched[0]
+assert pane.get("agent") == "codex"
+session = pane.get("agent_session")
+assert session and session.get("source") == "herdr:codex" and session.get("agent") == "codex"
+assert session.get("kind") == "id" and session.get("value") == run["session_id"]
+print("validated one Codex run, exact startup flags, reported thread id, comment, and file bytes")
+PY
+
+# Recheck the disposable path directly (the Python assertion above deliberately
+# receives workspace id separately because Herdr ids are not filesystem paths).
+python3 - "$RESULT_FILE" "$WORKSPACE_DIR" <<'PY'
+import pathlib, sys
+result = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(sys.argv[2]).resolve()
+assert result.parent.resolve() == workspace
+PY
+
+capture_runtime_evidence
+LAST_ERROR="none"
+RUN_SUCCEEDED=1
+exit 0

--- a/e2e/run-all.sh
+++ b/e2e/run-all.sh
@@ -78,7 +78,7 @@ SCENARIOS=(
   22-move-column-tui.sh 23-agent-pane-busy-retry.sh
   24-cross-board-move.sh 25-card-tabs.sh 26-compact-mobile.sh
   27-rescue-dead-pane.sh 28-pi-effort-catalog.sh 29-diagnostic-logs.sh
-  30-pane-reuse.sh
+  30-pane-reuse.sh 31-managed-codex.sh
 )
 run_this() {
   [ "${#FILTERS[@]}" -eq 0 ] && return 0

--- a/e2e/test-harness.sh
+++ b/e2e/test-harness.sh
@@ -519,12 +519,12 @@ s=open(sys.argv[1],encoding='utf-8').read()
 assert not re.search(r'''printf\s+'%s(?:\\n)?'\s+"\$show"''',s)
 PY
 ! rg -n '^\s*assert\b.*,[[:space:]]*(x(\[[^]]+\])?|prompt|system_prompt|show\[[^]]+\])[[:space:]]*$' \
-  "$E2E_LIB_DIR"/[0-9][0-9]-*.sh "$E2E_LIB_DIR"/real-*-smoke.sh "$E2E_LIB_DIR"/fake-bin/{pi,claude} >/dev/null \
+  "$E2E_LIB_DIR"/[0-9][0-9]-*.sh "$E2E_LIB_DIR"/real-*-smoke.sh "$E2E_LIB_DIR"/fake-bin/{pi,claude,codex} >/dev/null \
   || { echo 'unsafe sensitive assertion message remains' >&2; exit 1; }
 python3 - "$E2E_LIB_DIR" <<'PY'
 import ast,pathlib,re,sys
 root=pathlib.Path(sys.argv[1])
-for path in [*root.glob('[0-9][0-9]-*.sh'), *root.glob('real-*-smoke.sh'), root/'fake-bin/pi', root/'fake-bin/claude']:
+for path in [*root.glob('[0-9][0-9]-*.sh'), *root.glob('real-*-smoke.sh'), root/'fake-bin/pi', root/'fake-bin/claude', root/'fake-bin/codex']:
     text=path.read_text(encoding='utf-8')
     for match in re.finditer(r"<<'PY'\n(.*?)\nPY(?:\n|$)", text, re.S):
         tree=ast.parse(match.group(1))

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -16,7 +16,8 @@ CLI, cards, runs, comments, columns, and Herdr-backed spaces; it does not prescr
 prototype, test, or release herdr-board itself.
 
 A **card** is a title/description plus harness/model/effort, optional harness permission, and a target
-Herdr session and workspace. New cards default to Pi. **Columns** are pipeline stages: `manual` waits
+Herdr session and workspace. New cards default to Pi; the built-in catalog is `pi`, `claude`, `codex`
+(in that order), then any config-defined `[harness.NAME]`. **Columns** are pipeline stages: `manual` waits
 for a person and `auto` dispatches a visible agent run on entry. Each canonical Git root (or exact
 non-Git CWD) has an independent board; the preserved `Global` board remains available. Agents report
 through `board`; never edit the database. The daemon owns state and column transitions.
@@ -104,7 +105,15 @@ board card delete ID [--yes] [--json]
 ```
 
 `card new` is retained as an alias for `card create`. A new card defaults to Pi; an omitted model or
-effort uses the harness default. `new-workspace` requires both `--space-ref` and `--space-cwd`.
+effort uses the harness default. `--harness codex` selects the built-in Codex adapter: models are
+free-form (`--model` any string), every effort level is accepted (`off|minimal|low|medium|high|xhigh|max`;
+`off` is delivered to codex as `model_reasoning_effort=none`), and `--permission` takes
+`untrusted|on-request|never` (codex's `--ask-for-approval`; its `--sandbox` stays your own codex
+config and is never derived from the permission field). Codex mints its own conversation thread id —
+the board never invents one — and captures the integration-reported id after launch, so later stages
+can `resume`/`fork` the same conversation; a minted run whose id was never reported cannot be
+reopened by id (`card run focus` refuses; use `card run retry` for a new run).
+`new-workspace` requires both `--space-ref` and `--space-cwd`.
 Creating directly in an `auto` column dispatches immediately. `card list` defaults to active cards;
 `all` includes archived cards and `archived` returns only archived cards. `card show` includes current
 comments and run history; soft-deleted comments are omitted.
@@ -167,8 +176,8 @@ rescue never re-sends the card task and never writes to the database, so the reo
 ephemeral: it has no run row and is not watched or timed out. It gets `BOARD_CARD_ID`/`BOARD_SOCKET`
 but deliberately **no** `BOARD_RUN_ID`, so from inside it `board comment` still records on the card
 (as a human comment) while `board done` does not apply — the run stays closed. Closing the pane is up
-to you. Resuming requires an explicit per-harness capability (`pi` and
-`claude` have it; a `[harness.NAME]` harness needs `resume = true`) and a recorded conversation id;
+to you. Resuming requires an explicit per-harness capability (`pi`, `claude`, and
+`codex` have it; a `[harness.NAME]` harness needs `resume = true`) and a recorded conversation id;
 without either, focus is refused explicitly — use `card run retry` for a new run instead.
 
 Done/cancel/retry return `{run, card}` in JSON. Retry creates a new run while preserving history.


### PR DESCRIPTION
## Summary

- Add Codex as a built-in managed harness with cached model/effort discovery and native access presets.
- Capture self-minted Codex thread IDs and support resume, fork, pane reuse, and safe rescue.
- Add CLI/TUI coverage, protocol-19 session handling, documentation, and provider-free E2E scenario 31.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- 87 Python tests
- Static E2E safety checks
- Live E2E scenarios 01–31