### PR TITLE
fix(ci): repair Prepare Release PR creation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -155,7 +155,7 @@ jobs:
             "- release files synced by scripts/prepare-release.py" \
             "- CI is dispatched explicitly from this workflow" \
             "- base dev: the Promote workflow merges dev -> main, then Release tags the green commit" \
-            "- base main (hotfix): Release tags the green main commit directly")""
+            "- base main (hotfix): Release tags the green main commit directly")"
 
           pr_json="$(gh pr list --head "$BRANCH" --state open --json number,url)"
           if [ "$(printf '%s' "$pr_json" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')" -gt 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- [#67](https://github.com/nelsonPires5/herdr-board/pull/67) fix: repair the Prepare Release workflow so release pull requests open correctly.
 - [#64](https://github.com/nelsonPires5/herdr-board/pull/64) fix: retry `agent.start` on a fresh owned pane with backoff so slow login shells stop failing managed runs.
 
 ## [0.12.0] - 2026-08-08


### PR DESCRIPTION
The release PR body string in the Create or update PR step ended with an unbalanced extra quote, so the step failed with "unexpected EOF while looking for matching '"'" and the Prepare Release workflow could not open its PR. Fix introduced by f085673 (PR #62).