### PR TITLE
docs(releasing): reflect the main ruleset after the v0.13.0 promotion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,9 @@ Full layering, test placement, harness details, and how to add tests live in
   push, move, or delete release tags manually: a maintainer starts **Prepare Release**, merges its
   PR into `dev`, the **Promote** workflow merges `dev -> main`, and the **Release** workflow creates
   the tag only after `main` CI is green at that promotion SHA. Repository rulesets protect `main`
-  (PR-only, merge-commit, signed commits) and `v*` tags (deletion/force-update); this is policy and
-  workflow validation together.
+  (PR-only, merge-commit, required fast CI) and `v*` tags (deletion/force-update); this is
+  policy and workflow validation together. Bot-created PRs (release, promotion) need one manual
+  approval of their workflow runs before CI executes — see `docs/releasing.md`.
 - Branching: `dev` is the long-lived integration branch and the default target for feature PRs;
   `main` is production (default branch, Release's only publish path). The `dev -> main` promotion
   and hotfix PRs are opened/merged by the workflows themselves. After every promotion or hotfix,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- [#71](https://github.com/nelsonPires5/herdr-board/pull/71) chore(ci): drop the signed-commits rule on main so automated promotion PRs merge without manual signature rewrites.
 - [#62](https://github.com/nelsonPires5/herdr-board/pull/62) chore(ci): `dev` is now the long-lived integration branch; `main` stays production-only (automated promotion + release tagging).
 
 ### Fixed

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,13 +96,21 @@ merges) is a no-op.
 ## main protection
 
 `main` is protected by an active branch ruleset: every change must come through a pull request
-merged with a **merge commit** (squash/rebase are not allowed), the six fast CI jobs are required
-status checks with a strict policy, and **signed commits** are required — merge commits created
-by GitHub for a PR merge are GitHub-verified, so every commit on `main` carries a verified
-signature. Direct pushes to `main` are blocked by the pull-request rule; the only writer in
-practice is the automation (`github-actions[bot]`), whose promotion and hotfix merges are
-GitHub-verified. `dev` is protected the same way (PR + merge commit + required checks) but has no
-signature requirement.
+merged with a **merge commit** (squash/rebase are not allowed), and the six fast CI jobs are
+required status checks with a strict policy. Direct pushes to `main` are blocked by the
+pull-request rule; the only writer in practice is the automation (`github-actions[bot]`), whose
+promotion and hotfix merges are GitHub-verified merge commits. `dev` is protected the same way
+(PR + merge commit + required checks). There is no signature requirement on either branch: the
+former `required_signatures` rule on `main` was removed because it rejects every PR whose source
+commits are unsigned — including the release commit written by `github-actions[bot]` — so the
+automated promotion could never merge.
+
+PRs opened by `github-actions[bot]` (release PRs from Prepare Release, promotion PRs from
+Promote) hit GitHub's approval gate for bot-created PRs: their `pull_request` workflow runs stay
+in `action_required` until a maintainer approves them — click **Approve workflows to run** in
+the PR merge box, or call the workflow-run approval endpoint
+(`POST /repos/{owner}/{repo}/actions/runs/{id}/approve`). Once approved, the runs complete as
+usual and the PR becomes mergeable.
 
 ## Release gate
 


### PR DESCRIPTION
The v0.13.0 release exposed two blockers in the automated flow:\n\n- the `required_signatures` rule on main rejected the promotion PR (unsigned source commits, including the bot-written release commit) — the rule was removed from the ruleset;\n- GitHub's approval gate for bot-created PRs leaves their workflow runs in `action_required` until a maintainer approves them.\n\nThis PR updates `docs/releasing.md` and `AGENTS.md` to match the current ruleset and documents the approval step.