### PR TITLE
test(e2e): bind managed Codex fixture hermetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- [#74](https://github.com/nelsonPires5/herdr-board/pull/74) fix: E2E scenario 31 no longer stalls on hosts where a real Codex is installed (thanks to @v9yrbcgkyt-spec).
+
 ## [0.16.0] - 2026-08-22
 
 ### Added

--- a/e2e/31-managed-codex.sh
+++ b/e2e/31-managed-codex.sh
@@ -30,6 +30,8 @@ set -euo pipefail
 trap e2e_cleanup EXIT
 e2e_enable_fake_pi
 [ -x "$E2E_FAKE_PI_BIN_DIR/codex" ] || fail "fake codex missing/not executable at $E2E_FAKE_PI_BIN_DIR/codex"
+[ "$(type -P codex)" = "$E2E_FAKE_PI_BIN_DIR/codex" ] || fail "fake Codex PATH shadowing failed"
+[ "$(type -t codex)" = function ] || fail "fake Codex exec function was not exported"
 # Same-conversation reuse needs the looping fixture, and a daemon split pane
 # inherits the SERVER's env (never the workspace env), so the knob must be
 # exported before e2e_boot boots the ephemeral server.

--- a/e2e/lib.sh
+++ b/e2e/lib.sh
@@ -228,6 +228,7 @@ e2e_enable_fake_pi() {
     printf 'export BASH_ENV=/dev/null ENV=/dev/null\n'
     printf 'pi() { exec %q/pi "$@"; }\n' "$E2E_FAKE_PI_BIN_DIR"
     printf 'claude() { exec %q/claude "$@"; }\n' "$E2E_FAKE_PI_BIN_DIR"
+    printf 'codex() { exec %q/codex "$@"; }\n' "$E2E_FAKE_PI_BIN_DIR"
   } >"$E2E_MANAGED_ZDOTDIR/.zshenv"
   cp "$E2E_MANAGED_ZDOTDIR/.zshenv" "$E2E_MANAGED_ZDOTDIR/.zshrc"
   cp "$E2E_MANAGED_ZDOTDIR/.zshenv" "$E2E_MANAGED_HOME/.bashrc"
@@ -240,7 +241,8 @@ e2e_enable_fake_pi() {
   # these names to the checked-in fixtures even before its controlled rc runs.
   pi() { exec "$E2E_FAKE_PI_BIN_DIR/pi" "$@"; }
   claude() { exec "$E2E_FAKE_PI_BIN_DIR/claude" "$@"; }
-  export -f pi claude
+  codex() { exec "$E2E_FAKE_PI_BIN_DIR/codex" "$@"; }
+  export -f pi claude codex
 }
 
 # Resolve Herdr while the caller's PATH is still available. Managed panes use a


### PR DESCRIPTION
## Summary

- bind `codex` to the checked-in fake executable in every managed shell startup file
- export an exact `codex` exec function alongside the existing Pi and Claude bindings
- make scenario 31 fail before dispatch unless both PATH and shell function resolution are hermetic

## Why

`e2e_enable_fake_pi` put the fake-bin directory first on PATH, but managed interactive shells can load an existing host `codex` function from startup configuration. On hosts with Codex installed, scenario 31 could therefore launch the real CLI and stop at its first-run directory-trust/onboarding prompt. The pane looked idle, no fixture record appeared, and the run remained open. Pi and Claude were already protected against this hidden host dependency; Codex now uses the same exact-exec boundary.

This is test-harness isolation only and has no production behavior change.

## Testing

- regression assertion failed before the implementation with `fake Codex exec function was not exported`
- `/opt/homebrew/bin/bash e2e/31-managed-codex.sh` passed on a host whose PATH contains real Codex; all mint/fork/reuse/rescue/fail-closed fixture records were produced and no provider was called
- `cargo test --workspace --all-features -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (88 passed, 5 skipped)
- `/opt/homebrew/bin/bash e2e/test-harness.sh`
- `/opt/homebrew/bin/bash e2e/run-all.sh` (32/32 scenarios passed; artifact `/tmp/hb-e2e-run.LNFgg2`)

## Release note

No changelog entry: this changes only provider-free E2E isolation and does not affect shipped behavior.

Merge order: merge this fake-Codex fixture PR first; the remaining PRs may merge in any order.
