### PR TITLE
fix(ci,docs): maintainer merges the promotion PR so Release can tag

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -154,7 +154,7 @@ jobs:
             "" \
             "- release files synced by scripts/prepare-release.py" \
             "- CI is dispatched explicitly from this workflow" \
-            "- base dev: the Promote workflow merges dev -> main, then Release tags the green commit" \
+            "- base dev: a maintainer merges the Promote workflow's dev -> main PR, then Release tags the green commit" \
             "- base main (hotfix): Release tags the green main commit directly")"
 
           pr_json="$(gh pr list --head "$BRANCH" --state open --json number,url)"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,10 +2,12 @@ name: Promote
 
 # The action-owned half of a normal release: when CI completes green on a push
 # to `dev` whose workspace version is ahead of `main`, this workflow opens (or
-# updates) the `dev -> main` promotion PR, waits for its required checks, and
-# merges it with a merge commit. The resulting `main` push runs CI again, and
-# the Release workflow — still bound to green pushes on `main` — creates the
-# tag at that exact merge SHA. This workflow never creates or moves tags.
+# updates) the `dev -> main` promotion PR. A maintainer merges it with a merge
+# commit: GitHub never creates workflow runs for pushes made with GITHUB_TOKEN,
+# so an automated merge would silently skip CI and Release could never tag it.
+# The resulting `main` push runs CI again, and the Release workflow — still
+# bound to green pushes on `main` — creates the tag at that exact merge SHA.
+# This workflow never creates or moves tags.
 on:
   workflow_run:
     workflows:
@@ -37,7 +39,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'dev'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,7 +95,7 @@ jobs:
           body="$(printf '%s\n' \
             "Automatic promotion from \`dev\` after green \`dev\` CI (version v$VERSION)." \
             "" \
-            "- opened and merged by the Promote workflow" \
+            "- opened by the Promote workflow; a maintainer merges it (GITHUB_TOKEN pushes cannot trigger CI)" \
             "- the Release workflow tags this merge commit once \`main\` CI is green")"
 
           pr_json="$(gh pr list --head dev --base main --state open --json number,url)"
@@ -103,37 +105,6 @@ jobs:
             gh pr edit "$pr_number" --title "$title" --body "$body"
           else
             pr_url="$(gh pr create --head dev --base main --title "$title" --body "$body")"
-            pr_number="$(printf '%s' "$pr_url" | python3 -c 'import sys; print(sys.argv[1].rstrip("/").split("/")[-1])')"
           fi
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
-          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
           echo "PR: $pr_url"
-
-      - name: Wait for required checks on the promotion PR
-        if: steps.decide.outputs.needed == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          # gh pr checks --watch exits 0 immediately when no check has been
-          # reported yet, so first wait until the PR's checks actually exist.
-          for _ in $(seq 1 80); do
-            n="$(gh pr view "$PR_NUMBER" --json statusCheckRollup -q '.statusCheckRollup | length')"
-            [ "${n:-0}" -gt 0 ] && break
-            sleep 15
-          done
-          gh pr checks "$PR_NUMBER" --watch --interval 30
-
-      - name: Merge promotion PR (merge commit)
-        if: steps.decide.outputs.needed == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-        run: |
-          set -euo pipefail
-          gh pr merge "$PR_NUMBER" --merge --delete-branch=false
-          merged_sha="$(gh pr view "$PR_NUMBER" --json mergeCommit -q '.mergeCommit.oid')"
-          echo "Promoted dev to main at $merged_sha; Release will tag it after main CI is green."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+
+- [#89](https://github.com/nelsonPires5/herdr-board/pull/89) fix: the promotion PR is now merged by a maintainer so the Release workflow can tag the green main commit.
+
 ## [0.14.0] - 2026-08-13
 
 ### Added

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,8 +33,8 @@ Normal release flow:
    cuts `release/vX.Y.Z` from `dev` and opens (or updates) its PR to `dev`.
 2. The PR is reviewed and merged into `dev` with a merge commit. CI runs on that `dev` push —
    the full workflow including the dependent live E2E job — but never publishes.
-3. A maintainer opens a `dev -> main` promotion PR (merge commit). CI runs on the merge into
-   `main`.
+3. The **Promote** workflow opens the `dev -> main` promotion PR; a maintainer merges it with a
+   merge commit. CI runs on the merge into `main`.
 4. The **Release** workflow consumes the green `main` CI run, sees the version bump versus the
    merge's first parent, and creates the tag at that exact promotion SHA. The tag therefore lands
    on `main` and the release commit at the same time.
@@ -86,10 +86,12 @@ but it does not authorize publication.
 ## Promotion to main (action-owned)
 
 For a normal release the release PR merges into `dev`, not `main`. The bump reaches `main` only
-through the **Promote** workflow, which opens the `dev -> main` PR, waits for its required checks,
-and merges it with a merge commit. CI runs on the merge, and Release creates the tag at that exact
-SHA — "tag and main at the same time" means the tag points to the promotion commit. The tag is
-still created only after CI is green; there is no manual or pre-CI tagging anywhere in the flow.
+through the **Promote** workflow, which opens the `dev -> main` PR; a maintainer then merges it
+with a merge commit. The merge must be a maintainer action: GitHub never creates workflow runs for
+pushes made with `GITHUB_TOKEN`, so an automated merge would silently skip CI and the Release
+workflow could never tag it. CI runs on the merge, and Release creates the tag at that exact SHA —
+"tag and main at the same time" means the tag points to the promotion commit. The tag is still
+created only after CI is green; there is no manual or pre-CI tagging anywhere in the flow.
 A commit on `main` that does not bump the version (back-merge, documentation, other branches'
 merges) is a no-op.
 
@@ -98,8 +100,8 @@ merges) is a no-op.
 `main` is protected by an active branch ruleset: every change must come through a pull request
 merged with a **merge commit** (squash/rebase are not allowed), and the six fast CI jobs are
 required status checks with a strict policy. Direct pushes to `main` are blocked by the
-pull-request rule; the only writer in practice is the automation (`github-actions[bot]`), whose
-promotion and hotfix merges are GitHub-verified merge commits. `dev` is protected the same way
+pull-request rule; the only writers in practice are maintainers merging PRs (promotion, hotfix,
+back-merge) with GitHub-verified merge commits. `dev` is protected the same way
 (PR + merge commit + required checks). There is no signature requirement on either branch: the
 former `required_signatures` rule on `main` was removed because it rejects every PR whose source
 commits are unsigned — including the release commit written by `github-actions[bot]` — so the
@@ -143,8 +145,8 @@ missing tag must be repaired manually and then rerun.
 
 Promotion failures recover the same way: if the promotion PR's checks fail or its merge is
 blocked, rerun the green `dev` CI run — the Promote workflow re-evaluates the same SHA under its
-per-SHA lock, updates the PR, and retries the merge. If a promotion already landed, a rerun is a
-no-op (the dev tip is an ancestor of `main`).
+per-SHA lock and updates the PR; the maintainer merges it once the checks are green. If a
+promotion already landed, a rerun is a no-op (the dev tip is an ancestor of `main`).
 
 Expected assets:
 

--- a/scripts/tests/test_docs.py
+++ b/scripts/tests/test_docs.py
@@ -456,11 +456,14 @@ class DocumentationContractTests(unittest.TestCase):
 
     def test_promote_workflow_merges_dev_but_never_tags(self) -> None:
         """The action-owned promotion: green dev CI with a pending bump opens
-        and merges `dev -> main`; tagging stays exclusively in Release.
+        (or updates) the `dev -> main` PR; a maintainer merges it, because
+        GitHub never creates workflow runs for pushes made with GITHUB_TOKEN —
+        an automated merge would silently skip CI and Release could never tag
+        it. Tagging stays exclusively in Release.
 
-        The promote workflow must be bound to `dev` CI completions, merge
-        through a PR (so the merge commit is GitHub-verified and satisfies the
-        main ruleset), and contain no tag- or release-creation step.
+        The promote workflow must be bound to `dev` CI completions, open the
+        PR through `gh pr create`/`gh pr edit`, never merge it, and contain no
+        tag- or release-creation step.
         """
         workflow = (ROOT / ".github/workflows/promote.yml").read_text(encoding="utf-8")
         self.assertIn(
@@ -473,10 +476,12 @@ class DocumentationContractTests(unittest.TestCase):
             workflow,
             "promote job must stay gated to dev CI runs",
         )
-        self.assertIn(
+        self.assertIn("gh pr create", workflow, "promotion PR must be opened here")
+        self.assertIn("gh pr edit", workflow, "promotion PR must be updated on reruns")
+        self.assertNotIn(
             "gh pr merge",
             workflow,
-            "promotion must land via a merged PR",
+            "a maintainer merges the promotion PR (GITHUB_TOKEN pushes cannot trigger CI)",
         )
         self.assertNotIn("git tag", workflow, "promote must never create tags")
         self.assertNotIn("gh release", workflow, "promote must never publish")


### PR DESCRIPTION
**Problem:** the Promote workflow auto-merged `dev -> main` with `GITHUB_TOKEN`. GitHub never creates workflow runs for pushes made with `GITHUB_TOKEN`, so no CI run existed for that commit and the Release workflow could never fire — the v0.14.0 release had to be recovered by reverting and re-landing the promotion as a maintainer merge (PRs #86/#87).

**Fix:** the Promote workflow now only opens (or updates) the `dev -> main` PR; a maintainer merges it. This matches how every previous release actually landed (all historical main CI runs have `triggering_actor = nelsonPires5`).

- `promote.yml`: removed the wait-for-checks and merge steps
- `docs/releasing.md`: promotion section now documents the maintainer merge and why (GITHUB_TOKEN pushes cannot trigger CI)
- `prepare-release.yml`: release PR body text updated
- `test_docs.py`: contract now asserts Promote opens/updates the PR but never merges, and never tags/publishes
- CHANGELOG entry under Unreleased