### PR TITLE
fix(cli): board card edit accepts --space-kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 - [#103](https://github.com/nelsonPires5/herdr-board/pull/103) fix: managed Pi and Claude runs wait for harness session readiness before sending the initial prompt.
+- [#104](https://github.com/nelsonPires5/herdr-board/pull/104) fix: `board card edit` accepts `--space-kind`, restoring parity with the TUI edit form.
 
 ## [0.15.0] - 2026-08-16
 

--- a/crates/board-cli/src/args/card.rs
+++ b/crates/board-cli/src/args/card.rs
@@ -65,6 +65,9 @@ pub(crate) enum CardCmd {
         session: Option<String>,
         #[arg(long)]
         clear_session: bool,
+        /// Space kind: `workspace` or `new-workspace`.
+        #[arg(long)]
+        space_kind: Option<String>,
         #[arg(long)]
         space_ref: Option<String>,
         #[arg(long)]

--- a/crates/board-cli/src/commands/card.rs
+++ b/crates/board-cli/src/commands/card.rs
@@ -80,6 +80,7 @@ pub(crate) fn cmd_card(sub: CardCmd, ctx: &mut Ctx) -> Result<()> {
             clear_permission,
             session,
             clear_session,
+            space_kind,
             space_ref,
             clear_space_ref,
             space_cwd,
@@ -101,7 +102,7 @@ pub(crate) fn cmd_card(sub: CardCmd, ctx: &mut Ctx) -> Result<()> {
                 effort: Patch::from_flags(clear_effort, parse_effort(effort)?),
                 permission_mode: Patch::from_flags(clear_permission, permission),
                 session: Patch::from_flags(clear_session, session),
-                space_kind: None,
+                space_kind: space_kind.as_deref().map(parse_space_kind).transpose()?,
                 space_ref: Patch::from_flags(clear_space_ref, space_ref),
                 space_cwd: Patch::from_flags(clear_space_cwd, space_cwd),
             };

--- a/crates/board-cli/tests/integration/cards.rs
+++ b/crates/board-cli/tests/integration/cards.rs
@@ -4,10 +4,10 @@
 use std::process::Output;
 
 use board_core::client::BoardClient;
-use board_core::protocol::{CardCreateParams, Effort};
+use board_core::protocol::{CardCreateParams, Effort, SpaceKind};
 use serde_json::Value;
 
-use super::{json_output, old_card, TestDaemon};
+use super::{json_error, json_output, old_card, TestDaemon};
 
 fn json_card_ids(out: &Output) -> Vec<i64> {
     json_output(out)
@@ -210,6 +210,91 @@ fn card_edit_sets_and_explicitly_clears_nullable_patches() {
     assert_eq!(cleared["session"], Value::Null);
     assert_eq!(cleared["title"], "patched card");
     assert_eq!(cleared["description"], "patched description");
+}
+
+#[test]
+fn card_edit_changes_space_kind() {
+    let td = TestDaemon::start(&[]);
+    let card = td
+        .client()
+        .card_create(&CardCreateParams {
+            title: "space-kind card".into(),
+            harness: Some("fake".into()),
+            ..Default::default()
+        })
+        .unwrap();
+    let id = card.id.to_string();
+
+    // Switch to a new-workspace space with the hyphenated CLI spelling; the
+    // ref/cwd set in the same edit must satisfy the merged-space validation.
+    let switched = json_output(&td.board(&[
+        "card",
+        "edit",
+        &id,
+        "--space-kind",
+        "new-workspace",
+        "--space-ref",
+        "widget-build",
+        "--space-cwd",
+        "/tmp/widget",
+        "--json",
+    ]));
+    assert_eq!(switched["space_kind"], "new_workspace");
+    assert_eq!(switched["space_ref"], "widget-build");
+    assert_eq!(switched["space_cwd"], "/tmp/widget");
+
+    // The canonical underscored spelling is accepted too.
+    let underscored = json_output(&td.board(&[
+        "card",
+        "edit",
+        &id,
+        "--space-kind",
+        "new_workspace",
+        "--json",
+    ]));
+    assert_eq!(underscored["space_kind"], "new_workspace");
+
+    // Switch back to workspace while clearing the now-inert fields — a
+    // transition that was impossible from the CLI before --space-kind.
+    let back = json_output(&td.board(&[
+        "card",
+        "edit",
+        &id,
+        "--space-kind",
+        "workspace",
+        "--clear-space-ref",
+        "--clear-space-cwd",
+        "--json",
+    ]));
+    assert_eq!(back["space_kind"], "workspace");
+    assert_eq!(back["space_ref"], Value::Null);
+    assert_eq!(back["space_cwd"], Value::Null);
+
+    // Persisted, not just echoed.
+    let stored = td.client().card_get(card.id).unwrap().card;
+    assert_eq!(stored.space_kind, SpaceKind::Workspace);
+    assert_eq!(stored.space_ref, None);
+    assert_eq!(stored.space_cwd, None);
+
+    // A merged-invalid request (new_workspace without ref/cwd) is rejected
+    // without mutation; a bogus spelling is rejected by the CLI parser.
+    let invalid = td.board(&[
+        "card",
+        "edit",
+        &id,
+        "--space-kind",
+        "new-workspace",
+        "--json",
+    ]);
+    let error = json_error(&invalid);
+    assert_eq!(
+        error["error"]["code"], 1,
+        "validation failure surfaces as protocol code 1"
+    );
+    let bogus = td.board(&["card", "edit", &id, "--space-kind", "bogus", "--json"]);
+    assert!(!bogus.status.success(), "unknown kind must be refused");
+    let stored = td.client().card_get(card.id).unwrap().card;
+    assert_eq!(stored.space_kind, SpaceKind::Workspace);
 }
 
 #[test]

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -230,7 +230,8 @@ A card selects a **herdr session** (`session`, `null` = the daemon's default ses
       `new-workspace` as an alias so `board card create --space-kind new-workspace` resolves through
       board-core instead of a hand-rolled match in the CLI, and the CLI then emits the canonical
       underscored form. `parse_str` is also what reads the value back out of SQLite, where only the
-      canonical form is ever stored.
+      canonical form is ever stored. The same CLI spelling applies to `card edit --space-kind`, whose
+      omitted flag leaves the kind unchanged.
   - creating directly into an `auto` column dispatches immediately (same as move)
   - In the legacy v1→v2 migration, `cwd`/`worktree` kinds and `worktree_base` were removed;
     current schema v15 treats worktree isolation as the agent's job via prompt instructions, not a


### PR DESCRIPTION
## What

`board card edit` now accepts `--space-kind <workspace|new-workspace>` (the underscored `new_workspace` alias is accepted too), closing the parity gap with the TUI edit form, which already submits the field. Omitted flag leaves the kind unchanged. No clear variant by design: kind is non-nullable, so `--space-kind workspace` is the reset.

## Why

Without this flag a `new_workspace` card could never get its `space_ref`/`space_cwd` cleared from the CLI — the merged state kept `kind=new_workspace` with empty ref/cwd and failed engine validation. Switching back to `workspace` combined with `--clear-space-ref --clear-space-cwd` is now possible.

Closes card #36 (Paridade entre TUI e CLI).

## How

- Wires the existing protocol field (`CardUpdateParams.space_kind`) through the existing `parse_space_kind` helper — no daemon/core/protocol changes; the receiving end already merged and validated it.
- Test-first integration test through the real daemon: both spellings, persistence via `card_get`, switch-back+clears, merged-invalid rejection (protocol code 1, no mutation), bogus-value refusal.
- Docs: protocol.md notes the edit spelling; CHANGELOG entry under Unreleased → Fixed.

## Validation

`./scripts/sandbox.sh gates`: all gates green — selfcheck, fmt, clippy `-D warnings`, workspace tests, python tier, static harness gate, all 39 live E2E scenarios PASS. Red→green proven before implementation.