### PR TITLE
docs: restructure the README into a compact, user-first overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,24 @@ cargo build            # or ./scripts/build.sh for the release binary herdr's [[
 cargo run -p board-cli -- tui   # run the board locally
 ```
 
+## Architecture
+
+One `board` binary, five workspace crates: `board-core` (models, protocol, database, engine,
+prompts, config, harness adapters), `board-daemon` (orchestration and dispatch), `board-herdr`
+(Herdr socket client), `board-tui` (Ratatui application), and `board-cli` (the `board` binary).
+
+| Role | Responsibility |
+|---|---|
+| `board daemon` | Owns SQLite state, run queue, orchestration, workspace resolution, pane spawning, and status watching. |
+| `board tui` | Ratatui board opened inside a Herdr overlay/tab; talks to and auto-starts the daemon. |
+| `board <verb>` | CLI used by humans and dispatched agents (`comment`, `done`, `move`, and others). |
+
+The CLI and TUI share the typed `board_core::client::BoardClient`; only boardd touches SQLite.
+Design and protocol: [`docs/design.md`](docs/design.md) and [`docs/protocol.md`](docs/protocol.md);
+index: [`docs/README.md`](docs/README.md). `schema.sql` is the SQLite migration source of truth;
+`scripts/` holds build/install helpers; `e2e/` holds scenarios 01–32 against disposable Herdr
+sessions and workspaces.
+
 ## Gates that must pass
 
 Keep this tier green before opening a PR. The gate list has one maintained copy:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Rust](https://img.shields.io/badge/rust-edition%202021-orange.svg)
 ![herdr 0.8.0](https://img.shields.io/badge/herdr-0.8.0-8a2be2)
+![board protocol v1 · schema v13](https://img.shields.io/badge/board-protocol%20v1%20%C2%B7%20schema%20v13-blue.svg)
 ![platforms: linux, macOS](https://img.shields.io/badge/platforms-linux%2C%20macOS-informational)
-![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
 **Turn a kanban card into a real AI coding agent running in a visible Herdr pane.** Cards hold
 prompts, columns define pipeline stages, and moving work across the board can plan, execute, review,
@@ -13,13 +13,21 @@ and stop at human gates automatically.
   <img src="docs/assets/readme/board-overview.png" alt="Wide herdr-board view with boxed cards, colored statuses, a single-line header, and a persistent action rail" width="100%">
 </p>
 
-```text
-Todo ──► Plan ──► Execute ──► Review ──► Human Review ──► Done
-        (auto)    (auto)      (auto)     (manual gate)
-```
+<details>
+<summary><strong>Interface</strong></summary>
 
-Columns are fully user-defined. The pipeline above is an optional template; a new board starts with
-only `Todo`.
+| Guided card creation | Card context and run history | Compact mobile view |
+|:--:|:--:|:--:|
+| <img src="docs/assets/readme/new-card.png" alt="New card form with agent settings and execution target" width="440"> | <img src="docs/assets/readme/card-detail.png" alt="Card detail sheet with runs and comments" width="440"> | <img src="docs/assets/readme/compact-board.png" alt="Compact mobile layout with touch-friendly controls" width="250"> |
+
+The TUI is mobile-first: a compact, touch-friendly layout that fits phones and small terminals —
+the same board, anywhere. Agents run in visible Herdr panes, one stable `card-<id>` tab per card.
+
+<p align="center">
+  <img src="docs/assets/readme/agent-panes.png" alt="Visible board agent panes labeled per card" width="100%">
+</p>
+
+</details>
 
 ## Why herdr-board?
 
@@ -35,25 +43,44 @@ only `Todo`.
   existing or newly created workspaces.
 - **History stays with the card.** Comments, runs, outcomes, retries, and archived cards remain
   available for inspection.
+- **Mobile-first TUI.** The responsive layout keeps the board usable on phones and small terminals,
+  with touch-friendly navigation and controls.
+
+## How it works
+
+- A **card** contains a title, base prompt, harness/model/effort/permission settings, and a target
+  Herdr session and workspace.
+- A **column** can define a system prompt, automatic or manual triggering, timeout, and separate
+  success/failure destinations.
+- Moving a card into an automatic column queues a run: the daemon resolves the session, opens or
+  reuses the workspace, and starts the agent in a visible pane.
+- The agent reads card/run environment variables and uses the `board` CLI to comment and report its
+  outcome; the daemon then applies the column transition — the next automatic stage or a manual gate.
+
+```text
+┌────────┐  ┌────────┐
+│  TUI   │  │  CLI   │   interfaces — humans and agents
+└───┬────┘  └───┬────┘
+    └─────┬─────┘
+       ┌──┴─────┐
+       │ boardd │   daemon — queue, dispatch, lifecycle
+       └───┬────┘
+           │
+       ┌───┴────┐
+       │  herdr │   one visible pane per run
+       └────────┘
+```
+
+`boardd` runs as a background daemon and orchestrates everything; the TUI and the CLI are the two
+interfaces that talk to it. The CLI also exposes `board skill`, which prints the exact contract a
+dispatched agent is held to. All board state lives under `~/.local/share/herdr-board/`; Herdr's own
+state is never modified.
 
 ## Install
-
-Requires exactly **Herdr 0.8.0 (protocol 19)**, Git, and a Rust toolchain with `cargo`. Linux
-and macOS are supported. Ensure `~/.local/bin` is on your `PATH`. The board protocol is v1 and the
-current SQLite schema is v13; `schema.sql` defines fresh databases and the daemon applies tested
-upgrades through `board-core::db`.
-
-The daemon checks the selected Herdr socket before workspace discovery and pane launch. It rejects
-any Herdr version other than 0.8.0 and any protocol other than 19; older, unknown, and future
-protocols are not supported.
 
 ```bash
 herdr plugin install nelsonPires5/herdr-board --ref v0.13.0
 ```
-
-Precise live lifecycle status also requires Herdr's integration for the harness you dispatch (for
-example, `herdr integration install pi`). Without that integration the board still dispatches and
-accepts `board done`, but runs in degraded mode without precise working/blocked/done signals.
 
 Open the board:
 
@@ -61,27 +88,49 @@ Open the board:
 herdr plugin action invoke open-board --plugin herdr-board
 ```
 
-To open the board as a tab instead of an overlay:
+An optional keybinding (`prefix+shift+k`) opens it from anywhere — see
+[`docs/install.md`](docs/install.md).
 
-```bash
-herdr plugin pane open --plugin herdr-board --entrypoint board --placement tab --focus
-```
+### Supported harnesses
 
-For a custom CLI install directory, a Herdr keybinding, the harness integration, the optional
-agent skill, and named-session notes, see [`docs/install.md`](docs/install.md).
+| Harness | Integration (precise status) | GitHub |
+|---|---|---|
+| **Pi** (default) | `herdr integration install pi` | [earendil-works/pi](https://github.com/earendil-works/pi) |
+| **Claude Code** | `herdr integration install claude` | [anthropics/claude-code](https://github.com/anthropics/claude-code) |
+| **Codex** | `herdr integration install codex` | [openai/codex](https://github.com/openai/codex) |
+| **OpenCode** | `herdr integration install opencode` | [anomalyco/opencode](https://github.com/anomalyco/opencode) |
+
+<details>
+<summary><strong>Requirements and details</strong></summary>
+
+- Requires exactly **Herdr 0.8.0 (socket protocol 19)**, Git, and a Rust toolchain with `cargo`;
+  Linux and macOS are supported. The daemon rejects any other Herdr version or protocol before
+  workspace discovery and pane launch.
+- Board protocol **v1**, SQLite schema **v13** (`schema.sql`; upgrades via `board-core::db`).
+- The installer copies the `board` CLI to `~/.local/bin` — make sure that directory is on your
+  `PATH` (`HERDR_BOARD_CLI_INSTALL_DIR` overrides it before installing).
+- Without the harness integration the board still dispatches and accepts `board done`, but runs in
+  degraded mode without precise working/blocked/done signals.
+- To open the board as a tab instead of an overlay:
+
+  ```bash
+  herdr plugin pane open --plugin herdr-board --entrypoint board --placement tab --focus
+  ```
+
+- Custom CLI directory, keybinding setup, harness integration, optional agent skill, and named
+  sessions: [`docs/install.md`](docs/install.md).
+
+</details>
 
 ## Quickstart
 
-1. Open the board with the plugin action or an optional keybinding. Herdr's focused pane selects
-   its Git-root/CWD board; press `b` to switch boards or open the preserved `Global` board.
+1. Open the board: `herdr plugin action invoke open-board --plugin herdr-board` (or your keybinding).
 2. On an empty board press `T` to apply the example pipeline, or `N` to create your own columns.
-3. Press `n` to create a card. Pi is selected by default. Leave model at `(default)` to use Pi's
-   configured default, choose thinking effort if needed, then select the session and workspace.
-   Permission appears only for harnesses that support it (Pi does not; Codex offers
-   `untrusted|on-request|never`; OpenCode offers `default|auto-approve`).
+3. Press `n` to create a card. Pi is selected by default; leave the model at `(default)` to use
+   Pi's configured default, pick the thinking effort if needed, then select session and workspace.
 4. Move the card into an automatic column with `m`, `H` / `L`, or drag-and-drop.
-5. Watch the agent appear in its stable `card-<id>` workspace tab. Follow progress with `Enter`
-   for card detail; the agent comments and calls `board done` when its stage finishes.
+5. Watch the agent appear in its stable `card-<id>` tab. `Enter` opens card detail; the agent
+   comments and calls `board done` when its stage finishes.
 
 The same flow from the shell:
 
@@ -93,101 +142,11 @@ board card create --title "Add retry to the uploader" \
 board move <new-card-id> Execute
 ```
 
-`pi` is the default built-in harness. An omitted model lets Pi use its current configured default;
-an explicit model uses Pi's `provider/model` form. Board effort maps to Pi `--thinking`. Pi has no
-board permission mode and rejects `--permission`. Claude remains available explicitly with
-`--harness claude` and keeps its model/effort/permission behavior. Codex is the third built-in:
-`--harness codex` keeps free-form model entry and also discovers visible models plus per-model
-efforts from `$CODEX_HOME/models_cache.json`. Board effort `off` becomes Codex
-`model_reasoning_effort=none`. Its permission selector mirrors Codex: `ask-for-approval`
-(workspace-write + on-request), `approve-for-me` (automatic reviewer), or `full-access` (no sandbox
-or approvals). Codex mints its own thread id — the board never invents one — and captures the
-integration-reported id after launch so later stages can `resume`/`fork` the same conversation.
-OpenCode is the fourth built-in: `--harness opencode` treats models as free-form
-`provider/model` (the daemon discovers live models plus per-model reasoning variants from
-`opencode models --verbose`, falling back to a static catalog that truthfully lists OpenCode Zen
-Nemotron 3 Ultra Free — `opencode/nemotron-3-ultra-free`, which declares no variants and so offers
-no board effort — alongside a fixture model `opencode/deepseek-v4-flash-free` with `low`/`high`/`max`
-efforts). The board calls the variant dimension **effort**; the root/TUI has **no `--variant` flag**
-(verified: it exists only on `opencode run`), so an effort is applied through a process-local
-`OPENCODE_CONFIG_CONTENT` config defining a stable `herdr-board` agent with exactly `model` +
-`variant` (board `off` → opencode `none`), selected with `--agent herdr-board`, and `--variant`
-never rides argv. Its two permission modes are
-`default` (no flag) and `auto-approve` (`--auto`). Like Codex, OpenCode mints its own `ses_…`
-session id — a Mint carries no session flag and persists `NULL` until the integration-reported id is
-captured after launch, so later stages can `resume`/`fork` the same conversation by id.
+Pi is the default built-in harness; Claude Code, Codex, and OpenCode are available with
+`--harness <name>`, each keeping its own model, effort, and permission behavior — the full reference
+is [`skill/SKILL.md`](skill/SKILL.md) (also printed by `board skill`).
 
-## How it works
-
-- A **card** contains a title, base prompt, harness/model/effort/permission settings, and a target
-  Herdr session and workspace.
-- A **column** can define a system prompt, automatic or manual triggering, timeout, and separate
-  success/failure destinations.
-- Moving a card into an automatic column queues a run. The daemon resolves the target session,
-  opens or reuses the workspace, and starts the agent in a visible pane.
-- The agent receives card/run environment variables and uses the `board` CLI to comment and report
-  its outcome.
-- The daemon applies the column transition. It either dispatches the next automatic stage or stops
-  at a manual gate.
-
-Runtime launch ownership stays in `board-daemon`: it owns Herdr pane placement and process handles,
-and runs an always-on per-session supervisor that reconnects conservatively after outages.
-
-All board state lives under `~/.local/share/herdr-board/`; Herdr's own state is never modified.
-
-## A closer look
-
-| Guided card creation | Card context and run history |
-|:--:|:--:|
-| <img src="docs/assets/readme/new-card.png" alt="Current New card form with a description editor, agent settings, execution target, and persistent action rail" width="820"> | <img src="docs/assets/readme/card-detail.png" alt="Current card detail sheet showing idle status, task configuration, description, runs and comments sections, and actions" width="820"> |
-
-### Agents run in visible Herdr panes
-
-The daemon creates one stable `card-<id>` tab per new card. For a workspace the daemon itself
-just created (`new_workspace`), that workspace's own initial tab is adopted as the card tab —
-renamed to `card-<id>` — so no unused initial tab is left behind. The tab's root is reserved as a
-labeled `card-<id>-anchor` shell and every run is split into a child from it. A successful
-**managed** (Pi/Claude/Codex/OpenCode) launch then closes the anchor, leaving exactly the harness pane
-visible; **configured** harnesses keep the anchor because their child exits with the run. Ownership is
-proven from durable pane identity, never from a matching label, so a user tab is never adopted.
-The full placement and recovery rules are in [`docs/design.md`](docs/design.md).
-
-<p align="center">
-  <img src="docs/assets/readme/agent-panes.png" alt="Retained Herdr workspace view with visible board agent panes labeled per card" width="100%">
-</p>
-
-## Mobile-first TUI
-
-The `board tui` surface is responsive: **Compact (< 60 cols)** shows one
-full-width column with a three-row mobile header — product/running count, a
-board dropdown plus visibility chips, then the column navigator — while
-**Regular (60–119)** and **Wide (≥ 120)** show the multi-column board with all
-header controls balanced on one line. Compact navigation shows the column
-trigger as `(M)` or `(A)` and never repeats the global running count. Filter
-chips shorten only when needed; they never add a redundant `Board:` or
-`Visible:` label. Cards are compact boxed rows that always carry their real
-status glyph, an active-run timer, and harness/model metadata; Board cards have
-no Edit/Delete controls, while keyboard `e`/`d` remains available. Every
-visible button is a transparent `[ NAME ]` chip with bold white text and
-brackets; close controls are always `[ X ]`, selected chips add an underline,
-and primary/destructive tone does not recolor them. Card detail, forms, and
-picker sheets occupy only the board content region, leaving persistent top and
-bottom action rails visible. Multiline description and system-prompt fields
-retain wrapped editing and `$EDITOR` support while using the same focused and
-unfocused value treatment as title/name fields. The old persistent footer hint
-row is gone; only transient toasts use its former space. All original keyboard
-shortcuts are preserved.
-
-Compact adapts to smaller screens and is touch-friendly when the terminal maps
-taps to pointer clicks: navigation, filters, cards, and action chips are all
-tappable/clickable. This is pointer-click support rather than native swipe or
-pinch gestures; keyboard shortcuts remain available too.
-
-<p align="center">
-  <img src="docs/assets/readme/compact-board.png" alt="Compact herdr-board with a three-row header, touch-friendly navigation and filters, boxed cards, and a bottom action rail" width="470">
-</p>
-
-## Everyday controls
+### Everyday controls
 
 | Key | Action | Key | Action |
 |---|---|---|---|
@@ -274,7 +233,8 @@ Bare `board daemon` still runs the daemon, and the historical `--foreground` / `
 work but are hidden from `--help`. `board version [--json]` never starts boardd and reports
 `{cli_version, daemon_version}`, with `null`/`unavailable` when boardd is offline.
 
-### JSON and exit codes
+<details>
+<summary><strong>JSON output, exit codes, configuration, and maintenance</strong></summary>
 
 Successful `--json` goes to stdout; JSON errors go to stderr with stdout left empty, in the stable
 envelope `{"error":{"code":N,"kind":"...","message":"...","details":...}}` (`kind` and `details` are
@@ -290,44 +250,9 @@ The exit status carries the same number, so scripts branch on `$?` instead of pa
 | `64` | The CLI itself refused — usage/parse error, declined confirmation, bad enum value, unresolvable column, missing `$BOARD_CARD_ID` (`EX_USAGE`) |
 | `70` | Daemon reported a protocol code outside `1..=5`, clamped (`EX_SOFTWARE`) |
 
-## Configuration and maintenance
-
 - [`docs/configuration.md`](docs/configuration.md) — `config.toml`, `[daemon]` settings,
   config-defined harnesses, and every environment variable;
 - [`docs/operations.md`](docs/operations.md) — update, uninstall, and local-development
   source install.
 
-## Architecture and development
-
-| Role | Responsibility |
-|---|---|
-| `board daemon` | Owns SQLite state, run queue, orchestration, workspace resolution, pane spawning, and status watching. |
-| `board tui` | Ratatui board opened inside a Herdr overlay/tab; talks to and auto-starts the daemon. |
-| `board <verb>` | CLI used by humans and dispatched agents (`comment`, `done`, `move`, and others). |
-
-Five workspace crates — `board-core` (models, protocol, database, engine, prompts, config, harness
-adapters), `board-daemon` (orchestration and dispatch), `board-herdr` (Herdr socket client),
-`board-tui` (Ratatui application), and `board-cli` (the `board` binary). The CLI and TUI share the
-typed `board_core::client::BoardClient`; only boardd touches SQLite.
-
-- **[`docs/README.md`](docs/README.md) — the documentation index** (design, protocol, herdr facts,
-  implementation, testing, releasing) and the single maintained copy of the
-  [test gates](docs/README.md#test-gates-single-source);
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`AGENTS.md`](AGENTS.md) — read before contributing;
-- [`schema.sql`](schema.sql) — SQLite migration source of truth;
-- `scripts/` — `build.sh` (release build used by plugin installation), `install-cli.sh` (managed
-  CLI copy), `install.sh` (local-development setup), `open-board.sh` (open-or-focus plugin
-  action), and `board-rpc.py` (raw daemon protocol client);
-- `e2e/` — scenarios 01–32 against disposable Herdr sessions/workspaces; checked-in fake Pi,
-  Claude, Codex, OpenCode, and configured harnesses keep the standard suite provider-free. `e2e/test-harness.sh`
-  performs static ownership/safety checks without starting Herdr; the live suite is a separate
-  gate. The catalog is [`e2e/README.md`](e2e/README.md).
-
-## Status
-
-**v1 board protocol / schema v13 / Herdr 0.8.0 (protocol 19).** Rust with Ratatui, Rusqlite, and
-Tokio. See [`docs/README.md`](docs/README.md) for the full version and source-ownership matrix.
-
-## License
-
-MIT — see the `license` field in [`Cargo.toml`](Cargo.toml).
+</details>

--- a/README.md
+++ b/README.md
@@ -16,12 +16,26 @@ and stop at human gates automatically.
 <details>
 <summary><strong>Interface</strong></summary>
 
-| Guided card creation | Card context and run history | Compact mobile view |
-|:--:|:--:|:--:|
-| <img src="docs/assets/readme/new-card.png" alt="New card form with agent settings and execution target" width="440"> | <img src="docs/assets/readme/card-detail.png" alt="Card detail sheet with runs and comments" width="440"> | <img src="docs/assets/readme/compact-board.png" alt="Compact mobile layout with touch-friendly controls" width="250"> |
+**Guided card creation** — agent settings, execution target, and the action rail.
+
+<p align="center">
+  <img src="docs/assets/readme/new-card.png" alt="New card form with agent settings and execution target" width="640">
+</p>
+
+**Card context and run history** — runs, comments, and actions.
+
+<p align="center">
+  <img src="docs/assets/readme/card-detail.png" alt="Card detail sheet with runs and comments" width="640">
+</p>
 
 The TUI is mobile-first: a compact, touch-friendly layout that fits phones and small terminals —
-the same board, anywhere. Agents run in visible Herdr panes, one stable `card-<id>` tab per card.
+the same board, anywhere.
+
+<p align="center">
+  <img src="docs/assets/readme/compact-board.png" alt="Compact mobile layout with touch-friendly controls" width="360">
+</p>
+
+Agents run in visible Herdr panes, one stable `card-<id>` tab per card.
 
 <p align="center">
   <img src="docs/assets/readme/agent-panes.png" alt="Visible board agent panes labeled per card" width="100%">
@@ -88,8 +102,26 @@ Open the board:
 herdr plugin action invoke open-board --plugin herdr-board
 ```
 
-An optional keybinding (`prefix+shift+k`) opens it from anywhere — see
-[`docs/install.md`](docs/install.md).
+<details>
+<summary><strong>Set up a keybinding to open the board from anywhere</strong></summary>
+
+An optional keybinding (`prefix+shift+k`, so **Shift+K** after your prefix) opens the board from
+anywhere. It is not configured automatically — add it to your Herdr config at
+`~/.config/herdr/config.toml`:
+
+```toml
+[[keys.command]]
+key = "prefix+shift+k"
+type = "shell"
+command = "herdr plugin action invoke open-board --plugin herdr-board"
+description = "open herdr-board kanban (overlay)"
+```
+
+Herdr's default prefix is `ctrl+b`, so with defaults the binding is `Ctrl+B Shift+K` (if your
+prefix is `ctrl+a`, it is `Ctrl+A Shift+K`). Do not reuse `prefix+k` — it is Herdr's
+`focus_pane_up` by default.
+
+</details>
 
 ### Supported harnesses
 
@@ -117,8 +149,8 @@ An optional keybinding (`prefix+shift+k`) opens it from anywhere — see
   herdr plugin pane open --plugin herdr-board --entrypoint board --placement tab --focus
   ```
 
-- Custom CLI directory, keybinding setup, harness integration, optional agent skill, and named
-  sessions: [`docs/install.md`](docs/install.md).
+- Custom CLI directory, harness integration, optional agent skill, and named sessions:
+  [`docs/install.md`](docs/install.md).
 
 </details>
 
@@ -141,10 +173,6 @@ board card create --title "Add retry to the uploader" \
   --space-kind new-workspace --space-ref uploader --space-cwd /path/to/repo
 board move <new-card-id> Execute
 ```
-
-Pi is the default built-in harness; Claude Code, Codex, and OpenCode are available with
-`--harness <name>`, each keeping its own model, effort, and permission behavior — the full reference
-is [`skill/SKILL.md`](skill/SKILL.md) (also printed by `board skill`).
 
 ### Everyday controls
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ The exit status carries the same number, so scripts branch on `$?` instead of pa
 | `64` | The CLI itself refused — usage/parse error, declined confirmation, bad enum value, unresolvable column, missing `$BOARD_CARD_ID` (`EX_USAGE`) |
 | `70` | Daemon reported a protocol code outside `1..=5`, clamped (`EX_SOFTWARE`) |
 
+- [`docs/README.md`](docs/README.md) — the documentation index (design, protocol, herdr facts,
+  testing, releasing), the single source of the
+  [test gates](docs/README.md#test-gates-single-source), and the `e2e/` catalog (scenarios 01–32);
 - [`docs/configuration.md`](docs/configuration.md) — `config.toml`, `[daemon]` settings,
   config-defined harnesses, and every environment variable;
 - [`docs/operations.md`](docs/operations.md) — update, uninstall, and local-development


### PR DESCRIPTION
## Summary

Tighten the root README from ~330 to ~260 lines so a first-time visitor can read, install, and start using the board quickly.

- Drop the example-pipeline ASCII flow and the "columns are user-defined" note (now implicit in the tagline).
- Move the interface gallery into a collapsible **Interface** block right below the hero image, with screenshots stacked for readability and the mobile-first layout highlighted.
- Rewrite **Install** to lead with the command: requirements, tab-vs-overlay, and harness integrations move into a details block, plus a new supported-harnesses table (Pi, Claude Code, Codex, OpenCode) and an inline keybinding setup snippet.
- Move **How it works** before Install, add an ASCII diagram of the TUI/CLI → boardd → herdr flow, and note `board skill`.
- Fold Everyday controls into Quickstart; move JSON/exit codes and configuration links into a final details block.
- Remove the Status and License sections and the License badge; add a board protocol v1 · schema v13 badge.
- Move the Architecture section to CONTRIBUTING.md.

No changelog entry: docs-only, no user-facing product change.