### PR TITLE
fix(cli): silence same-board move warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented here. The format is based on
 - [#77](https://github.com/nelsonPires5/herdr-board/pull/77) fix: Clarify run completion errors for unknown cards, idle manual cards, and queued runs missing run ids (thanks to @v9yrbcgkyt-spec).
 - [#76](https://github.com/nelsonPires5/herdr-board/pull/76) fix: Workspace dispatch honors an explicit card cwd or fails closed on conflicting pane directories (thanks to @v9yrbcgkyt-spec).
 - [#75](https://github.com/nelsonPires5/herdr-board/pull/75) fix: Reconnect an open TUI to a restarted board daemon and refetch changes missed during the outage (thanks to @v9yrbcgkyt-spec).
+- [#78](https://github.com/nelsonPires5/herdr-board/pull/78) fix: Card moves via a global selector warn only when they cross boards or projects (thanks to @v9yrbcgkyt-spec).
 
 ## [0.16.0] - 2026-08-22
 

--- a/crates/board-cli/src/commands/card.rs
+++ b/crates/board-cli/src/commands/card.rs
@@ -167,12 +167,14 @@ fn card_archive(ctx: &mut Ctx, id: i64, archived: bool) -> Result<()> {
 ///
 /// Destination precedence: `--to-project` (with an optional `--to-board`
 /// id-or-name within it), else an explicit `--destination-board`, else the
-/// global `--board` selector (deprecated — it warns), else the global
-/// `--project` (deprecated — it warns), else the card's own board. Every arm
+/// global `--board` selector (deprecated — it warns only when it actually
+/// crosses boards), else the global `--project` (deprecated — it warns only
+/// when it actually leaves the project), else the card's own board. Every arm
 /// is non-selecting: card moves never touch the daemon's selection or recency.
 /// A named destination costs two RPCs (`project.get`/`board.open`/`board.get`
-/// plus `card.move`); the "stay on the card's board" case needs three, because
-/// protocol v1 has no way to learn a card's board without `card.get` and no
+/// plus `card.move`); a fallback that ends up crossing boards or projects,
+/// and the "stay on the card's board" case, need one extra `card.get`,
+/// because protocol v1 has no way to learn a card's board without it and no
 /// way to move a card by column *name*. A `card.move` that accepted a column
 /// name would collapse every case to one round-trip.
 pub(crate) fn cmd_move(
@@ -196,21 +198,29 @@ pub(crate) fn cmd_move(
             Some(selector) => destination_board_legacy(ctx.client()?, selector)?,
             None => match ctx.selector() {
                 Some(selector) => {
-                    eprintln!(
-                        "board: warning: `move` is using the global --board {selector} as the move \
-                         destination; this fallback is deprecated, pass --destination-board \
-                         {selector} to cross boards"
-                    );
-                    destination_board_legacy(ctx.client()?, selector)?
+                    let board = destination_board_legacy(ctx.client()?, selector)?;
+                    let source_board_id = ctx.client()?.card_get(card_id)?.card.board_id;
+                    if source_board_id != board.board.id {
+                        eprintln!(
+                            "board: warning: `move` is using the global --board {selector} as the move \
+                             destination; this fallback is deprecated, pass --destination-board \
+                             {selector} to cross boards"
+                        );
+                    }
+                    board
                 }
                 None => match ctx.project_selector() {
                     Some(path) => {
-                        eprintln!(
-                            "board: warning: `move` is using the global --project as the move \
-                             destination; pass --to-project to cross projects"
-                        );
                         let scope = resolved_scope_path(path)?;
-                        destination_board_in_project(ctx.client()?, &scope, None)?
+                        let board = destination_board_in_project(ctx.client()?, &scope, None)?;
+                        let source_board_id = ctx.client()?.card_get(card_id)?.card.board_id;
+                        if source_board_id != board.board.id {
+                            eprintln!(
+                                "board: warning: `move` is using the global --project as the move \
+                                 destination; pass --to-project to cross projects"
+                            );
+                        }
+                        board
                     }
                     None => {
                         let board_id = ctx.client()?.card_get(card_id)?.card.board_id;

--- a/crates/board-cli/tests/integration/scope.rs
+++ b/crates/board-cli/tests/integration/scope.rs
@@ -200,6 +200,13 @@ fn cross_board_move_prefers_destination_board_and_deprecates_the_selector() {
             ..Default::default()
         })
         .unwrap();
+    let same_board = client
+        .card_create(&CardCreateParams {
+            board_id: Some(beta.id),
+            title: "same-board selector".into(),
+            ..Default::default()
+        })
+        .unwrap();
 
     let out = td.board(&[
         "move",
@@ -221,6 +228,21 @@ fn cross_board_move_prefers_destination_board_and_deprecates_the_selector() {
         "--board",
         &beta.id.to_string(),
         "move",
+        &same_board.id.to_string(),
+        "Done",
+        "--json",
+    ]);
+    let moved = json_output(&out);
+    assert_eq!(moved["column_id"], beta_done.id);
+    assert!(
+        String::from_utf8_lossy(&out.stderr).is_empty(),
+        "the global selector must stay quiet when the card is already on that board"
+    );
+
+    let out = td.board(&[
+        "--board",
+        &beta.id.to_string(),
+        "move",
         &fallback.id.to_string(),
         "Done",
         "--json",
@@ -231,5 +253,55 @@ fn cross_board_move_prefers_destination_board_and_deprecates_the_selector() {
     assert!(
         warning.contains("deprecated") && warning.contains("--destination-board"),
         "the fallback must warn: {warning}"
+    );
+}
+
+/// The global `--project` fallback warns only when the move actually leaves
+/// the project; a same-project move stays quiet.
+#[test]
+fn same_project_move_via_global_project_selector_stays_quiet() {
+    let td = TestDaemon::start(&[]);
+    let proj_path = td._dir.path().join("proj-move");
+    std::fs::create_dir_all(&proj_path).unwrap();
+    let proj = proj_path.canonicalize().unwrap();
+
+    td.board(&["project", "create", proj.to_str().unwrap(), "--json"]);
+
+    let mut client = td.client();
+    let board = client
+        .project_get(proj.to_str().unwrap())
+        .unwrap()
+        .boards
+        .into_iter()
+        .find(|board| board.name == "main")
+        .unwrap();
+    let done = client
+        .column_create(&ColumnCreateParams {
+            board_id: Some(board.id),
+            name: "Done".into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let card = client
+        .card_create(&CardCreateParams {
+            board_id: Some(board.id),
+            title: "same-project selector".into(),
+            ..Default::default()
+        })
+        .unwrap();
+
+    let out = td.board(&[
+        "--project",
+        proj.to_str().unwrap(),
+        "move",
+        &card.id.to_string(),
+        "Done",
+        "--json",
+    ]);
+    let moved = json_output(&out);
+    assert_eq!(moved["column_id"], done.id);
+    assert!(
+        String::from_utf8_lossy(&out.stderr).is_empty(),
+        "the global --project selector must stay quiet when the card is already in that project"
     );
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -177,7 +177,7 @@ first board-aware command bootstraps it from the current directory.
 - `column.create {name, board_id?, position?, system_prompt?, trigger?, on_success_column_id?, on_fail_column_id?, fresh_session?, harness_override?, model_override?, effort_override?, permission_override?, timeout_minutes?}` → `Column`; omitted `board_id` means `Global`.
 - `column.update {id, …any subset of the above}` → `Column` (name/trigger/etc.; nullable update fields use the tri-state encoding below)
 - `column.reorder {id, position}` → `[Column…]`
-- `column.delete {id, move_cards_to?}` → `{deleted:true}`; destination must belong to the same board; error 3 if cards lack a destination or any card has an open run (`queued|running|blocked|awaiting`; `done` is not open).
+- `column.delete {id, move_cards_to?}` → `{deleted:true}`; destination must belong to the same board; error 3 if cards lack a destination or any card has an open run (`queued|running|blocked|awaiting`; `done` is not open). With a destination, the bulk move includes archived cards; unlike `card.move`, they do not need to be restored first.
 - `template.apply {name:"pipeline", board_id?}` → the requested board's full column set (omitted = `Global`; error 3 unless it has only seed `Todo` and no cards).
 
 The store enforces board boundaries: card create, column-delete destinations,
@@ -548,7 +548,7 @@ parks the card in `awaiting` instead of failing the run.
 
 Coarse by design — the TUI refetches only its selected `board.get {board_id}` on any event; payload is for logs/toasts.
 
-- `{"event":"board_changed","reason":"card_moved|card_created|card_updated|card_deleted|card_archived|column_changed|comment_added|run_started|run_ended|run_blocked","board_id"?:N,"card_id"?:N,"column_id"?:N}` — `board_id` scopes the change to a specific board; a cross-board card transfer emits one event per affected board (source + destination). Omitted `board_id` means a coarse, board-agnostic refresh.
+- `{"event":"board_changed","reason":"card_moved|card_created|card_updated|card_deleted|card_archived|column_changed|comment_added|run_started|run_ended|run_blocked","board_id"?:N,"card_id"?:N,"column_id"?:N}` — `board_id` scopes the change to a specific board; a same-board move reports the destination `column_id`, while a cross-board transfer emits a source-board event with the source column and a destination-board event with the destination column. Omitted `board_id` means a coarse, board-agnostic refresh.
 - `{"event":"run_ended","card_id":N,"run_id":N,"outcome":"ok|fail|cancelled|lost"}` (also emitted as board_changed; `lost` is legacy — no longer produced, see Card statuses)
 
 ## Dispatch semantics (column engine — lives in board-core, pure; daemon executes effects)


### PR DESCRIPTION
## Summary

- emit the deprecated global `--board` move warning only when it actually selects a different destination board
- keep same-board moves quiet while preserving the existing cross-board warning and explicit `--destination-board` behavior
- document precise `board_changed.column_id` semantics for same-board and cross-board moves
- document that `column.delete` bulk migration includes archived cards

## Why

The global selector remains a supported compatibility fallback for cross-board moves, but the CLI warned before resolving the card and destination boards. Normal same-board automation therefore received a misleading warning on every move. Delaying the comparison preserves the migration warning only for the deprecated cross-board spelling.

## Testing

- regression test was observed failing before the implementation and now proves same-board silence, explicit-destination silence, and fallback cross-board warning
- `cargo test --workspace --all-features -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (88 passed, 5 skipped)
- `/opt/homebrew/bin/bash e2e/test-harness.sh`
- `/opt/homebrew/bin/bash e2e/run-all.sh` (32/32 scenarios passed; artifact `/tmp/hb-e2e-run.66VpgD`)

The full E2E run used the separately proposed hermetic fake-Codex binding for scenario 31, then removed that temporary patch before this branch was committed. No provider was called.

## Release note

The required `CHANGELOG.md` entry now links this PR under `Unreleased / Fixed`.

Merge order: merge the fake-Codex fixture PR [#74](https://github.com/nelsonPires5/herdr-board/pull/74) (board card #18) first; the remaining PRs may merge in any order.
