### PR TITLE
fix(daemon): restrict socket permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project are documented here. The format is based on
 ### Fixed
 
 - [#81](https://github.com/nelsonPires5/herdr-board/pull/81) fix: `f` types normally in form text fields; the popup/fullscreen toggle now works only on picker fields.
+- [#79](https://github.com/nelsonPires5/herdr-board/pull/79) fix: Restrict the board daemon socket to its owner and fail startup if owner-only permissions cannot be applied.
 
 ## [0.13.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. The format is based on
 ### Fixed
 
 - [#74](https://github.com/nelsonPires5/herdr-board/pull/74) fix: E2E scenario 31 no longer stalls on hosts where a real Codex is installed (thanks to @v9yrbcgkyt-spec).
+- [#79](https://github.com/nelsonPires5/herdr-board/pull/79) fix: Restrict the daemon socket to owner-only mode and fail startup when securing fails (thanks to @v9yrbcgkyt-spec).
 
 ## [0.16.0] - 2026-08-22
 
@@ -57,7 +58,6 @@ All notable changes to this project are documented here. The format is based on
 ### Fixed
 
 - [#81](https://github.com/nelsonPires5/herdr-board/pull/81) fix: `f` types normally in form text fields; the popup/fullscreen toggle now works only on picker fields.
-- [#79](https://github.com/nelsonPires5/herdr-board/pull/79) fix: Restrict the board daemon socket to its owner and fail startup if owner-only permissions cannot be applied.
 
 ## [0.13.0] - 2026-08-10
 

--- a/crates/board-cli/tests/integration/meta.rs
+++ b/crates/board-cli/tests/integration/meta.rs
@@ -1,9 +1,22 @@
 //! Cross-cutting CLI surface: the command tree's refusals, `template apply`,
 //! version/status separation, `skill`, and the JSON error envelope.
 
+use std::os::unix::fs::PermissionsExt;
 use std::process::{Command, Stdio};
 
 use super::{json_error, json_output, TestDaemon};
+
+#[test]
+fn daemon_socket_is_owner_only() {
+    let td = TestDaemon::start(&[]);
+    let mode = std::fs::metadata(&td.socket)
+        .expect("boardd socket metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+
+    assert_eq!(mode, 0o600, "boardd socket must be owner-only");
+}
 
 #[test]
 fn top_level_status_is_rejected() {

--- a/crates/board-daemon/Cargo.toml
+++ b/crates/board-daemon/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 rusqlite = { workspace = true }
+tempfile = { workspace = true }
 # The fake-client ↔ daemon method parity guard (`ops::tests::parity`) compares
 # `ROUTED_METHODS` against board-core's `FAKE_CLIENT_METHODS`, which the
 # `fake-client` feature gates.

--- a/crates/board-daemon/src/lib.rs
+++ b/crates/board-daemon/src/lib.rs
@@ -23,6 +23,7 @@ mod supervisor;
 mod testkit;
 mod watchers;
 
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -215,6 +216,13 @@ async fn async_main(db_path: PathBuf, socket_path: PathBuf) -> anyhow::Result<()
     }
     let listener = tokio::net::UnixListener::bind(&socket_path)
         .with_context(|| format!("cannot bind the boardd socket {socket_path:?}"))?;
+    if let Err(error) =
+        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
+    {
+        let _ = std::fs::remove_file(&socket_path);
+        return Err(error)
+            .with_context(|| format!("cannot secure the boardd socket {socket_path:?}"));
+    }
     tracing::info!("boardd listening");
 
     server::serve(daemon.clone(), listener).await;

--- a/crates/board-daemon/src/lib.rs
+++ b/crates/board-daemon/src/lib.rs
@@ -269,6 +269,15 @@ fn spawn_signal_handler(d: Arc<Daemon>) {
 /// fails, remove the half-created file so a later start is not blocked by a
 /// stale socket, then surface the security error. `secure` is injectable so
 /// tests can force a permission-change failure deterministically.
+///
+/// The bind→chmod window is deliberately left un-temporarized: (1) the span is
+/// fully synchronous with no await points, so no other task can observe or
+/// connect through the socket mid-window; (2) an AF_UNIX `connect` requires
+/// write permission on the socket file, and under the default directory umask
+/// (0755) group/other lack it; (3) any chmod failure is fail-closed — the
+/// half-created file is removed and startup errors. Do NOT "harden" this by
+/// binding a temp name and renaming it into place: that would reopen a window
+/// where the well-known path does not yet point at the secured file.
 fn bind_secured_socket(
     socket_path: &Path,
     secure: impl FnOnce(&Path) -> std::io::Result<()>,

--- a/crates/board-daemon/src/lib.rs
+++ b/crates/board-daemon/src/lib.rs
@@ -214,15 +214,9 @@ async fn async_main(db_path: PathBuf, socket_path: PathBuf) -> anyhow::Result<()
         std::fs::create_dir_all(parent)
             .with_context(|| format!("cannot create the boardd socket directory {parent:?}"))?;
     }
-    let listener = tokio::net::UnixListener::bind(&socket_path)
-        .with_context(|| format!("cannot bind the boardd socket {socket_path:?}"))?;
-    if let Err(error) =
-        std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))
-    {
-        let _ = std::fs::remove_file(&socket_path);
-        return Err(error)
-            .with_context(|| format!("cannot secure the boardd socket {socket_path:?}"));
-    }
+    let listener = bind_secured_socket(&socket_path, |path| {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+    })?;
     tracing::info!("boardd listening");
 
     server::serve(daemon.clone(), listener).await;
@@ -269,4 +263,52 @@ fn spawn_signal_handler(d: Arc<Daemon>) {
         }
         d.trigger_shutdown();
     });
+}
+
+/// Bind the daemon socket and make it owner-only. When securing the socket
+/// fails, remove the half-created file so a later start is not blocked by a
+/// stale socket, then surface the security error. `secure` is injectable so
+/// tests can force a permission-change failure deterministically.
+fn bind_secured_socket(
+    socket_path: &Path,
+    secure: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> anyhow::Result<tokio::net::UnixListener> {
+    let listener = tokio::net::UnixListener::bind(socket_path)
+        .with_context(|| format!("cannot bind the boardd socket {socket_path:?}"))?;
+    if let Err(error) = secure(socket_path) {
+        let _ = std::fs::remove_file(socket_path);
+        return Err(error)
+            .with_context(|| format!("cannot secure the boardd socket {socket_path:?}"));
+    }
+    Ok(listener)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn failed_socket_securing_removes_the_partial_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("boardd.sock");
+
+        let error = bind_secured_socket(&socket_path, |_| {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "injected chmod failure",
+            ))
+        })
+        .expect_err("a failed security step must fail startup");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot secure the boardd socket"),
+            "error must name the security step: {error}"
+        );
+        assert!(
+            !socket_path.exists(),
+            "the half-created socket must be removed after a security failure"
+        );
+    }
 }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -8,7 +8,8 @@ protocol version.
 ## Transport
 
 - Unix socket. Path resolution (both daemon and clients): `$BOARD_SOCKET` if set, else
-  `~/.local/share/herdr-board/boardd.sock`.
+  `~/.local/share/herdr-board/boardd.sock`. The daemon sets the socket to mode `0600`; local socket
+  access is the protocol's authentication boundary.
 - DB path resolution (daemon only): `$BOARD_DB` if set, else `~/.local/share/herdr-board/board.db`.
 - Log directory resolution (daemon only): `$BOARD_LOG_DIR` if set, else `<data>/logs`.
 - Newline-delimited JSON (NDJSON), UTF-8. One JSON object per line, both directions.


### PR DESCRIPTION
## Summary

- set the bound board daemon Unix socket to owner-only mode (`0600`) before accepting requests
- fail daemon startup and remove the just-bound socket if the permission change fails
- add a real-daemon integration assertion for the socket mode
- document that local socket access is the board protocol's authentication boundary

## Security impact

The board protocol has no separate application-level authentication. A process that can connect to `boardd.sock` can read board/card/comment/run data, mutate cards, and trigger agent dispatch. The default parent data directory is private, but `BOARD_SOCKET` may redirect the socket elsewhere and directory permissions may drift. The previous socket inode inherited the process umask and was observed as `0755`; this change makes the boundary explicit and owner-only at the inode itself.

## Testing

- regression test observed mode `0755` before the implementation and `0600` after it
- `cargo test --workspace --all-features -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (88 passed, 5 skipped)
- `/opt/homebrew/bin/bash e2e/test-harness.sh`
- `/opt/homebrew/bin/bash e2e/run-all.sh` (32/32 scenarios passed; artifact `/tmp/hb-e2e-run.MXeAsz`)

One earlier full run reached 31/32 because scenario 19 hit its known watcher/reconcile comment-count race; the run outcome, card status, and column were correct. Scenario 19 then passed in isolation and the complete rerun passed 32/32.

The full E2E runs used the separately proposed hermetic fake-Codex binding for scenario 31, then removed that temporary patch before this branch was committed. No provider was called.

## Release note

The required `CHANGELOG.md` entry now links this PR under `Unreleased / Fixed`.

Merge order: merge the fake-Codex fixture PR [#74](https://github.com/nelsonPires5/herdr-board/pull/74) (board card #18) first; the remaining PRs may merge in any order.
