### PR TITLE
fix(daemon): clarify run completion errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented here. The format is based on
 
 - [#74](https://github.com/nelsonPires5/herdr-board/pull/74) fix: E2E scenario 31 no longer stalls on hosts where a real Codex is installed (thanks to @v9yrbcgkyt-spec).
 - [#79](https://github.com/nelsonPires5/herdr-board/pull/79) fix: Restrict the daemon socket to owner-only mode and fail startup when securing fails (thanks to @v9yrbcgkyt-spec).
+- [#77](https://github.com/nelsonPires5/herdr-board/pull/77) fix: Clarify run completion errors for unknown cards, idle manual cards, and queued runs missing run ids (thanks to @v9yrbcgkyt-spec).
 
 ## [0.16.0] - 2026-08-22
 

--- a/crates/board-daemon/src/ops/errors.rs
+++ b/crates/board-daemon/src/ops/errors.rs
@@ -29,11 +29,12 @@ pub(super) fn lifecycle_facts(
 
 pub(super) fn lifecycle_rejection(card_id: i64, rejection: LifecycleRejection) -> Error {
     match rejection {
-        LifecycleRejection::NoOpenRun
-        | LifecycleRejection::QueuedCompletionRequiresRunId
-        | LifecycleRejection::QueuedBuiltinCompletion => {
+        LifecycleRejection::NoOpenRun | LifecycleRejection::QueuedBuiltinCompletion => {
             Error::NotFound(format!("no active run for card {card_id}"))
         }
+        LifecycleRejection::QueuedCompletionRequiresRunId => Error::InvalidState(format!(
+            "queued run for card {card_id} requires run_id"
+        )),
         LifecycleRejection::SuppliedRunIdMismatch { expected, supplied } => Error::InvalidState(
             format!(
                 "no active run for card {card_id}: run {supplied} does not match active run {expected}"

--- a/crates/board-daemon/src/ops/runs.rs
+++ b/crates/board-daemon/src/ops/runs.rs
@@ -13,10 +13,24 @@ pub(super) fn run_done(d: &Arc<Daemon>, p: RunDoneParams) -> Result<Value> {
         // eligibility, including the narrow queued configured-run exception.
         let _sched = d.sched.lock().unwrap();
         let db = d.store.lock();
-        let run = db
-            .open_run_for_card(p.card_id)?
-            .ok_or_else(|| Error::NotFound(format!("no active run for card {}", p.card_id)))?;
         let card = db.require_card(p.card_id)?;
+        let run = match db.open_run_for_card(p.card_id)? {
+            Some(run) => run,
+            None => {
+                let manual_idle = card.status == CardStatus::Idle
+                    && db.require_column(card.column_id)?.trigger == Trigger::Manual;
+                let message = if manual_idle {
+                    format!(
+                        "no active run for card {}; manual column: close via board move {} <column>",
+                        p.card_id,
+                        p.card_id
+                    )
+                } else {
+                    format!("no active run for card {}", p.card_id)
+                };
+                return Err(Error::NotFound(message));
+            }
+        };
         // A reused agent pane keeps its first stage's BOARD_RUN_ID (a running
         // process's env cannot change); when its HERDR_PANE_ID matches this
         // open run's pane, the caller is this run's pane, so the stale id is

--- a/crates/board-daemon/src/ops/tests/lifecycle.rs
+++ b/crates/board-daemon/src/ops/tests/lifecycle.rs
@@ -5,6 +5,40 @@
 use super::*;
 
 #[test]
+fn run_done_reports_a_missing_card_before_the_absent_run() {
+    let d = test_daemon(Config::default());
+
+    let err =
+        handle_request(&d, "run.done", json!({"card_id": 9999, "outcome": "ok"})).unwrap_err();
+
+    assert_eq!(err.to_string(), "not found: card 9999");
+}
+
+#[test]
+fn run_done_guides_an_idle_manual_card_to_move_instead() {
+    let d = test_daemon(Config::default());
+    let card = d
+        .store
+        .lock()
+        .create_card(&CardCreateParams {
+            title: "manual handoff".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let err =
+        handle_request(&d, "run.done", json!({"card_id": card.id, "outcome": "ok"})).unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        format!(
+            "not found: no active run for card {}; manual column: close via board move {} <column>",
+            card.id, card.id
+        )
+    );
+}
+
+#[test]
 fn run_done_ok_without_target_column_marks_card_done() {
     let d = test_daemon(Config::default());
     let (card_id, run_id) = {
@@ -181,7 +215,17 @@ fn run_done_rejects_queued_configured_runs_without_or_with_stale_run_id() {
             json!({"card_id": card_id, "outcome": "ok"})
         };
         let err = handle_request(&d, "run.done", params).unwrap_err();
-        assert!(err.to_string().contains("no active run"), "{err}");
+        if stale {
+            assert!(
+                err.to_string().contains("does not match active run"),
+                "{err}"
+            );
+        } else {
+            assert_eq!(
+                err.to_string(),
+                format!("invalid state: queued run for card {card_id} requires run_id")
+            );
+        }
 
         let db = d.store.lock();
         let run = db.get_run(run_id).unwrap();

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -310,7 +310,10 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
   exception is a configured harness: its `board done` must provide the exact queued run id and may
   arrive before runner registration. A queued built-in (pi/claude/codex/opencode/antigravity) run is rejected because
   managed completion requires a registered pane. A mismatched id/pane, missing id for the queued
-  exception, or otherwise ineligible run returns an error.
+  exception, or otherwise ineligible run returns an error. Error precedence is deliberate: an
+  unknown card returns `not found: card <id>` before run lookup; an existing idle card in a manual
+  column returns `no active run` with `board move <id> <column>` guidance; and a configured run that
+  is queued without `run_id` returns `queued run for card <id> requires run_id`.
 - `run.cancel {card_id}` → `{run, card}` — kills the pane (herdr `pane.close`), outcome `cancelled`, card status `failed`, no transition.
 - `run.retry {card_id}` → `{run, card}` — re-enqueue in the current column as a fresh run. Claude
   resumes with `--fork-session`; Pi uses `--fork <old-id> --session-id <new-id>` and persists it;


### PR DESCRIPTION
## Summary

- validate the card before looking up its active run, so `run.done` reports an unknown card accurately
- add an actionable `board move <id> <column>` hint when `run.done` is used on an idle card in a manual column
- distinguish a queued configured run that is missing `run_id` from a card with no open run
- document the error precedence and exact operator-facing guidance

## Why

The previous ops-layer ordering and rejection adapter collapsed three different operator mistakes into `no active run`. That hid an invalid card id, suggested the wrong recovery action for manual cards, and described a queued run as absent even though it existed. The lifecycle engine already made the correct distinctions; this change preserves it and maps those distinctions precisely at the daemon boundary.

## Testing

- `cargo test -p board-daemon run_done_ -- --nocapture` (7 passed)
- `cargo test --workspace --all-features -- --test-threads=1` (all passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (88 passed, 5 skipped)
- `/opt/homebrew/bin/bash e2e/test-harness.sh`
- `/opt/homebrew/bin/bash e2e/run-all.sh` (32/32 scenarios passed; artifact `/tmp/hb-e2e-run.H6RrA6`)

The full E2E run used the separately proposed hermetic fake-Codex binding for scenario 31, then removed that temporary patch before this branch was committed. No provider was called.

## Release note

The required `CHANGELOG.md` entry now links this PR under `Unreleased / Fixed`.

Merge order: merge the fake-Codex fixture PR [#74](https://github.com/nelsonPires5/herdr-board/pull/74) (board card #18) first; the remaining PRs may merge in any order.
